### PR TITLE
Adding support for owning MAME's `cfg` path

### DIFF
--- a/src/dialogs/file.rs
+++ b/src/dialogs/file.rs
@@ -26,12 +26,14 @@ pub enum PathType {
 	SoftwareLists,
 	#[strum(to_string = "Plugins")]
 	Plugins,
+	#[strum(to_string = "MAME Configs")]
+	Cfg,
 }
 
 impl PathType {
 	pub fn is_multi(&self) -> bool {
 		match self {
-			Self::MameExecutable => false,
+			Self::MameExecutable | Self::Cfg => false,
 			Self::Roms | Self::Samples | Self::SoftwareLists | Self::Plugins => true,
 		}
 	}
@@ -42,7 +44,7 @@ impl PathType {
 				name: "MAME Executable",
 				extension: EXE_EXTENSION,
 			},
-			Self::Roms | Self::Samples | Self::SoftwareLists | Self::Plugins => PickType::Dir,
+			Self::Roms | Self::Samples | Self::SoftwareLists | Self::Plugins | Self::Cfg => PickType::Dir,
 		}
 	}
 
@@ -67,6 +69,7 @@ impl PathType {
 			PathType::Samples => SingleOrMultiple::Multiple(&prefs_paths.samples),
 			PathType::SoftwareLists => SingleOrMultiple::Multiple(&prefs_paths.software_lists),
 			PathType::Plugins => SingleOrMultiple::Multiple(&prefs_paths.plugins),
+			PathType::Cfg => SingleOrMultiple::Single(&prefs_paths.cfg),
 		};
 
 		match target {
@@ -91,6 +94,7 @@ impl PathType {
 			PathType::Samples => SingleOrMultiple::Multiple(&mut prefs_paths.samples),
 			PathType::SoftwareLists => SingleOrMultiple::Multiple(&mut prefs_paths.software_lists),
 			PathType::Plugins => SingleOrMultiple::Multiple(&mut prefs_paths.plugins),
+			PathType::Cfg => SingleOrMultiple::Single(&mut prefs_paths.cfg),
 		};
 
 		match target {

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -62,6 +62,9 @@ pub struct PrefsPaths {
 
 	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
 	pub software_lists: Vec<String>,
+
+	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
+	pub cfg: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq)]
@@ -219,6 +222,9 @@ impl Preferences {
 	pub fn fresh(prefs_path: Option<PathBuf>) -> Self {
 		let json = include_str!("prefs_fresh.json");
 		let mut result = load_prefs_from_reader(json.as_bytes()).unwrap();
+		Rc::get_mut(&mut result.paths).unwrap().cfg = prefs_path
+			.as_ref()
+			.and_then(|x| x.clone().into_os_string().into_string().ok());
 		result.prefs_path = prefs_path;
 		result
 	}

--- a/src/runtime/args.rs
+++ b/src/runtime/args.rs
@@ -19,6 +19,7 @@ pub struct MameArgumentsSource<'a> {
 	pub roms_paths: &'a [String],
 	pub samples_paths: &'a [String],
 	pub plugins_paths: &'a [String],
+	pub cfg_path: &'a [String],
 }
 
 impl<'a> MameArgumentsSource<'a> {
@@ -27,12 +28,14 @@ impl<'a> MameArgumentsSource<'a> {
 		let roms_paths = prefs_paths.roms.as_slice();
 		let samples_paths = prefs_paths.samples.as_slice();
 		let plugins_paths = prefs_paths.plugins.as_slice();
+		let cfg_path = prefs_paths.cfg.as_slice();
 		let result = Self {
 			windowing,
 			roms_paths,
 			mame_executable_path,
 			samples_paths,
 			plugins_paths,
+			cfg_path,
 		};
 		Ok(result)
 	}
@@ -60,6 +63,7 @@ impl From<MameArgumentsSource<'_>> for MameArguments {
 			("-rompath", value.roms_paths),
 			("-samplepath", value.samples_paths),
 			("-pluginspath", value.plugins_paths),
+			("-cfg_directory", value.cfg_path),
 		]
 		.into_iter()
 		.filter(|(_, paths)| !paths.is_empty())


### PR DESCRIPTION
This reimplements support in BletchMAME for owning MAME's `-cfg_directory` option.  Like older versions of BletchMAME, this will now default to the BletchMAME preferences directory.