### PR TITLE
Fixing the main search bar

### DIFF
--- a/ui/main.slint
+++ b/ui/main.slint
@@ -98,7 +98,6 @@ export component AppWindow inherits Window {
 
                 LineEdit {
                     text <=> items-search-text;
-                    enabled: !is-empty;
                     edited(text) => {
                         items-search-text-changed(text)
                     }


### PR DESCRIPTION
Not sure why `enabled: !is-empty` was added