### PR TITLE
Ensuring that the multiply in `calculate_sizes_hash()` will not overflow

### DIFF
--- a/src/info/build.rs
+++ b/src/info/build.rs
@@ -577,7 +577,9 @@ pub fn calculate_sizes_hash() -> u64 {
 		binary::MachineSoftwareList::SERIALIZED_SIZE,
 	]
 	.into_iter()
-	.fold(0, |value, item| (value * multiplicand) ^ (item as u64))
+	.fold(0, |value, item| {
+		u64::overflowing_mul(value, multiplicand).0 ^ (item as u64)
+	})
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is calculating a hash; therefore overflowing is not a problem