### PR TITLE
Preliminary support for launching software items

### DIFF
--- a/src/appcommand.rs
+++ b/src/appcommand.rs
@@ -44,7 +44,7 @@ pub enum AppCommand {
 	Shutdown,
 	RunMame {
 		machine_name: String,
-		software_name: Option<Arc<str>>,
+		initial_loads: Vec<(Arc<str>, Arc<str>)>,
 	},
 	Browse(PrefsCollection),
 	HistoryAdvance(isize),

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -668,11 +668,16 @@ fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 		}
 		AppCommand::RunMame {
 			machine_name,
-			software_name,
+			initial_loads,
 		} => {
+			let initial_loads = initial_loads
+				.iter()
+				.map(|(dev, arg)| (dev.as_ref(), arg.as_ref()))
+				.collect::<Vec<_>>();
+
 			let command = MameCommand::Start {
 				machine_name: &machine_name,
-				software_name: software_name.as_ref().map(|x| x.as_ref()),
+				initial_loads: initial_loads.as_slice(),
 			};
 			model.mame_controller.issue_command(command);
 		}

--- a/src/info/binary.rs
+++ b/src/info/binary.rs
@@ -18,6 +18,7 @@ pub struct Header {
 	pub build_strindex: u32,
 	pub machine_count: u32,
 	pub chips_count: u32,
+	pub device_count: u32,
 	pub software_list_count: u32,
 	pub software_list_machine_count: u32,
 	pub machine_software_lists_count: u32,
@@ -34,6 +35,8 @@ pub struct Machine {
 	pub manufacturer_strindex: u32,
 	pub chips_start: u32,
 	pub chips_end: u32,
+	pub devices_start: u32,
+	pub devices_end: u32,
 	pub machine_software_lists_start: u32,
 	pub machine_software_lists_end: u32,
 	pub runnable: bool,
@@ -60,6 +63,15 @@ pub enum ChipType {
 	Cpu,
 	#[strum(serialize = "audio")]
 	Audio,
+}
+
+#[derive(Clone, Copy, Debug, BinarySerde)]
+pub struct Device {
+	pub type_strindex: u32,
+	pub tag_strindex: u32,
+	pub mandatory: bool,
+	pub interface_strindex: u32,
+	pub extensions_strindex: u32,
 }
 
 #[derive(Clone, Copy, Debug, BinarySerde)]

--- a/src/info/entities.rs
+++ b/src/info/entities.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use binary_search::binary_search;
 use binary_search::Direction;
 
@@ -12,6 +14,7 @@ use crate::info::View;
 pub type Machine<'a> = Object<'a, binary::Machine>;
 pub type MachinesView<'a> = SimpleView<'a, binary::Machine>;
 pub type Chip<'a> = Object<'a, binary::Chip>;
+pub type Device<'a> = Object<'a, binary::Device>;
 pub type SoftwareList<'a> = Object<'a, binary::SoftwareList>;
 pub type SoftwareListsView<'a> = SimpleView<'a, binary::SoftwareList>;
 pub type MachineSoftwareList<'a> = Object<'a, binary::MachineSoftwareList>;
@@ -55,6 +58,12 @@ impl<'a> Machine<'a> {
 		self.db.chips().sub_view(self.obj().chips_start..self.obj().chips_end)
 	}
 
+	pub fn devices(&self) -> impl View<'a, Device<'a>> {
+		self.db
+			.devices()
+			.sub_view(self.obj().devices_start..self.obj().devices_end)
+	}
+
 	pub fn machine_software_lists(&self) -> impl View<'a, MachineSoftwareList<'a>> {
 		self.db
 			.machine_software_lists()
@@ -95,6 +104,28 @@ impl<'a> Chip<'a> {
 
 	pub fn chip_type(&self) -> ChipType {
 		self.obj().chip_type
+	}
+}
+
+impl<'a> Device<'a> {
+	pub fn device_type(&self) -> SmallStrRef<'a> {
+		self.string(|x| x.type_strindex)
+	}
+
+	pub fn tag(&self) -> SmallStrRef<'a> {
+		self.string(|x| x.tag_strindex)
+	}
+
+	pub fn mandatory(&self) -> bool {
+		self.obj().mandatory
+	}
+
+	pub fn interface(&self) -> SmallStrRef<'a> {
+		self.string(|x| x.interface_strindex)
+	}
+
+	pub fn extensions(&self) -> impl Iterator<Item = Cow<'a, str>> {
+		self.string(|x| x.extensions_strindex).split('\0')
 	}
 }
 

--- a/src/software/mod.rs
+++ b/src/software/mod.rs
@@ -38,7 +38,7 @@ pub struct Software {
 pub struct SoftwarePart {
 	#[allow(dead_code)]
 	pub name: Arc<str>,
-	#[allow(dead_code)]
+
 	pub interface: Arc<str>,
 }
 

--- a/src/software/mod.rs
+++ b/src/software/mod.rs
@@ -31,6 +31,15 @@ pub struct Software {
 	pub description: Arc<str>,
 	pub year: Arc<str>,
 	pub publisher: Arc<str>,
+	pub parts: Vec<SoftwarePart>,
+}
+
+#[derive(Debug)]
+pub struct SoftwarePart {
+	#[allow(dead_code)]
+	pub name: Arc<str>,
+	#[allow(dead_code)]
+	pub interface: Arc<str>,
 }
 
 impl SoftwareList {

--- a/src/software/process.rs
+++ b/src/software/process.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 
 use crate::software::Software;
 use crate::software::SoftwareList;
+use crate::software::SoftwarePart;
 use crate::xml::XmlElement;
 use crate::xml::XmlEvent;
 use crate::xml::XmlReader;
@@ -71,6 +72,7 @@ impl State {
 					description: self.empty_str.clone(),
 					year: self.empty_str.clone(),
 					publisher: self.empty_str.clone(),
+					parts: Vec::new(),
 				};
 				self.current_software = Some(software);
 				Some(Phase::Software)
@@ -78,6 +80,15 @@ impl State {
 			(Phase::Software, b"description") => Some(Phase::SoftwareDescription),
 			(Phase::Software, b"year") => Some(Phase::SoftwareYear),
 			(Phase::Software, b"publisher") => Some(Phase::SoftwarePublisher),
+			(Phase::Software, b"part") => {
+				let [name, interface] = evt.find_attributes([b"name", b"interface"])?;
+				if let Some((name, interface)) = Option::zip(name, interface) {
+					let (name, interface) = (name.into(), interface.into());
+					let part = SoftwarePart { name, interface };
+					self.current_software.as_mut().unwrap().parts.push(part);
+				}
+				None
+			}
 			_ => None,
 		};
 		Ok(new_phase)


### PR DESCRIPTION
This is very preliminary support for launching software items.  This is gnarly because we are launching the software from within MAME and we need to do the work to identify all of the specific slots and the pertinent software parts.  Furthermore, this causes MAME to "cycle" because it causes a hard reset.
    
Caveats:
1.  This is not well tested at all
2.  For some unknown reason, when the software actually runs, subsequent `worker_ui` commands seem to be ignored.  This is likely a bug in the LUA code
3.  The overall experience with software items is pretty ugly, as when we add a software item to a folder, we provide an ugly context menu that lets the user choose any of the machines that might be relevant for this machine.  This experience needs to be refined
