### PR TITLE
Now refreshing MAME InfoDB when build skew is detected

### DIFF
--- a/plugins/worker_ui/init.lua
+++ b/plugins/worker_ui/init.lua
@@ -359,6 +359,9 @@ function emit_status(light, out)
 	emit("<status");
 	emit("\tapp_name=\"" .. tostring(emu.app_name()) .. "\"");
 	emit("\tapp_version=\"" .. tostring(emu.app_version()) .. "\"");
+	if emu.app_build then
+		emit("\tapp_build=\"" .. tostring(emu.app_build()) .. "\"");
+	end
 
 	-- most status is only relevant if we're running
 	if not is_running() then

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -16,6 +16,7 @@ const LOG: Level = Level::TRACE;
 pub struct Status {
 	pub has_initialized: bool,
 	pub running: Option<StatusRunning>,
+	pub build: Option<String>,
 }
 
 impl Status {
@@ -38,6 +39,7 @@ impl Status {
 		event!(LOG, "Status::merge(): running={:?}", running);
 		self.running = running;
 		self.has_initialized = true;
+		self.build = update.build
 	}
 }
 
@@ -52,6 +54,7 @@ pub struct StatusRunning {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Update {
 	running: Option<UpdateRunning>,
+	build: Option<String>,
 }
 
 impl Update {


### PR DESCRIPTION
This is enabled by the merging of MAME PR#12959, which allows us to access the build from LUA