### PR TITLE
Partial fix to the MAME frozen search bar issue

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -1104,13 +1104,16 @@ async fn ping_callback(model_weak: std::rc::Weak<AppModel>) {
 	while let Some(model) = model_weak.upgrade() {
 		event!(LOG_PINGING, "ping_callback(): pinging");
 
+		// are we running?
+		let is_running = model.running_status.borrow().running.is_some();
+
 		// set the child window size
 		if let Some(child_window) = &model.child_window {
-			child_window.set_size(model.app_window().window().size());
+			child_window.set_size(model.app_window().window().size(), is_running);
 		}
 
 		// send a ping command (if we're running)
-		if model.running_status.borrow().running.is_some() && model.mame_controller.is_queue_empty() {
+		if is_running && model.mame_controller.is_queue_empty() {
 			handle_command(&model, AppCommand::MamePing);
 		}
 		drop(model);

--- a/src/guiutils/childwnd.rs
+++ b/src/guiutils/childwnd.rs
@@ -68,7 +68,7 @@ impl ChildWindow {
 		}
 	}
 
-	pub fn set_size(&self, container_size: PhysicalSize) {
+	pub fn set_size(&self, container_size: PhysicalSize, set_focus: bool) {
 		// get the HWND's width/height
 		let (width, height) = unsafe {
 			let mut rect = zeroed();
@@ -93,7 +93,7 @@ impl ChildWindow {
 		unsafe {
 			SetWindowPos(self.hwnd, 0 as HWND, x, y, cx, cy, flags);
 
-			if GetFocus() == GetParent(self.hwnd) {
+			if set_focus && (GetFocus() == GetParent(self.hwnd)) {
 				SetFocus(self.hwnd);
 			}
 		}


### PR DESCRIPTION
The change I made ensures that we don't try to set the focus to the child window to which we attach MAME.  However, the search bar still seems to be frozen unless the user clicks away from BletchMAME and gives it focus back.  I do not yet understand this behavior.