### PR TITLE
Modal dialog refactor

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -51,7 +51,7 @@ use crate::guiutils::menuing::setup_window_menu_bar;
 use crate::guiutils::menuing::show_popup_menu;
 use crate::guiutils::menuing::update_menu_items;
 use crate::guiutils::menuing::MenuItemUpdate;
-use crate::guiutils::windowing::with_modal_parent;
+use crate::guiutils::modal::Modal;
 use crate::history::History;
 use crate::info::InfoDb;
 use crate::models::collectionsview::CollectionsViewModel;
@@ -660,8 +660,8 @@ fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 			let _ = open::that("https://www.bletchmame.org");
 		}
 		AppCommand::HelpAbout => {
-			let dialog = with_modal_parent(&model.app_window(), || AboutDialog::new().unwrap());
-			dialog.show().unwrap();
+			let modal = Modal::new(&model.app_window(), || AboutDialog::new().unwrap());
+			modal.launch();
 		}
 		AppCommand::MameSessionStarted => {
 			// do nothing

--- a/src/guiutils/hook.rs
+++ b/src/guiutils/hook.rs
@@ -1,0 +1,45 @@
+use std::cell::RefCell;
+
+use winit::window::WindowAttributes;
+
+type WindowAttributeHookCallback = Box<dyn Fn(WindowAttributes) -> WindowAttributes + 'static>;
+thread_local! {
+	static WINDOW_ATTRIBUTE_HOOK_CALLBACK: RefCell<Option<WindowAttributeHookCallback>> = const { RefCell::new(None) }
+}
+
+/// creates a global attributes hook for setting up the Slint backend
+pub fn create_window_attributes_hook(
+	global_hook: impl Fn(WindowAttributes) -> WindowAttributes + 'static,
+) -> Option<Box<dyn Fn(WindowAttributes) -> WindowAttributes>> {
+	let hook = move |attrs| {
+		// invoke the global hook
+		let attrs = global_hook(attrs);
+
+		WINDOW_ATTRIBUTE_HOOK_CALLBACK.with_borrow(|callback| {
+			if let Some(callback) = callback {
+				callback(attrs)
+			} else {
+				attrs
+			}
+		})
+	};
+	Some(Box::new(hook))
+}
+
+pub fn with_attributes_hook<T>(
+	func: impl FnOnce() -> T,
+	hook: impl Fn(WindowAttributes) -> WindowAttributes + 'static,
+) -> T {
+	// stow the callback
+	WINDOW_ATTRIBUTE_HOOK_CALLBACK.set(Some(Box::new(hook)));
+
+	// invoke the function
+	let result = func();
+
+	// clear out the hook
+	let old_hook = WINDOW_ATTRIBUTE_HOOK_CALLBACK.take();
+	assert!(old_hook.is_some(), "WINDOW_ATTRIBUTE_HOOK_CALLBACK was lost");
+
+	// and return
+	result
+}

--- a/src/guiutils/modal.rs
+++ b/src/guiutils/modal.rs
@@ -1,0 +1,124 @@
+use std::future::Future;
+use std::rc::Rc;
+
+use i_slint_backend_winit::winit::platform::windows::WindowExtWindows;
+use i_slint_backend_winit::WinitWindowAccessor;
+use raw_window_handle::HasWindowHandle;
+use raw_window_handle::RawWindowHandle;
+use slint::CloseRequestResponse;
+use slint::ComponentHandle;
+use slint::PhysicalPosition;
+use slint::Window;
+use slint::WindowHandle;
+use winit::platform::windows::WindowAttributesExtWindows;
+use winit::window::WindowAttributes;
+
+use crate::guiutils::hook::with_attributes_hook;
+
+pub struct Modal<D> {
+	reenable_parent: Rc<dyn Fn() + 'static>,
+	dialog: D,
+}
+
+impl<D> Modal<D>
+where
+	D: ComponentHandle + 'static,
+{
+	pub fn new(parent: &(impl ComponentHandle + 'static), func: impl FnOnce() -> D) -> Self {
+		// disable the parent and get the parent handle and position
+		let (parent_handle, parent_position) = {
+			let window = parent.window();
+			window.with_winit_window(|window| window.set_enable(false));
+			(window.window_handle().clone(), window.position())
+		};
+
+		// set up a hook
+		let hook = move |window_attributes| {
+			set_window_attributes_for_modal_parent(window_attributes, &parent_handle, parent_position)
+		};
+
+		// invoke the func
+		let dialog = with_attributes_hook(func, hook);
+
+		// set up a bogus callback because the default callback won't do the right thing
+		dialog
+			.window()
+			.on_close_requested(move || panic!("Need to override on_close_requested"));
+
+		// create a callback to reenable the parent
+		let parent = parent.clone_strong();
+		let reenable_parent = move || reenable_modal_parent(&parent);
+		let reenable_parent = Rc::from(reenable_parent);
+
+		// and return
+		Self {
+			reenable_parent,
+			dialog,
+		}
+	}
+
+	pub fn dialog(&self) -> &'_ D {
+		&self.dialog
+	}
+
+	pub fn window(&self) -> &'_ Window {
+		self.dialog.window()
+	}
+
+	pub fn launch(self) {
+		// stow a callback to reenable the parent here
+		let reenable_parent_clone = self.reenable_parent.clone();
+		self.window().on_close_requested(move || {
+			reenable_parent_clone();
+			CloseRequestResponse::HideWindow
+		});
+
+		// show the dialog
+		self.dialog.show().unwrap();
+	}
+
+	pub async fn run<R>(self, fut: impl Future<Output = R>) -> R {
+		// show the dialog
+		self.dialog.show().unwrap();
+
+		// run the function
+		let result = fut.await;
+
+		// before we hide the dialog, reenable the parent
+		(self.reenable_parent)();
+
+		// hide the dialog
+		self.dialog.hide().unwrap();
+
+		// return
+		result
+	}
+}
+
+fn set_window_attributes_for_modal_parent(
+	mut window_attributes: WindowAttributes,
+	parent_handle: &WindowHandle,
+	parent_position: PhysicalPosition,
+) -> WindowAttributes {
+	match parent_handle.window_handle().unwrap().as_raw() {
+		// modal dialog on Windows
+		#[cfg(target_os = "windows")]
+		RawWindowHandle::Win32(win32_window) => {
+			let position = winit::dpi::PhysicalPosition {
+				x: parent_position.x + 64,
+				y: parent_position.y + 64,
+			};
+			window_attributes = window_attributes.with_owner_window(win32_window.hwnd.into());
+			window_attributes.position = Some(position.into());
+		}
+
+		// no modal dialog, or unknown platform
+		_ => {}
+	};
+
+	window_attributes
+}
+
+fn reenable_modal_parent(parent: &impl ComponentHandle) {
+	parent.window().with_winit_window(|window| window.set_enable(true));
+}

--- a/src/guiutils/windowing.rs
+++ b/src/guiutils/windowing.rs
@@ -38,7 +38,7 @@ where
 	let _ = result.window().size();
 
 	// clear out WINDOW_ATTRIBUTE_HOOK_CALLBACK
-	let old_hook = WINDOW_ATTRIBUTE_HOOK_CALLBACK.take();
+	let old_hook: Option<Box<dyn Fn(WindowAttributes) -> WindowAttributes>> = WINDOW_ATTRIBUTE_HOOK_CALLBACK.take();
 	assert!(old_hook.is_some(), "WINDOW_ATTRIBUTE_HOOK_CALLBACK was lost");
 
 	// by default install an `on_close_requested` handle that will reenable the modal parent


### PR DESCRIPTION
Refactor to make modal dialogs (not supported by Slint) a bit less unwieldy.  Encapsulating logic in a `Modal` struct.  Better encapsulation of `WindowsAttributes` hook code.