### PR TITLE
Various changes/cleanups to processing of XML emitted by MAME

### DIFF
--- a/src/info/build.rs
+++ b/src/info/build.rs
@@ -21,6 +21,7 @@ use crate::info::ChipType;
 use crate::info::SoftwareListStatus;
 use crate::info::ENDIANNESS;
 use crate::info::MAGIC_HDR;
+use crate::parse::normalize_tag;
 use crate::parse::parse_mame_bool;
 use crate::xml::XmlElement;
 use crate::xml::XmlEvent;
@@ -171,6 +172,7 @@ impl State {
 				let [device_type, tag, mandatory, interface] =
 					evt.find_attributes([b"type", b"tag", b"mandatory", b"interface"])?;
 				let tag = tag.ok_or(ThisError::MissingMandatoryAttribute("tag"))?;
+				let tag = normalize_tag(tag);
 				let type_strindex = self.strings.lookup(&device_type.unwrap_or_default());
 				let tag_strindex = self.strings.lookup(&tag);
 				let mandatory = mandatory.map(parse_mame_bool).transpose()?.unwrap_or(false);

--- a/src/info/build.rs
+++ b/src/info/build.rs
@@ -21,6 +21,7 @@ use crate::info::ChipType;
 use crate::info::SoftwareListStatus;
 use crate::info::ENDIANNESS;
 use crate::info::MAGIC_HDR;
+use crate::parse::parse_mame_bool;
 use crate::xml::XmlElement;
 use crate::xml::XmlEvent;
 use crate::xml::XmlReader;
@@ -122,7 +123,7 @@ impl State {
 				let source_file_strindex = self.strings.lookup(&source_file.unwrap_or_default());
 				let clone_of_machine_index = self.strings.lookup(&clone_of.unwrap_or_default());
 				let rom_of_machine_index = self.strings.lookup(&rom_of.unwrap_or_default());
-				let runnable = runnable.map(bool_attribute).unwrap_or(true);
+				let runnable = runnable.map(parse_mame_bool).transpose()?.unwrap_or(true);
 				let machine = binary::Machine {
 					name_strindex,
 					source_file_strindex,
@@ -172,7 +173,7 @@ impl State {
 				let tag = tag.ok_or(ThisError::MissingMandatoryAttribute("tag"))?;
 				let type_strindex = self.strings.lookup(&device_type.unwrap_or_default());
 				let tag_strindex = self.strings.lookup(&tag);
-				let mandatory = mandatory.map(bool_attribute).unwrap_or(false);
+				let mandatory = mandatory.map(parse_mame_bool).transpose()?.unwrap_or(false);
 				let interface_strindex = self.strings.lookup(&interface.unwrap_or_default());
 				let device = binary::Device {
 					type_strindex,
@@ -607,11 +608,6 @@ where
 			self.push(obj);
 		}
 	}
-}
-
-fn bool_attribute(text: impl AsRef<str>) -> bool {
-	let text = text.as_ref();
-	text == "yes" || text == "1" || text == "true"
 }
 
 pub fn calculate_sizes_hash() -> u64 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod history;
 mod icon;
 mod info;
 mod models;
+mod parse;
 mod platform;
 mod prefs;
 mod runtime;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,6 +1,10 @@
 //! General utility functions for parsing stuff outputted by MAME
+use std::borrow::Cow;
+
 use anyhow::Error;
 use anyhow::Result;
+use itertools::Itertools;
+use itertools::Position;
 
 /// General parsing function for bool string values outputted by MAME
 pub fn parse_mame_bool(text: impl AsRef<str>) -> Result<bool> {
@@ -15,9 +19,39 @@ pub fn parse_mame_bool(text: impl AsRef<str>) -> Result<bool> {
 	}
 }
 
+/// Normalizes tags (e.g. - `:ext` ==> `ext`)
+pub fn normalize_tag<'a>(tag: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
+	let tag = tag.into();
+	if let Some(s) = internal_normalize_tag(tag.as_ref()) {
+		s.into()
+	} else {
+		tag
+	}
+}
+
+fn internal_normalize_tag(tag: &str) -> Option<String> {
+	let normalize_iter =
+		tag.chars()
+			.map(Some)
+			.chain([None])
+			.tuple_windows()
+			.with_position()
+			.map(|(pos, (ch, next))| match (pos != Position::Middle, ch, next) {
+				(_, Some(':'), Some(':')) => None,
+				(true, Some(':'), _) => None,
+				_ => ch,
+			});
+	normalize_iter
+		.clone()
+		.any(|x| x.is_none())
+		.then(|| normalize_iter.flatten().collect::<String>())
+}
+
 #[cfg(test)]
 mod test {
 	use test_case::test_case;
+
+	use super::internal_normalize_tag;
 
 	#[test_case(0, "0", Ok(false))]
 	#[test_case(1, "1", Ok(true))]
@@ -30,5 +64,18 @@ mod test {
 	fn parse_mame_bool(_index: usize, s: &str, expected: Result<bool, ()>) {
 		let actual = super::parse_mame_bool(s).map_err(|_| ());
 		assert_eq!(expected, actual);
+	}
+
+	#[test_case(0, "ext", None)]
+	#[test_case(1, "ext:", Some("ext"))]
+	#[test_case(2, ":ext", Some("ext"))]
+	#[test_case(3, ":ext:", Some("ext"))]
+	#[test_case(4, "ext:fdcv11:wd17xx:0:qd", None)]
+	#[test_case(5, ":ext:fdcv11:wd17xx:0:qd", Some("ext:fdcv11:wd17xx:0:qd"))]
+	#[test_case(6, "ext:fdcv11:wd17xx:0:qd:", Some("ext:fdcv11:wd17xx:0:qd"))]
+	#[test_case(7, "ext:fdcv11::::wd17xx:0:qd", Some("ext:fdcv11:wd17xx:0:qd"))]
+	pub fn normalize_tag(_index: usize, tag: &str, expected: Option<&str>) {
+		let actual = internal_normalize_tag(tag);
+		assert_eq!(expected, actual.as_deref());
 	}
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,34 @@
+//! General utility functions for parsing stuff outputted by MAME
+use anyhow::Error;
+use anyhow::Result;
+
+/// General parsing function for bool string values outputted by MAME
+pub fn parse_mame_bool(text: impl AsRef<str>) -> Result<bool> {
+	let text = text.as_ref().trim();
+	match text {
+		"0" | "false" | "no" => Ok(false),
+		"1" | "true" | "yes" => Ok(true),
+		_ => {
+			let message = format!("Cannot parse boolean value {text:?}");
+			Err(Error::msg(message))
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use test_case::test_case;
+
+	#[test_case(0, "0", Ok(false))]
+	#[test_case(1, "1", Ok(true))]
+	#[test_case(2, "false", Ok(false))]
+	#[test_case(3, "true", Ok(true))]
+	#[test_case(4, "no", Ok(false))]
+	#[test_case(5, "yes", Ok(true))]
+	#[test_case(6, "", Err(()))]
+	#[test_case(7, "zyx", Err(()))]
+	fn parse_mame_bool(_index: usize, s: &str, expected: Result<bool, ()>) {
+		let actual = super::parse_mame_bool(s).map_err(|_| ());
+		assert_eq!(expected, actual);
+	}
+}


### PR DESCRIPTION
- Changing `-listxml` processing to not tolerate various missing attributes
- Centralized processing of bools emitted by MAME in XML
- Normalizing device `tag` values