### PR TITLE
Rename of various Status-related structs

### DIFF
--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -19,7 +19,7 @@ const LOG: Level = Level::TRACE;
 #[derive(Default)]
 pub struct Status {
 	pub has_initialized: bool,
-	pub running: Option<StatusRunning>,
+	pub running: Option<Running>,
 	pub build: Option<MameVersion>,
 }
 
@@ -34,7 +34,7 @@ impl Status {
 			let throttle_rate = running.throttle_rate.unwrap_or(status_running.throttle_rate);
 			let sound_attenuation = running.sound_attenuation.unwrap_or(status_running.sound_attenuation);
 
-			StatusRunning {
+			Running {
 				machine_name,
 				is_paused,
 				is_throttled,
@@ -60,7 +60,7 @@ impl Debug for Status {
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct StatusRunning {
+pub struct Running {
 	pub machine_name: String,
 	pub is_paused: bool,
 	pub is_throttled: bool,
@@ -70,7 +70,7 @@ pub struct StatusRunning {
 
 #[derive(Clone, Deserialize, Serialize, PartialEq)]
 pub struct Update {
-	running: Option<UpdateRunning>,
+	running: Option<RunningUpdate>,
 	build: Option<MameVersion>,
 }
 
@@ -90,7 +90,7 @@ impl Debug for Update {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
-struct UpdateRunning {
+struct RunningUpdate {
 	pub machine_name: String,
 	pub is_paused: Option<bool>,
 	pub is_throttled: Option<bool>,

--- a/src/status/parse.rs
+++ b/src/status/parse.rs
@@ -6,8 +6,8 @@ use tracing::event;
 use tracing::Level;
 
 use crate::parse::parse_mame_bool;
+use crate::status::RunningUpdate;
 use crate::status::Update;
-use crate::status::UpdateRunning;
 use crate::version::MameVersion;
 use crate::xml::XmlElement;
 use crate::xml::XmlEvent;
@@ -25,7 +25,7 @@ enum Phase {
 struct State {
 	phase_stack: Vec<Phase>,
 	build: Option<MameVersion>,
-	running: UpdateRunning,
+	running: RunningUpdate,
 }
 
 impl State {
@@ -86,7 +86,7 @@ pub fn parse_update(reader: impl BufRead) -> Result<Update> {
 	let mut state = State {
 		phase_stack: Vec::with_capacity(32),
 		build: None,
-		running: UpdateRunning::default(),
+		running: RunningUpdate::default(),
 	};
 
 	while let Some(evt) = reader.next(&mut buf).map_err(|e| statusxml_err(&reader, e))? {


### PR DESCRIPTION
* `StatusRunning` ==> `Running`
* `UpdateRunning` ==> `RunningUpdate`

The goal here is to make the `Status*` structs the "norm", so that the `*Update` structs can be internal to `crate::status`