### PR TITLE
Initial (and thus crude) "Connect To Socket" dialog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,7 @@ dependencies = [
  "derive-enum-all-values",
  "dirs",
  "dpi",
+ "hostname-validator",
  "i-slint-backend-winit",
  "i-slint-common",
  "i-slint-core",
@@ -2282,6 +2283,12 @@ checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "hostname-validator"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
 name = "i-slint-backend-linuxkms"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ win32job = "=2.0.0"
 blockingqueue = "0.1.1"
 is_executable = "1.0.4"
 anyhow = "1.0.94"
+hostname-validator = "1.1.1"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/src/appcommand.rs
+++ b/src/appcommand.rs
@@ -90,6 +90,9 @@ pub enum AppCommand {
 	UnloadImage {
 		tag: String,
 	},
+	ConnectToSocketDialog {
+		tag: String,
+	},
 	ChangeSlots(Vec<(String, Option<String>)>),
 }
 

--- a/src/dialogs/devimages.rs
+++ b/src/dialogs/devimages.rs
@@ -123,6 +123,11 @@ fn entry_popup_menu(model: &DevicesAndImagesModel, entry_index: usize, point: Lo
 			let command = AppCommand::LoadImageDialog { tag };
 			Some(command.into())
 		};
+		let connect_socket_command = {
+			let tag = entry.tag.to_string();
+			let command = AppCommand::ConnectToSocketDialog { tag };
+			Some(command.into())
+		};
 		let unload_command = filename.is_some().then(|| {
 			let tag = entry.tag.to_string();
 			let command = AppCommand::UnloadImage { tag };
@@ -132,6 +137,7 @@ fn entry_popup_menu(model: &DevicesAndImagesModel, entry_index: usize, point: Lo
 			MenuDesc::Item("Create Image...".into(), None),
 			MenuDesc::Item("Load Image...".into(), load_command),
 			MenuDesc::Item("Load Software List Part...".into(), None),
+			MenuDesc::Item("Connect To Socket...".into(), connect_socket_command),
 			MenuDesc::Item("Unload".into(), unload_command),
 		]
 	});

--- a/src/dialogs/mod.rs
+++ b/src/dialogs/mod.rs
@@ -10,6 +10,7 @@ pub mod loading;
 pub mod messagebox;
 pub mod namecollection;
 pub mod paths;
+pub mod socket;
 
 struct SingleResult<T>(Rc<(Notify, RefCell<Option<T>>)>);
 

--- a/src/dialogs/socket.rs
+++ b/src/dialogs/socket.rs
@@ -1,0 +1,62 @@
+use slint::CloseRequestResponse;
+use slint::ComponentHandle;
+use slint::Weak;
+
+use crate::dialogs::SingleResult;
+use crate::guiutils::modal::Modal;
+use crate::ui::ConnectToSocketDialog;
+
+pub async fn dialog_connect_to_socket(parent: Weak<impl ComponentHandle + 'static>) -> Option<(String, u16)> {
+	// prepare the dialog
+	let modal = Modal::new(&parent.unwrap(), || ConnectToSocketDialog::new().unwrap());
+	let single_result = SingleResult::default();
+
+	// set up the accepted handler (when "OK" is clicked)
+	let signaller = single_result.signaller();
+	let dialog_weak = modal.dialog().as_weak();
+	modal.dialog().on_accepted(move || {
+		let dialog = dialog_weak.unwrap();
+		let result = get_results(&dialog).unwrap();
+		signaller.signal(Some(result));
+	});
+
+	// set up the cancelled handler (when "Cancel" is clicked)
+	let signaller = single_result.signaller();
+	modal.dialog().on_cancelled(move || {
+		signaller.signal(None);
+	});
+
+	// set up the changed handler
+	let dialog_weak = modal.dialog().as_weak();
+	modal.dialog().on_changed(move || {
+		update_can_accept(&dialog_weak.unwrap());
+	});
+
+	// set up the close handler
+	let signaller = single_result.signaller();
+	modal.window().on_close_requested(move || {
+		signaller.signal(None);
+		CloseRequestResponse::KeepWindowShown
+	});
+
+	// set up defaults
+	modal.dialog().set_host_text("localhost".into());
+	modal.dialog().set_port_text("12345".into());
+	update_can_accept(modal.dialog());
+
+	// present the modal dialog
+	modal.run(async { single_result.wait().await }).await
+}
+
+fn update_can_accept(dialog: &ConnectToSocketDialog) {
+	let is_enabled = get_results(dialog).is_some();
+	dialog.set_can_accept(is_enabled);
+}
+
+fn get_results(dialog: &ConnectToSocketDialog) -> Option<(String, u16)> {
+	let host_text = dialog.get_host_text();
+	let port_text = dialog.get_port_text();
+	let port = port_text.parse().ok()?;
+	let is_valid = hostname_validator::is_valid(&host_text);
+	is_valid.then(|| (host_text.into(), port))
+}

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -5,9 +5,10 @@ import { LoadingDialog } from "loading.slint";
 import { PathsDialog } from "paths.slint";
 import { MessageBoxDialog } from "messagebox.slint";
 import { NameCollectionDialog } from "namecollection.slint";
+import { ConnectToSocketDialog } from "socket.slint";
 import { DevicesAndImagesDialog, DeviceAndImageEntry } from "devimages.slint";
 
-export { AboutDialog, LoadingDialog, MessageBoxDialog, NameCollectionDialog, PathsDialog, DevicesAndImagesDialog, DeviceAndImageEntry, Icons }
+export { AboutDialog, ConnectToSocketDialog, LoadingDialog, MessageBoxDialog, NameCollectionDialog, PathsDialog, DevicesAndImagesDialog, DeviceAndImageEntry, Icons }
 
 export component AppWindow inherits Window {
     min-width: 100px;

--- a/ui/socket.slint
+++ b/ui/socket.slint
@@ -1,0 +1,62 @@
+import { Button, VerticalBox, HorizontalBox, LineEdit } from "std-widgets.slint";
+
+export component ConnectToSocketDialog inherits Window {
+    title: "Connect To Socket";
+    icon: @image-url("bletchmame.png");
+    height: 150px;
+    width: 350px;
+    callback accepted();
+    callback cancelled();
+    callback changed();
+    in property <bool> can-accept;
+    in-out property <string> host-text;
+    in-out property <string> port-text;
+    VerticalBox {
+        Text {
+            horizontal-alignment: left;
+            text: "Enter Hostname of Host or IP Address and Port:";
+        }
+
+        HorizontalBox {
+            LineEdit {
+                text <=> root.host-text;
+                accepted => {
+                    root.accepted();
+                }
+                edited => {
+                    root.changed();
+                }
+            }
+
+            LineEdit {
+                width: 100px;
+                text <=> root.port-text;
+                input-type: number;
+                accepted => {
+                    root.accepted();
+                }
+                edited => {
+                    root.changed();
+                }
+            }
+        }
+
+        HorizontalBox {
+            alignment: end;
+            Button {
+                text: "Cancel";
+                clicked => {
+                    root.cancelled();
+                }
+            }
+
+            Button {
+                text: "OK";
+                enabled: root.can-accept;
+                clicked => {
+                    root.accepted();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Known Problems:
- The dialog is not parented properly
- The "Connect To Socket" menu option is present on all image types, even when not appropriate (e.g. - floppy images)
- If you already have a socket open, the dialog should default to the active socket