### PR TITLE
Fixed an issue with slots that got ignored when building InfoDB

### DIFF
--- a/src/info/build.rs
+++ b/src/info/build.rs
@@ -206,10 +206,6 @@ impl State {
 			(Phase::Machine, b"slot") => {
 				let [name] = evt.find_attributes([b"name"])?;
 				let name = name.ok_or(ThisError::MissingMandatoryAttribute("slot"))?;
-				if !name.starts_with(':') && name.contains(':') {
-					// we want to slots in the -listxml output that are there by virtue of having selected options
-					return Ok(None);
-				}
 				let name = normalize_tag(name);
 				let name_strindex: u32 = self.strings.lookup(&name);
 				let slot = binary::Slot {
@@ -691,7 +687,7 @@ where
 }
 
 pub fn calculate_sizes_hash() -> u64 {
-	let multiplicand = 4733; // arbitrary prime number
+	let multiplicand = 4729; // arbitrary prime number
 	[
 		binary::Header::SERIALIZED_SIZE,
 		binary::Machine::SERIALIZED_SIZE,

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -637,8 +637,8 @@ mod test {
 		assert_eq!(expected, actual);
 	}
 
-	#[test_case(0, include_str!("test_data/listxml_coco.xml"), "coco2b", &["rs232", "ext"])]
-	#[test_case(1, include_str!("test_data/listxml_fake.xml"), "fake", &["ext"])]
+	#[test_case(0, include_str!("test_data/listxml_coco.xml"), "coco2b", &["rs232", "ext", "ext:fdc:wd17xx:0", "ext:fdc:wd17xx:1", "ext:fdc:wd17xx:2", "ext:fdc:wd17xx:3"])]
+	#[test_case(1, include_str!("test_data/listxml_fake.xml"), "fake", &["ext", "ext:fdcv11:wd17xx:0", "ext:fdcv11:wd17xx:1"])]
 	pub fn slots(_index: usize, xml: &str, machine: &str, expected: &[&str]) {
 		let db = InfoDb::from_listxml_output(xml.as_bytes(), |_| false).unwrap().unwrap();
 		let actual = db


### PR DESCRIPTION
This was first reported as a crash on the "Devices & Images" dialog with `at486`

The issue was that we were ignoring "child devices" when setting up the InfoDB, so that we would ignore slots in `-listxml` that only existed because of the default Machine Config (e.g. - `ext:fdc:wd17xx:0` on `coco2b`).  Some drivers (like `at486`) seem to have child devices (i.e. - with a colon in the tag) that are not associated with a configurable device.

The fix was to stop ignoring these when building InfoDB, and to identify them when we create our MachineConfigs.