### PR TITLE
The "Classic MAME Menu" feature now requires MAME 0.274

### DIFF
--- a/src/appcommand.rs
+++ b/src/appcommand.rs
@@ -29,7 +29,7 @@ pub enum AppCommand {
 	OptionsThrottleRate(f32),
 	OptionsToggleWarp,
 	OptionsToggleSound,
-	#[strum(props(MinimumMame = "0.273"))] // should be 0.274
+	#[strum(props(MinimumMame = "0.274"))]
 	OptionsClassic,
 
 	// Settings menu


### PR DESCRIPTION
This is (of course) the first official version of MAME with the required LUA hooks.