### PR TITLE
Changed `prefs_path` to be `PathBuf` instead of `Option<PathBuf>`

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -89,7 +89,7 @@ const SOUND_ATTENUATION_ON: i32 = 0;
 /// are power user features or diagnostics
 #[derive(Debug)]
 pub struct AppArgs {
-	pub prefs_path: Option<PathBuf>,
+	pub prefs_path: PathBuf,
 	pub mame_stderr: MameStderr,
 	pub menuing_type: MenuingType,
 }
@@ -198,7 +198,7 @@ impl AppModel {
 			// do we have an InfoDb mismatch?
 			if new_state.has_infodb_mismatch() {
 				let preferences = self.preferences.borrow();
-				let prefs_path = preferences.prefs_path.as_deref();
+				let prefs_path = &preferences.prefs_path;
 				new_state = new_state
 					.infodb_load(prefs_path, &preferences.paths, true)
 					.unwrap_or(new_state);
@@ -305,7 +305,7 @@ impl AppModel {
 	pub fn infodb_load(self: &Rc<Self>, force_refresh: bool) {
 		self.update_state(|state| {
 			let preferences = self.preferences.borrow();
-			let prefs_path = preferences.prefs_path.as_deref();
+			let prefs_path = &preferences.prefs_path;
 			state.infodb_load(prefs_path, &preferences.paths, force_refresh)
 		});
 	}
@@ -336,7 +336,7 @@ pub fn create(args: AppArgs) -> AppWindow {
 
 	// get preferences
 	let prefs_path = args.prefs_path;
-	let preferences = Preferences::load(prefs_path.as_ref())
+	let preferences = Preferences::load(&prefs_path)
 		.ok()
 		.flatten()
 		.unwrap_or_else(|| Preferences::fresh(prefs_path));
@@ -808,8 +808,7 @@ fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 			});
 		}
 		AppCommand::SettingsReset => model.modify_prefs(|prefs| {
-			let prefs_path = prefs.prefs_path.take();
-			*prefs = Preferences::fresh(prefs_path);
+			*prefs = Preferences::fresh(prefs.prefs_path.clone());
 		}),
 		AppCommand::HelpWebSite => {
 			let _ = open::that("https://www.bletchmame.org");

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -125,7 +125,7 @@ impl InfoDb {
 		Ok(result)
 	}
 
-	pub fn load(prefs_path: Option<impl AsRef<Path>>, mame_executable_path: &str) -> Result<Self> {
+	pub fn load(prefs_path: impl AsRef<Path>, mame_executable_path: &str) -> Result<Self> {
 		let filename = infodb_filename(prefs_path, mame_executable_path).map_err(infodb_load_error)?;
 		let file = File::open(filename).map_err(infodb_load_error)?;
 		let mut reader = BufReader::new(file);
@@ -134,7 +134,7 @@ impl InfoDb {
 		Self::new(data.into())
 	}
 
-	pub fn save(&self, prefs_path: Option<impl AsRef<Path>>, mame_executable_path: &str) -> Result<()> {
+	pub fn save(&self, prefs_path: impl AsRef<Path>, mame_executable_path: &str) -> Result<()> {
 		let filename = infodb_filename(prefs_path, mame_executable_path).map_err(infodb_save_error)?;
 		let mut file = File::create(filename).map_err(infodb_save_error)?;
 		file.write_all(&self.data).map_err(infodb_save_error)?;
@@ -287,7 +287,7 @@ struct RootView<T> {
 	phantom: PhantomData<T>,
 }
 
-fn infodb_filename(prefs_path: Option<impl AsRef<Path>>, mame_executable_path: &str) -> Result<PathBuf> {
+fn infodb_filename(prefs_path: impl AsRef<Path>, mame_executable_path: &str) -> Result<PathBuf> {
 	let file_name = Path::new(mame_executable_path)
 		.file_name()
 		.ok_or_else(infodb_filename_error)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,11 +85,9 @@ fn main() {
 	}
 
 	// identify the preferences directory
-	let prefs_path = opts.prefs_path.or_else(|| {
-		let mut path = config_local_dir();
-		if let Some(path) = &mut path {
-			path.push("BletchMAME");
-		}
+	let prefs_path = opts.prefs_path.unwrap_or_else(|| {
+		let mut path = config_local_dir().unwrap_or_default();
+		path.push("BletchMAME");
 		path
 	});
 

--- a/src/prefs_fresh.json
+++ b/src/prefs_fresh.json
@@ -3,7 +3,9 @@
     "plugins": [
       "$(BLETCHMAMEPATH)\\plugins",
       "$(MAMEPATH)\\plugins"
-    ]
+    ],
+    "cfg": "/cfg/BletchMAME",
+    "nvram": "/cfg/BletchMAME"
   },
   "itemsColumns": [
     {


### PR DESCRIPTION
BletchMAME is really not able to function in a meaningful way without something for `prefs_path`, so this logic simplifies things greatly by changing our logic to expect something to be there