### PR TITLE
Various cleanups to `Status` management

### DIFF
--- a/src/appstate.rs
+++ b/src/appstate.rs
@@ -351,15 +351,8 @@ impl AppState {
 		}
 
 		// merge the new status
-		let new_status = self
-			.session
-			.as_ref()
-			.unwrap()
-			.status
-			.as_deref()
-			.map(Cow::Borrowed)
-			.unwrap_or_else(|| Cow::Owned(Status::default()))
-			.merge(update);
+		let old_status = self.session.as_ref().unwrap().status.as_deref();
+		let new_status = Status::new(old_status, update);
 
 		// update the session
 		let session = Session {

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -478,12 +478,7 @@ pub fn create(args: AppArgs) -> AppWindow {
 		if is_context_menu_event(&evt) {
 			let index = usize::try_from(index).unwrap();
 			let folder_info = get_folder_collections(&model_clone.preferences.borrow().collections);
-			let has_mame_initialized = model_clone
-				.state
-				.borrow()
-				.status()
-				.map(|s| s.has_initialized)
-				.unwrap_or_default();
+			let has_mame_initialized = model_clone.state.borrow().status().is_some();
 			if let Some(popup_menu) =
 				model_clone.with_items_table_model(|x| x.context_commands(index, &folder_info, has_mame_initialized))
 			{

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::cell::RefCell;
 use std::iter::once;
 use std::path::PathBuf;
@@ -969,21 +968,14 @@ async fn show_paths_dialog(model: Rc<AppModel>) {
 fn update_menus(model: &AppModel) {
 	// calculate properties
 	let state = model.state.borrow();
-	let running_status = state
-		.status()
-		.map(Cow::Borrowed)
-		.unwrap_or_else(|| Cow::Owned(Status::default()));
+	let build = state.status().and_then(|s| s.build.as_ref());
+	let running = state.status().and_then(|s| s.running.as_ref());
 	let has_mame_executable = model.preferences.borrow().paths.mame_executable.is_some();
-	let is_running = running_status.running.is_some();
-	let is_paused = running_status.running.as_ref().map(|r| r.is_paused).unwrap_or_default();
-	let is_throttled = running_status
-		.running
-		.as_ref()
-		.map(|r| r.is_throttled)
-		.unwrap_or_default();
-	let throttle_rate = running_status.running.as_ref().map(|r| r.throttle_rate);
-	let is_sound_enabled = running_status
-		.running
+	let is_running = running.is_some();
+	let is_paused = running.as_ref().map(|r| r.is_paused).unwrap_or_default();
+	let is_throttled = running.as_ref().map(|r| r.is_throttled).unwrap_or_default();
+	let throttle_rate = running.as_ref().map(|r| r.throttle_rate);
+	let is_sound_enabled = running
 		.as_ref()
 		.map(|r| r.sound_attenuation > SOUND_ATTENUATION_OFF)
 		.unwrap_or_default();
@@ -1012,7 +1004,7 @@ fn update_menus(model: &AppModel) {
 				.as_ref()
 				.ok()
 				.and_then(AppCommand::minimum_mame_version)
-				.is_none_or(|a| running_status.build.as_ref().is_some_and(|b| b >= &a))
+				.is_none_or(|a| build.is_some_and(|b| b >= &a))
 		});
 		MenuItemUpdate { enabled, checked }
 	});

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -968,7 +968,7 @@ async fn show_paths_dialog(model: Rc<AppModel>) {
 fn update_menus(model: &AppModel) {
 	// calculate properties
 	let state = model.state.borrow();
-	let build = state.status().and_then(|s| s.build.as_ref());
+	let build = state.status().map(|s| &s.build);
 	let running = state.status().and_then(|s| s.running.as_ref());
 	let has_mame_executable = model.preferences.borrow().paths.mame_executable.is_some();
 	let is_running = running.is_some();

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -2,12 +2,10 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-#[derive(Default)]
 pub struct Channel<T>(Rc<RefCell<ChannelInner<T>>>);
 
 type Callback<T> = Box<dyn Fn(&T) + 'static>;
 
-#[derive(Default)]
 struct ChannelInner<T> {
 	subscribers: Vec<Option<Callback<T>>>,
 }
@@ -70,5 +68,14 @@ impl<T> Clone for Channel<T> {
 impl<T> Drop for Subscription<T> {
 	fn drop(&mut self) {
 		self.channel.unsubscribe(self.id);
+	}
+}
+
+impl<T> Default for Channel<T> {
+	fn default() -> Self {
+		let inner = ChannelInner {
+			subscribers: Default::default(),
+		};
+		Self(Rc::new(RefCell::new(inner)))
 	}
 }

--- a/src/devimageconfig.rs
+++ b/src/devimageconfig.rs
@@ -389,7 +389,7 @@ mod test {
 
 		// build the status
 		let update = Update::parse(status_xml.as_bytes()).unwrap();
-		let status = Status::default().merge(update);
+		let status = Status::new(None, update);
 
 		// now create the config and update the status
 		let config = DevicesImagesConfig::new(info_db);

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -23,7 +23,7 @@ const LOG: Level = Level::TRACE;
 #[derive(Clone)]
 pub struct Status {
 	pub running: Option<Running>,
-	pub build: Option<MameVersion>,
+	pub build: MameVersion,
 }
 
 impl Status {
@@ -133,7 +133,7 @@ pub struct ImageFormat {
 #[derive(Clone, Deserialize, Serialize, PartialEq)]
 pub struct Update {
 	running: Option<RunningUpdate>,
-	build: Option<MameVersion>,
+	build: MameVersion,
 }
 
 impl Update {

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -22,7 +22,6 @@ const LOG: Level = Level::TRACE;
 
 #[derive(Clone, Default)]
 pub struct Status {
-	pub has_initialized: bool,
 	pub running: Option<Running>,
 	pub build: Option<MameVersion>,
 }
@@ -83,7 +82,6 @@ impl Status {
 		event!(LOG, "Status::merge(): running={:?}", running);
 		Self {
 			running,
-			has_initialized: true,
 			build: update.build,
 		}
 	}
@@ -92,7 +90,6 @@ impl Status {
 impl Debug for Status {
 	fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
 		fmt.debug_struct("Status")
-			.field("has_initialized", &self.has_initialized)
 			.field("running", &self.running.as_ref().map(DebugString::elipsis))
 			.field("build", &self.build)
 			.finish()

--- a/src/status/test_data/status_mame0226_coco2b_1.xml
+++ b/src/status/test_data/status_mame0226_coco2b_1.xml
@@ -1,5 +1,6 @@
 <status
 	romname="coco2b"
+	app_version="0.226"
 	phase="running"
 	polling_input_seq="false"
 	natural_keyboard_in_use="false"

--- a/src/status/test_data/status_mame0227_coco2b_1.xml
+++ b/src/status/test_data/status_mame0227_coco2b_1.xml
@@ -1,5 +1,6 @@
 <status
 	romname="coco2b"
+	app_version="0.227"
 	phase="running"
 	polling_input_seq="false"
 	natural_keyboard_in_use="false"

--- a/src/status/test_data/status_mame0273_alienar_1.xml
+++ b/src/status/test_data/status_mame0273_alienar_1.xml
@@ -1,0 +1,1299 @@
+<status
+	app_name="mame"
+	app_version="0.273"
+	app_build="0.273 (mame0273)"
+	gamename="Alien Arena"
+	romname="alienar"
+	softname=""
+	time="45.85984"
+	pid="4264"
+	polling_input_seq="false"
+	natural_keyboard_in_use="false"
+	paused="false"
+	startup_text=""
+	debugger_present="0"
+	show_profiler="false"
+	has_input_using_mouse="true"
+	has_mouse_enabled_problem="false"
+>
+	<video
+		speed_percent="0.99983251002874"
+		frameskip="0"
+		effective_frameskip="0"
+		throttled="true"
+		throttle_rate="1.0"
+		is_recording="0"
+	/>
+	<sound
+		attenuation="0"
+	/>
+	<cheats>
+		<cheat id="1" enabled="0" description="Infinite Time"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="2" enabled="0" description=""
+			>
+		</cheat>
+		<cheat id="3" enabled="0" description="P1 Just 2 Pieces to make a Trap"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="4" enabled="0" description="P1 Just 2 Pieces to make a Mine"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="5" enabled="0" description="P1 Just 2 Pieces to make a Drone"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="6" enabled="0" description="P1 Just 2 Pieces to make a Spazzmatazz"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="7" enabled="0" description="P1 Just 2 Pieces to make a QTPI"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="8" enabled="0" description="P1 Can Never Make a Trap"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="9" enabled="0" description="P1 Can Never Make a Mine"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="10" enabled="0" description="P1 Can Never Make a Drone"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="11" enabled="0" description="P1 Can Never Make a Spazzmatazz"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="12" enabled="0" description="P1 Can Never Make a QTPI"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="13" enabled="0" description=""
+			>
+		</cheat>
+		<cheat id="14" enabled="0" description="P2 is for an actual P2 not the CPU"
+			>
+		</cheat>
+		<cheat id="15" enabled="0" description=""
+			>
+		</cheat>
+		<cheat id="16" enabled="0" description="P2 Just 2 Pieces to make a Trap"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="17" enabled="0" description="P2 Just 2 Pieces to make a Mine"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="18" enabled="0" description="P2 Just 2 Pieces to make a Drone"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="19" enabled="0" description="P2 Just 2 Pieces to make a Spazzmatazz"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="20" enabled="0" description="P2 Just 2 Pieces to make a QTPI"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="21" enabled="0" description="P2 Can Never Make a Trap"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="22" enabled="0" description="P2 Can Never Make a Mine"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="23" enabled="0" description="P2 Can Never Make a Drone"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="24" enabled="0" description="P2 Can Never Make a Spazzmatazz"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+		<cheat id="25" enabled="0" description="P2 Can Never Make a QTPI"
+			has_run_script="1" has_on_script="0" has_off_script="0" has_change_script="0"
+			>
+		</cheat>
+	</cheats>
+	<images>
+	</images>
+	<cassettes>
+	</cassettes>
+	<slots>
+	</slots>
+	<inputs>
+		<input port_tag=":IN0" mask="32" class="misc" group="11" type="8" player="0" is_analog="0" name="2 Players Start"
+		>
+			<seq type="standard" tokens="KEYCODE_2 OR JOYCODE_2_UNKNOWN_SWITCH"/>
+		</input>
+		<input port_tag=":IN0" mask="16" class="misc" group="11" type="7" player="0" is_analog="0" name="1 Player Start"
+		>
+			<seq type="standard" tokens="KEYCODE_1 OR JOYCODE_1_UNKNOWN_SWITCH"/>
+		</input>
+		<input port_tag=":IN2" mask="2" class="misc" group="11" type="40" player="0" is_analog="0" name="Advance"
+		>
+			<seq type="standard" tokens="KEYCODE_F2"/>
+		</input>
+		<input port_tag=":IN2" mask="8" class="misc" group="11" type="43" player="0" is_analog="0" name="High Score Reset"
+		>
+			<seq type="standard" tokens="KEYCODE_F1"/>
+		</input>
+		<input port_tag=":IN2" mask="64" class="misc" group="11" type="41" player="0" is_analog="0" name="Tilt"
+		>
+			<seq type="standard" tokens="KEYCODE_T"/>
+		</input>
+		<input port_tag=":IN2" mask="1" class="misc" group="11" type="30" player="0" is_analog="0" name="Auto Up / Manual Down"
+		>
+			<seq type="standard" tokens="KEYCODE_9"/>
+		</input>
+		<input port_tag=":IN2" mask="16" class="misc" group="11" type="17" player="0" is_analog="0" name="Coin 1"
+		>
+			<seq type="standard" tokens="KEYCODE_5 OR JOYCODE_1_UNKNOWN_SWITCH"/>
+		</input>
+		<input port_tag=":IN2" mask="32" class="misc" group="11" type="18" player="0" is_analog="0" name="Coin 2"
+		>
+			<seq type="standard" tokens="KEYCODE_6 OR JOYCODE_2_UNKNOWN_SWITCH"/>
+		</input>
+		<input port_tag=":IN2" mask="4" class="misc" group="11" type="19" player="0" is_analog="0" name="Coin 3"
+		>
+			<seq type="standard" tokens="KEYCODE_7 OR JOYCODE_3_UNKNOWN_SWITCH"/>
+		</input>
+		<input port_tag=":INP1" mask="8" class="controller" group="1" type="54" player="0" is_analog="0" name="P1 Right"
+		>
+			<seq type="standard" tokens="KEYCODE_RIGHT OR JOYCODE_1_XAXIS_RIGHT_SWITCH"/>
+		</input>
+		<input port_tag=":INP1" mask="2" class="controller" group="1" type="52" player="0" is_analog="0" name="P1 Down"
+		>
+			<seq type="standard" tokens="KEYCODE_DOWN OR JOYCODE_1_YAXIS_DOWN_SWITCH"/>
+		</input>
+		<input port_tag=":INP1" mask="4" class="controller" group="1" type="53" player="0" is_analog="0" name="P1 Left"
+		>
+			<seq type="standard" tokens="KEYCODE_LEFT OR JOYCODE_1_XAXIS_LEFT_SWITCH"/>
+		</input>
+		<input port_tag=":INP1" mask="1" class="controller" group="1" type="51" player="0" is_analog="0" name="P1 Up"
+		>
+			<seq type="standard" tokens="KEYCODE_UP OR JOYCODE_1_YAXIS_UP_SWITCH"/>
+		</input>
+		<input port_tag=":INP1A" mask="1" class="controller" group="1" type="64" player="0" is_analog="0" name="P1 Button 1"
+		>
+			<seq type="standard" tokens="KEYCODE_LCONTROL OR MOUSECODE_1_BUTTON1 OR GUNCODE_1_BUTTON1 OR JOYCODE_1_BUTTON1"/>
+		</input>
+		<input port_tag=":INP1A" mask="2" class="controller" group="1" type="65" player="0" is_analog="0" name="P1 Button 2"
+		>
+			<seq type="standard" tokens="KEYCODE_LALT OR MOUSECODE_1_BUTTON3 OR GUNCODE_1_BUTTON2 OR JOYCODE_1_BUTTON2"/>
+		</input>
+		<input port_tag=":INP2" mask="8" class="controller" group="2" type="54" player="1" is_analog="0" name="P2 Right"
+		>
+			<seq type="standard" tokens="KEYCODE_G"/>
+		</input>
+		<input port_tag=":INP2" mask="4" class="controller" group="2" type="53" player="1" is_analog="0" name="P2 Left"
+		>
+			<seq type="standard" tokens="KEYCODE_D"/>
+		</input>
+		<input port_tag=":INP2" mask="1" class="controller" group="2" type="51" player="1" is_analog="0" name="P2 Up"
+		>
+			<seq type="standard" tokens="KEYCODE_R"/>
+		</input>
+		<input port_tag=":INP2" mask="2" class="controller" group="2" type="52" player="1" is_analog="0" name="P2 Down"
+		>
+			<seq type="standard" tokens="KEYCODE_F"/>
+		</input>
+		<input port_tag=":INP2A" mask="2" class="controller" group="2" type="65" player="1" is_analog="0" name="P2 Button 2"
+		>
+			<seq type="standard" tokens="KEYCODE_S OR MOUSECODE_2_UNKNOWN_SWITCH OR GUNCODE_2_UNKNOWN_SWITCH"/>
+		</input>
+		<input port_tag=":INP2A" mask="1" class="controller" group="2" type="64" player="1" is_analog="0" name="P2 Button 1"
+		>
+			<seq type="standard" tokens="KEYCODE_A OR MOUSECODE_2_UNKNOWN_SWITCH OR GUNCODE_2_UNKNOWN_SWITCH"/>
+		</input>
+	</inputs>
+	<input_devices>
+		<class name="keyboard" enabled="1" multi="0">
+			<device name="HID Keyboard Device" id="\\?\HID#ConvertedDevice&amp;Col01#5&amp;51a60f0&amp;0&amp;0000#{884b96c3-56ef-11d1-bc8c-00a0c91405dd}" devindex="0">
+				<item name="A" token="A" code="KEYCODE_A"/>
+				<item name="B" token="B" code="KEYCODE_B"/>
+				<item name="C" token="C" code="KEYCODE_C"/>
+				<item name="D" token="D" code="KEYCODE_D"/>
+				<item name="E" token="E" code="KEYCODE_E"/>
+				<item name="F" token="F" code="KEYCODE_F"/>
+				<item name="G" token="G" code="KEYCODE_G"/>
+				<item name="H" token="H" code="KEYCODE_H"/>
+				<item name="I" token="I" code="KEYCODE_I"/>
+				<item name="J" token="J" code="KEYCODE_J"/>
+				<item name="K" token="K" code="KEYCODE_K"/>
+				<item name="L" token="L" code="KEYCODE_L"/>
+				<item name="M" token="M" code="KEYCODE_M"/>
+				<item name="N" token="N" code="KEYCODE_N"/>
+				<item name="O" token="O" code="KEYCODE_O"/>
+				<item name="P" token="P" code="KEYCODE_P"/>
+				<item name="Q" token="Q" code="KEYCODE_Q"/>
+				<item name="R" token="R" code="KEYCODE_R"/>
+				<item name="S" token="S" code="KEYCODE_S"/>
+				<item name="T" token="T" code="KEYCODE_T"/>
+				<item name="U" token="U" code="KEYCODE_U"/>
+				<item name="V" token="V" code="KEYCODE_V"/>
+				<item name="W" token="W" code="KEYCODE_W"/>
+				<item name="X" token="X" code="KEYCODE_X"/>
+				<item name="Y" token="Y" code="KEYCODE_Y"/>
+				<item name="Z" token="Z" code="KEYCODE_Z"/>
+				<item name="0" token="0" code="KEYCODE_0"/>
+				<item name="1" token="1" code="KEYCODE_1"/>
+				<item name="2" token="2" code="KEYCODE_2"/>
+				<item name="3" token="3" code="KEYCODE_3"/>
+				<item name="4" token="4" code="KEYCODE_4"/>
+				<item name="5" token="5" code="KEYCODE_5"/>
+				<item name="6" token="6" code="KEYCODE_6"/>
+				<item name="7" token="7" code="KEYCODE_7"/>
+				<item name="8" token="8" code="KEYCODE_8"/>
+				<item name="9" token="9" code="KEYCODE_9"/>
+				<item name="F1" token="F1" code="KEYCODE_F1"/>
+				<item name="F2" token="F2" code="KEYCODE_F2"/>
+				<item name="F3" token="F3" code="KEYCODE_F3"/>
+				<item name="F4" token="F4" code="KEYCODE_F4"/>
+				<item name="F5" token="F5" code="KEYCODE_F5"/>
+				<item name="F6" token="F6" code="KEYCODE_F6"/>
+				<item name="F7" token="F7" code="KEYCODE_F7"/>
+				<item name="F8" token="F8" code="KEYCODE_F8"/>
+				<item name="F9" token="F9" code="KEYCODE_F9"/>
+				<item name="F10" token="F10" code="KEYCODE_F10"/>
+				<item name="F11" token="F11" code="KEYCODE_F11"/>
+				<item name="F12" token="F12" code="KEYCODE_F12"/>
+				<item name="Scan100" token="F13" code="KEYCODE_F13"/>
+				<item name="Scan101" token="F14" code="KEYCODE_F14"/>
+				<item name="Scan102" token="F15" code="KEYCODE_F15"/>
+				<item name="Esc" token="ESC" code="KEYCODE_ESC"/>
+				<item name="`" token="TILDE" code="KEYCODE_TILDE"/>
+				<item name="-" token="MINUS" code="KEYCODE_MINUS"/>
+				<item name="=" token="EQUALS" code="KEYCODE_EQUALS"/>
+				<item name="Backspace" token="BACKSPACE" code="KEYCODE_BACKSPACE"/>
+				<item name="Tab" token="TAB" code="KEYCODE_TAB"/>
+				<item name="[" token="OPENBRACE" code="KEYCODE_OPENBRACE"/>
+				<item name="]" token="CLOSEBRACE" code="KEYCODE_CLOSEBRACE"/>
+				<item name="Enter" token="ENTER" code="KEYCODE_ENTER"/>
+				<item name=";" token="COLON" code="KEYCODE_COLON"/>
+				<item name="'" token="QUOTE" code="KEYCODE_QUOTE"/>
+				<item name="\" token="BACKSLASH" code="KEYCODE_BACKSLASH"/>
+				<item name="\" token="BACKSLASH2" code="KEYCODE_BACKSLASH2"/>
+				<item name="," token="COMMA" code="KEYCODE_COMMA"/>
+				<item name="." token="STOP" code="KEYCODE_STOP"/>
+				<item name="/" token="SLASH" code="KEYCODE_SLASH"/>
+				<item name="Space" token="SPACE" code="KEYCODE_SPACE"/>
+				<item name="Insert" token="INSERT" code="KEYCODE_INSERT"/>
+				<item name="Delete" token="DEL" code="KEYCODE_DEL"/>
+				<item name="Home" token="HOME" code="KEYCODE_HOME"/>
+				<item name="End" token="END" code="KEYCODE_END"/>
+				<item name="Page Up" token="PGUP" code="KEYCODE_PGUP"/>
+				<item name="Page Down" token="PGDN" code="KEYCODE_PGDN"/>
+				<item name="Left" token="LEFT" code="KEYCODE_LEFT"/>
+				<item name="Right" token="RIGHT" code="KEYCODE_RIGHT"/>
+				<item name="Up" token="UP" code="KEYCODE_UP"/>
+				<item name="Down" token="DOWN" code="KEYCODE_DOWN"/>
+				<item name="Num 0" token="0PAD" code="KEYCODE_0PAD"/>
+				<item name="Num 1" token="1PAD" code="KEYCODE_1PAD"/>
+				<item name="Num 2" token="2PAD" code="KEYCODE_2PAD"/>
+				<item name="Num 3" token="3PAD" code="KEYCODE_3PAD"/>
+				<item name="Num 4" token="4PAD" code="KEYCODE_4PAD"/>
+				<item name="Num 5" token="5PAD" code="KEYCODE_5PAD"/>
+				<item name="Num 6" token="6PAD" code="KEYCODE_6PAD"/>
+				<item name="Num 7" token="7PAD" code="KEYCODE_7PAD"/>
+				<item name="Num 8" token="8PAD" code="KEYCODE_8PAD"/>
+				<item name="Num 9" token="9PAD" code="KEYCODE_9PAD"/>
+				<item name="Num /" token="SLASHPAD" code="KEYCODE_SLASHPAD"/>
+				<item name="Num *" token="ASTERISK" code="KEYCODE_ASTERISK"/>
+				<item name="Num -" token="MINUSPAD" code="KEYCODE_MINUSPAD"/>
+				<item name="Num +" token="PLUSPAD" code="KEYCODE_PLUSPAD"/>
+				<item name="Num Del" token="DELPAD" code="KEYCODE_DELPAD"/>
+				<item name="Num Enter" token="ENTERPAD" code="KEYCODE_ENTERPAD"/>
+				<item name="," token="SCAN179" code="KEYCODE_SCAN179"/>
+				<item name="=" token="SCAN141" code="KEYCODE_SCAN141"/>
+				<item name="Prnt Scrn" token="PRTSCR" code="KEYCODE_PRTSCR"/>
+				<item name="Pause" token="PAUSE" code="KEYCODE_PAUSE"/>
+				<item name="Shift" token="LSHIFT" code="KEYCODE_LSHIFT"/>
+				<item name="Right Shift" token="RSHIFT" code="KEYCODE_RSHIFT"/>
+				<item name="Ctrl" token="LCONTROL" code="KEYCODE_LCONTROL"/>
+				<item name="Right Ctrl" token="RCONTROL" code="KEYCODE_RCONTROL"/>
+				<item name="Alt" token="LALT" code="KEYCODE_LALT"/>
+				<item name="Right Alt" token="RALT" code="KEYCODE_RALT"/>
+				<item name="Scroll Lock" token="SCRLOCK" code="KEYCODE_SCRLOCK"/>
+				<item name="Num Lock" token="NUMLOCK" code="KEYCODE_NUMLOCK"/>
+				<item name="Caps Lock" token="CAPSLOCK" code="KEYCODE_CAPSLOCK"/>
+				<item name="Left Windows" token="LWIN" code="KEYCODE_LWIN"/>
+				<item name="Right Windows" token="RWIN" code="KEYCODE_RWIN"/>
+				<item name="Application" token="MENU" code="KEYCODE_MENU"/>
+				<item name="Scan000" token="SCAN000" code="KEYCODE_SCAN000"/>
+				<item name="Sys Req" token="SCAN084" code="KEYCODE_SCAN084"/>
+				<item name="Scan085" token="SCAN085" code="KEYCODE_SCAN085"/>
+				<item name="Scan089" token="SCAN089" code="KEYCODE_SCAN089"/>
+				<item name="Scan090" token="SCAN090" code="KEYCODE_SCAN090"/>
+				<item name="Scan091" token="SCAN091" code="KEYCODE_SCAN091"/>
+				<item name="Scan092" token="SCAN092" code="KEYCODE_SCAN092"/>
+				<item name="Scan093" token="SCAN093" code="KEYCODE_SCAN093"/>
+				<item name="Scan094" token="SCAN094" code="KEYCODE_SCAN094"/>
+				<item name="Scan095" token="SCAN095" code="KEYCODE_SCAN095"/>
+				<item name="Scan096" token="SCAN096" code="KEYCODE_SCAN096"/>
+				<item name="Scan097" token="SCAN097" code="KEYCODE_SCAN097"/>
+				<item name="Scan098" token="SCAN098" code="KEYCODE_SCAN098"/>
+				<item name="Scan099" token="SCAN099" code="KEYCODE_SCAN099"/>
+				<item name="Scan103" token="SCAN103" code="KEYCODE_SCAN103"/>
+				<item name="Scan104" token="SCAN104" code="KEYCODE_SCAN104"/>
+				<item name="Scan105" token="SCAN105" code="KEYCODE_SCAN105"/>
+				<item name="Scan106" token="SCAN106" code="KEYCODE_SCAN106"/>
+				<item name="Scan107" token="SCAN107" code="KEYCODE_SCAN107"/>
+				<item name="Scan108" token="SCAN108" code="KEYCODE_SCAN108"/>
+				<item name="Scan109" token="SCAN109" code="KEYCODE_SCAN109"/>
+				<item name="Scan110" token="SCAN110" code="KEYCODE_SCAN110"/>
+				<item name="Scan111" token="SCAN111" code="KEYCODE_SCAN111"/>
+				<item name="Scan112" token="SCAN112" code="KEYCODE_SCAN112"/>
+				<item name="Scan113" token="SCAN113" code="KEYCODE_SCAN113"/>
+				<item name="Scan114" token="SCAN114" code="KEYCODE_SCAN114"/>
+				<item name="Scan115" token="SCAN115" code="KEYCODE_SCAN115"/>
+				<item name="Scan116" token="SCAN116" code="KEYCODE_SCAN116"/>
+				<item name="Scan117" token="SCAN117" code="KEYCODE_SCAN117"/>
+				<item name="Scan118" token="SCAN118" code="KEYCODE_SCAN118"/>
+				<item name="Scan119" token="SCAN119" code="KEYCODE_SCAN119"/>
+				<item name="Scan120" token="SCAN120" code="KEYCODE_SCAN120"/>
+				<item name="Scan121" token="SCAN121" code="KEYCODE_SCAN121"/>
+				<item name="Scan122" token="SCAN122" code="KEYCODE_SCAN122"/>
+				<item name="Scan123" token="SCAN123" code="KEYCODE_SCAN123"/>
+				<item name="F13" token="SCAN124" code="KEYCODE_SCAN124"/>
+				<item name="F14" token="SCAN125" code="KEYCODE_SCAN125"/>
+				<item name="F15" token="SCAN126" code="KEYCODE_SCAN126"/>
+				<item name="F16" token="SCAN127" code="KEYCODE_SCAN127"/>
+				<item name="Scan128" token="SCAN128" code="KEYCODE_SCAN128"/>
+				<item name="&#57371;" token="SCAN129" code="KEYCODE_SCAN129"/>
+				<item name="1" token="SCAN130" code="KEYCODE_SCAN130"/>
+				<item name="2" token="SCAN131" code="KEYCODE_SCAN131"/>
+				<item name="3" token="SCAN132" code="KEYCODE_SCAN132"/>
+				<item name="4" token="SCAN133" code="KEYCODE_SCAN133"/>
+				<item name="5" token="SCAN134" code="KEYCODE_SCAN134"/>
+				<item name="6" token="SCAN135" code="KEYCODE_SCAN135"/>
+				<item name="7" token="SCAN136" code="KEYCODE_SCAN136"/>
+				<item name="8" token="SCAN137" code="KEYCODE_SCAN137"/>
+				<item name="9" token="SCAN138" code="KEYCODE_SCAN138"/>
+				<item name="0" token="SCAN139" code="KEYCODE_SCAN139"/>
+				<item name="-" token="SCAN140" code="KEYCODE_SCAN140"/>
+				<item name="&#57352;" token="SCAN142" code="KEYCODE_SCAN142"/>
+				<item name="&#9;" token="SCAN143" code="KEYCODE_SCAN143"/>
+				<item name="Q" token="SCAN144" code="KEYCODE_SCAN144"/>
+				<item name="W" token="SCAN145" code="KEYCODE_SCAN145"/>
+				<item name="E" token="SCAN146" code="KEYCODE_SCAN146"/>
+				<item name="R" token="SCAN147" code="KEYCODE_SCAN147"/>
+				<item name="T" token="SCAN148" code="KEYCODE_SCAN148"/>
+				<item name="Y" token="SCAN149" code="KEYCODE_SCAN149"/>
+				<item name="U" token="SCAN150" code="KEYCODE_SCAN150"/>
+				<item name="I" token="SCAN151" code="KEYCODE_SCAN151"/>
+				<item name="O" token="SCAN152" code="KEYCODE_SCAN152"/>
+				<item name="P" token="SCAN153" code="KEYCODE_SCAN153"/>
+				<item name="[" token="SCAN154" code="KEYCODE_SCAN154"/>
+				<item name="]" token="SCAN155" code="KEYCODE_SCAN155"/>
+				<item name="A" token="SCAN158" code="KEYCODE_SCAN158"/>
+				<item name="S" token="SCAN159" code="KEYCODE_SCAN159"/>
+				<item name="D" token="SCAN160" code="KEYCODE_SCAN160"/>
+				<item name="F" token="SCAN161" code="KEYCODE_SCAN161"/>
+				<item name="G" token="SCAN162" code="KEYCODE_SCAN162"/>
+				<item name="H" token="SCAN163" code="KEYCODE_SCAN163"/>
+				<item name="J" token="SCAN164" code="KEYCODE_SCAN164"/>
+				<item name="K" token="SCAN165" code="KEYCODE_SCAN165"/>
+				<item name="L" token="SCAN166" code="KEYCODE_SCAN166"/>
+				<item name=";" token="SCAN167" code="KEYCODE_SCAN167"/>
+				<item name="'" token="SCAN168" code="KEYCODE_SCAN168"/>
+				<item name="`" token="SCAN169" code="KEYCODE_SCAN169"/>
+				<item name="Scan170" token="SCAN170" code="KEYCODE_SCAN170"/>
+				<item name="\" token="SCAN171" code="KEYCODE_SCAN171"/>
+				<item name="Z" token="SCAN172" code="KEYCODE_SCAN172"/>
+				<item name="X" token="SCAN173" code="KEYCODE_SCAN173"/>
+				<item name="C" token="SCAN174" code="KEYCODE_SCAN174"/>
+				<item name="V" token="SCAN175" code="KEYCODE_SCAN175"/>
+				<item name="B" token="SCAN176" code="KEYCODE_SCAN176"/>
+				<item name="N" token="SCAN177" code="KEYCODE_SCAN177"/>
+				<item name="M" token="SCAN178" code="KEYCODE_SCAN178"/>
+				<item name="." token="SCAN180" code="KEYCODE_SCAN180"/>
+				<item name="Scan182" token="SCAN182" code="KEYCODE_SCAN182"/>
+				<item name=" " token="SCAN185" code="KEYCODE_SCAN185"/>
+				<item name="Scan186" token="SCAN186" code="KEYCODE_SCAN186"/>
+				<item name="Scan187" token="SCAN187" code="KEYCODE_SCAN187"/>
+				<item name="Scan188" token="SCAN188" code="KEYCODE_SCAN188"/>
+				<item name="Scan189" token="SCAN189" code="KEYCODE_SCAN189"/>
+				<item name="Scan190" token="SCAN190" code="KEYCODE_SCAN190"/>
+				<item name="Scan191" token="SCAN191" code="KEYCODE_SCAN191"/>
+				<item name="Scan192" token="SCAN192" code="KEYCODE_SCAN192"/>
+				<item name="Scan193" token="SCAN193" code="KEYCODE_SCAN193"/>
+				<item name="Scan194" token="SCAN194" code="KEYCODE_SCAN194"/>
+				<item name="Scan195" token="SCAN195" code="KEYCODE_SCAN195"/>
+				<item name="Scan196" token="SCAN196" code="KEYCODE_SCAN196"/>
+				<item name="Break" token="SCAN198" code="KEYCODE_SCAN198"/>
+				<item name="-" token="SCAN202" code="KEYCODE_SCAN202"/>
+				<item name="Scan204" token="SCAN204" code="KEYCODE_SCAN204"/>
+				<item name="+" token="SCAN206" code="KEYCODE_SCAN206"/>
+				<item name="&lt;00&gt;" token="SCAN212" code="KEYCODE_SCAN212"/>
+				<item name="Scan213" token="SCAN213" code="KEYCODE_SCAN213"/>
+				<item name="Help" token="SCAN214" code="KEYCODE_SCAN214"/>
+				<item name="Scan215" token="SCAN215" code="KEYCODE_SCAN215"/>
+				<item name="Scan216" token="SCAN216" code="KEYCODE_SCAN216"/>
+				<item name="Scan217" token="SCAN217" code="KEYCODE_SCAN217"/>
+				<item name="Scan218" token="SCAN218" code="KEYCODE_SCAN218"/>
+				<item name="Scan222" token="SCAN222" code="KEYCODE_SCAN222"/>
+				<item name="Scan223" token="SCAN223" code="KEYCODE_SCAN223"/>
+				<item name="Scan224" token="SCAN224" code="KEYCODE_SCAN224"/>
+				<item name="Scan225" token="SCAN225" code="KEYCODE_SCAN225"/>
+				<item name="Scan226" token="SCAN226" code="KEYCODE_SCAN226"/>
+				<item name="Scan227" token="SCAN227" code="KEYCODE_SCAN227"/>
+				<item name="Scan228" token="SCAN228" code="KEYCODE_SCAN228"/>
+				<item name="Scan229" token="SCAN229" code="KEYCODE_SCAN229"/>
+				<item name="Scan230" token="SCAN230" code="KEYCODE_SCAN230"/>
+				<item name="Scan231" token="SCAN231" code="KEYCODE_SCAN231"/>
+				<item name="Scan232" token="SCAN232" code="KEYCODE_SCAN232"/>
+				<item name="Scan233" token="SCAN233" code="KEYCODE_SCAN233"/>
+				<item name="Scan234" token="SCAN234" code="KEYCODE_SCAN234"/>
+				<item name="Scan235" token="SCAN235" code="KEYCODE_SCAN235"/>
+				<item name="Scan236" token="SCAN236" code="KEYCODE_SCAN236"/>
+				<item name="Scan237" token="SCAN237" code="KEYCODE_SCAN237"/>
+				<item name="Scan238" token="SCAN238" code="KEYCODE_SCAN238"/>
+				<item name="Scan239" token="SCAN239" code="KEYCODE_SCAN239"/>
+				<item name="Scan240" token="SCAN240" code="KEYCODE_SCAN240"/>
+				<item name="Scan241" token="SCAN241" code="KEYCODE_SCAN241"/>
+				<item name="Scan242" token="SCAN242" code="KEYCODE_SCAN242"/>
+				<item name="Scan243" token="SCAN243" code="KEYCODE_SCAN243"/>
+				<item name="Scan244" token="SCAN244" code="KEYCODE_SCAN244"/>
+				<item name="Scan245" token="SCAN245" code="KEYCODE_SCAN245"/>
+				<item name="Scan246" token="SCAN246" code="KEYCODE_SCAN246"/>
+				<item name="Scan247" token="SCAN247" code="KEYCODE_SCAN247"/>
+				<item name="Scan248" token="SCAN248" code="KEYCODE_SCAN248"/>
+				<item name="Scan249" token="SCAN249" code="KEYCODE_SCAN249"/>
+				<item name="Scan250" token="SCAN250" code="KEYCODE_SCAN250"/>
+				<item name="Scan251" token="SCAN251" code="KEYCODE_SCAN251"/>
+				<item name="&#9;" token="SCAN252" code="KEYCODE_SCAN252"/>
+				<item name="Scan253" token="SCAN253" code="KEYCODE_SCAN253"/>
+				<item name="Scan254" token="SCAN254" code="KEYCODE_SCAN254"/>
+				<item name="Scan255" token="SCAN255" code="KEYCODE_SCAN255"/>
+			</device>
+			<device name="HID Keyboard Device" id="\\?\HID#INTC816&amp;Col01#3&amp;27ef53f1&amp;0&amp;0000#{884b96c3-56ef-11d1-bc8c-00a0c91405dd}" devindex="1">
+				<item name="A" token="A" code="KEYCODE_2_A"/>
+				<item name="B" token="B" code="KEYCODE_2_B"/>
+				<item name="C" token="C" code="KEYCODE_2_C"/>
+				<item name="D" token="D" code="KEYCODE_2_D"/>
+				<item name="E" token="E" code="KEYCODE_2_E"/>
+				<item name="F" token="F" code="KEYCODE_2_F"/>
+				<item name="G" token="G" code="KEYCODE_2_G"/>
+				<item name="H" token="H" code="KEYCODE_2_H"/>
+				<item name="I" token="I" code="KEYCODE_2_I"/>
+				<item name="J" token="J" code="KEYCODE_2_J"/>
+				<item name="K" token="K" code="KEYCODE_2_K"/>
+				<item name="L" token="L" code="KEYCODE_2_L"/>
+				<item name="M" token="M" code="KEYCODE_2_M"/>
+				<item name="N" token="N" code="KEYCODE_2_N"/>
+				<item name="O" token="O" code="KEYCODE_2_O"/>
+				<item name="P" token="P" code="KEYCODE_2_P"/>
+				<item name="Q" token="Q" code="KEYCODE_2_Q"/>
+				<item name="R" token="R" code="KEYCODE_2_R"/>
+				<item name="S" token="S" code="KEYCODE_2_S"/>
+				<item name="T" token="T" code="KEYCODE_2_T"/>
+				<item name="U" token="U" code="KEYCODE_2_U"/>
+				<item name="V" token="V" code="KEYCODE_2_V"/>
+				<item name="W" token="W" code="KEYCODE_2_W"/>
+				<item name="X" token="X" code="KEYCODE_2_X"/>
+				<item name="Y" token="Y" code="KEYCODE_2_Y"/>
+				<item name="Z" token="Z" code="KEYCODE_2_Z"/>
+				<item name="0" token="0" code="KEYCODE_2_0"/>
+				<item name="1" token="1" code="KEYCODE_2_1"/>
+				<item name="2" token="2" code="KEYCODE_2_2"/>
+				<item name="3" token="3" code="KEYCODE_2_3"/>
+				<item name="4" token="4" code="KEYCODE_2_4"/>
+				<item name="5" token="5" code="KEYCODE_2_5"/>
+				<item name="6" token="6" code="KEYCODE_2_6"/>
+				<item name="7" token="7" code="KEYCODE_2_7"/>
+				<item name="8" token="8" code="KEYCODE_2_8"/>
+				<item name="9" token="9" code="KEYCODE_2_9"/>
+				<item name="F1" token="F1" code="KEYCODE_2_F1"/>
+				<item name="F2" token="F2" code="KEYCODE_2_F2"/>
+				<item name="F3" token="F3" code="KEYCODE_2_F3"/>
+				<item name="F4" token="F4" code="KEYCODE_2_F4"/>
+				<item name="F5" token="F5" code="KEYCODE_2_F5"/>
+				<item name="F6" token="F6" code="KEYCODE_2_F6"/>
+				<item name="F7" token="F7" code="KEYCODE_2_F7"/>
+				<item name="F8" token="F8" code="KEYCODE_2_F8"/>
+				<item name="F9" token="F9" code="KEYCODE_2_F9"/>
+				<item name="F10" token="F10" code="KEYCODE_2_F10"/>
+				<item name="F11" token="F11" code="KEYCODE_2_F11"/>
+				<item name="F12" token="F12" code="KEYCODE_2_F12"/>
+				<item name="Scan100" token="F13" code="KEYCODE_2_F13"/>
+				<item name="Scan101" token="F14" code="KEYCODE_2_F14"/>
+				<item name="Scan102" token="F15" code="KEYCODE_2_F15"/>
+				<item name="Esc" token="ESC" code="KEYCODE_2_ESC"/>
+				<item name="`" token="TILDE" code="KEYCODE_2_TILDE"/>
+				<item name="-" token="MINUS" code="KEYCODE_2_MINUS"/>
+				<item name="=" token="EQUALS" code="KEYCODE_2_EQUALS"/>
+				<item name="Backspace" token="BACKSPACE" code="KEYCODE_2_BACKSPACE"/>
+				<item name="Tab" token="TAB" code="KEYCODE_2_TAB"/>
+				<item name="[" token="OPENBRACE" code="KEYCODE_2_OPENBRACE"/>
+				<item name="]" token="CLOSEBRACE" code="KEYCODE_2_CLOSEBRACE"/>
+				<item name="Enter" token="ENTER" code="KEYCODE_2_ENTER"/>
+				<item name=";" token="COLON" code="KEYCODE_2_COLON"/>
+				<item name="'" token="QUOTE" code="KEYCODE_2_QUOTE"/>
+				<item name="\" token="BACKSLASH" code="KEYCODE_2_BACKSLASH"/>
+				<item name="\" token="BACKSLASH2" code="KEYCODE_2_BACKSLASH2"/>
+				<item name="," token="COMMA" code="KEYCODE_2_COMMA"/>
+				<item name="." token="STOP" code="KEYCODE_2_STOP"/>
+				<item name="/" token="SLASH" code="KEYCODE_2_SLASH"/>
+				<item name="Space" token="SPACE" code="KEYCODE_2_SPACE"/>
+				<item name="Insert" token="INSERT" code="KEYCODE_2_INSERT"/>
+				<item name="Delete" token="DEL" code="KEYCODE_2_DEL"/>
+				<item name="Home" token="HOME" code="KEYCODE_2_HOME"/>
+				<item name="End" token="END" code="KEYCODE_2_END"/>
+				<item name="Page Up" token="PGUP" code="KEYCODE_2_PGUP"/>
+				<item name="Page Down" token="PGDN" code="KEYCODE_2_PGDN"/>
+				<item name="Left" token="LEFT" code="KEYCODE_2_LEFT"/>
+				<item name="Right" token="RIGHT" code="KEYCODE_2_RIGHT"/>
+				<item name="Up" token="UP" code="KEYCODE_2_UP"/>
+				<item name="Down" token="DOWN" code="KEYCODE_2_DOWN"/>
+				<item name="Num 0" token="0PAD" code="KEYCODE_2_0PAD"/>
+				<item name="Num 1" token="1PAD" code="KEYCODE_2_1PAD"/>
+				<item name="Num 2" token="2PAD" code="KEYCODE_2_2PAD"/>
+				<item name="Num 3" token="3PAD" code="KEYCODE_2_3PAD"/>
+				<item name="Num 4" token="4PAD" code="KEYCODE_2_4PAD"/>
+				<item name="Num 5" token="5PAD" code="KEYCODE_2_5PAD"/>
+				<item name="Num 6" token="6PAD" code="KEYCODE_2_6PAD"/>
+				<item name="Num 7" token="7PAD" code="KEYCODE_2_7PAD"/>
+				<item name="Num 8" token="8PAD" code="KEYCODE_2_8PAD"/>
+				<item name="Num 9" token="9PAD" code="KEYCODE_2_9PAD"/>
+				<item name="Num /" token="SLASHPAD" code="KEYCODE_2_SLASHPAD"/>
+				<item name="Num *" token="ASTERISK" code="KEYCODE_2_ASTERISK"/>
+				<item name="Num -" token="MINUSPAD" code="KEYCODE_2_MINUSPAD"/>
+				<item name="Num +" token="PLUSPAD" code="KEYCODE_2_PLUSPAD"/>
+				<item name="Num Del" token="DELPAD" code="KEYCODE_2_DELPAD"/>
+				<item name="Num Enter" token="ENTERPAD" code="KEYCODE_2_ENTERPAD"/>
+				<item name="," token="SCAN179" code="KEYCODE_2_SCAN179"/>
+				<item name="=" token="SCAN141" code="KEYCODE_2_SCAN141"/>
+				<item name="Prnt Scrn" token="PRTSCR" code="KEYCODE_2_PRTSCR"/>
+				<item name="Pause" token="PAUSE" code="KEYCODE_2_PAUSE"/>
+				<item name="Shift" token="LSHIFT" code="KEYCODE_2_LSHIFT"/>
+				<item name="Right Shift" token="RSHIFT" code="KEYCODE_2_RSHIFT"/>
+				<item name="Ctrl" token="LCONTROL" code="KEYCODE_2_LCONTROL"/>
+				<item name="Right Ctrl" token="RCONTROL" code="KEYCODE_2_RCONTROL"/>
+				<item name="Alt" token="LALT" code="KEYCODE_2_LALT"/>
+				<item name="Right Alt" token="RALT" code="KEYCODE_2_RALT"/>
+				<item name="Scroll Lock" token="SCRLOCK" code="KEYCODE_2_SCRLOCK"/>
+				<item name="Num Lock" token="NUMLOCK" code="KEYCODE_2_NUMLOCK"/>
+				<item name="Caps Lock" token="CAPSLOCK" code="KEYCODE_2_CAPSLOCK"/>
+				<item name="Left Windows" token="LWIN" code="KEYCODE_2_LWIN"/>
+				<item name="Right Windows" token="RWIN" code="KEYCODE_2_RWIN"/>
+				<item name="Application" token="MENU" code="KEYCODE_2_MENU"/>
+				<item name="Scan000" token="SCAN000" code="KEYCODE_2_SCAN000"/>
+				<item name="Sys Req" token="SCAN084" code="KEYCODE_2_SCAN084"/>
+				<item name="Scan085" token="SCAN085" code="KEYCODE_2_SCAN085"/>
+				<item name="Scan089" token="SCAN089" code="KEYCODE_2_SCAN089"/>
+				<item name="Scan090" token="SCAN090" code="KEYCODE_2_SCAN090"/>
+				<item name="Scan091" token="SCAN091" code="KEYCODE_2_SCAN091"/>
+				<item name="Scan092" token="SCAN092" code="KEYCODE_2_SCAN092"/>
+				<item name="Scan093" token="SCAN093" code="KEYCODE_2_SCAN093"/>
+				<item name="Scan094" token="SCAN094" code="KEYCODE_2_SCAN094"/>
+				<item name="Scan095" token="SCAN095" code="KEYCODE_2_SCAN095"/>
+				<item name="Scan096" token="SCAN096" code="KEYCODE_2_SCAN096"/>
+				<item name="Scan097" token="SCAN097" code="KEYCODE_2_SCAN097"/>
+				<item name="Scan098" token="SCAN098" code="KEYCODE_2_SCAN098"/>
+				<item name="Scan099" token="SCAN099" code="KEYCODE_2_SCAN099"/>
+				<item name="Scan103" token="SCAN103" code="KEYCODE_2_SCAN103"/>
+				<item name="Scan104" token="SCAN104" code="KEYCODE_2_SCAN104"/>
+				<item name="Scan105" token="SCAN105" code="KEYCODE_2_SCAN105"/>
+				<item name="Scan106" token="SCAN106" code="KEYCODE_2_SCAN106"/>
+				<item name="Scan107" token="SCAN107" code="KEYCODE_2_SCAN107"/>
+				<item name="Scan108" token="SCAN108" code="KEYCODE_2_SCAN108"/>
+				<item name="Scan109" token="SCAN109" code="KEYCODE_2_SCAN109"/>
+				<item name="Scan110" token="SCAN110" code="KEYCODE_2_SCAN110"/>
+				<item name="Scan111" token="SCAN111" code="KEYCODE_2_SCAN111"/>
+				<item name="Scan112" token="SCAN112" code="KEYCODE_2_SCAN112"/>
+				<item name="Scan113" token="SCAN113" code="KEYCODE_2_SCAN113"/>
+				<item name="Scan114" token="SCAN114" code="KEYCODE_2_SCAN114"/>
+				<item name="Scan115" token="SCAN115" code="KEYCODE_2_SCAN115"/>
+				<item name="Scan116" token="SCAN116" code="KEYCODE_2_SCAN116"/>
+				<item name="Scan117" token="SCAN117" code="KEYCODE_2_SCAN117"/>
+				<item name="Scan118" token="SCAN118" code="KEYCODE_2_SCAN118"/>
+				<item name="Scan119" token="SCAN119" code="KEYCODE_2_SCAN119"/>
+				<item name="Scan120" token="SCAN120" code="KEYCODE_2_SCAN120"/>
+				<item name="Scan121" token="SCAN121" code="KEYCODE_2_SCAN121"/>
+				<item name="Scan122" token="SCAN122" code="KEYCODE_2_SCAN122"/>
+				<item name="Scan123" token="SCAN123" code="KEYCODE_2_SCAN123"/>
+				<item name="F13" token="SCAN124" code="KEYCODE_2_SCAN124"/>
+				<item name="F14" token="SCAN125" code="KEYCODE_2_SCAN125"/>
+				<item name="F15" token="SCAN126" code="KEYCODE_2_SCAN126"/>
+				<item name="F16" token="SCAN127" code="KEYCODE_2_SCAN127"/>
+				<item name="Scan128" token="SCAN128" code="KEYCODE_2_SCAN128"/>
+				<item name="&#57371;" token="SCAN129" code="KEYCODE_2_SCAN129"/>
+				<item name="1" token="SCAN130" code="KEYCODE_2_SCAN130"/>
+				<item name="2" token="SCAN131" code="KEYCODE_2_SCAN131"/>
+				<item name="3" token="SCAN132" code="KEYCODE_2_SCAN132"/>
+				<item name="4" token="SCAN133" code="KEYCODE_2_SCAN133"/>
+				<item name="5" token="SCAN134" code="KEYCODE_2_SCAN134"/>
+				<item name="6" token="SCAN135" code="KEYCODE_2_SCAN135"/>
+				<item name="7" token="SCAN136" code="KEYCODE_2_SCAN136"/>
+				<item name="8" token="SCAN137" code="KEYCODE_2_SCAN137"/>
+				<item name="9" token="SCAN138" code="KEYCODE_2_SCAN138"/>
+				<item name="0" token="SCAN139" code="KEYCODE_2_SCAN139"/>
+				<item name="-" token="SCAN140" code="KEYCODE_2_SCAN140"/>
+				<item name="&#57352;" token="SCAN142" code="KEYCODE_2_SCAN142"/>
+				<item name="&#9;" token="SCAN143" code="KEYCODE_2_SCAN143"/>
+				<item name="Q" token="SCAN144" code="KEYCODE_2_SCAN144"/>
+				<item name="W" token="SCAN145" code="KEYCODE_2_SCAN145"/>
+				<item name="E" token="SCAN146" code="KEYCODE_2_SCAN146"/>
+				<item name="R" token="SCAN147" code="KEYCODE_2_SCAN147"/>
+				<item name="T" token="SCAN148" code="KEYCODE_2_SCAN148"/>
+				<item name="Y" token="SCAN149" code="KEYCODE_2_SCAN149"/>
+				<item name="U" token="SCAN150" code="KEYCODE_2_SCAN150"/>
+				<item name="I" token="SCAN151" code="KEYCODE_2_SCAN151"/>
+				<item name="O" token="SCAN152" code="KEYCODE_2_SCAN152"/>
+				<item name="P" token="SCAN153" code="KEYCODE_2_SCAN153"/>
+				<item name="[" token="SCAN154" code="KEYCODE_2_SCAN154"/>
+				<item name="]" token="SCAN155" code="KEYCODE_2_SCAN155"/>
+				<item name="A" token="SCAN158" code="KEYCODE_2_SCAN158"/>
+				<item name="S" token="SCAN159" code="KEYCODE_2_SCAN159"/>
+				<item name="D" token="SCAN160" code="KEYCODE_2_SCAN160"/>
+				<item name="F" token="SCAN161" code="KEYCODE_2_SCAN161"/>
+				<item name="G" token="SCAN162" code="KEYCODE_2_SCAN162"/>
+				<item name="H" token="SCAN163" code="KEYCODE_2_SCAN163"/>
+				<item name="J" token="SCAN164" code="KEYCODE_2_SCAN164"/>
+				<item name="K" token="SCAN165" code="KEYCODE_2_SCAN165"/>
+				<item name="L" token="SCAN166" code="KEYCODE_2_SCAN166"/>
+				<item name=";" token="SCAN167" code="KEYCODE_2_SCAN167"/>
+				<item name="'" token="SCAN168" code="KEYCODE_2_SCAN168"/>
+				<item name="`" token="SCAN169" code="KEYCODE_2_SCAN169"/>
+				<item name="Scan170" token="SCAN170" code="KEYCODE_2_SCAN170"/>
+				<item name="\" token="SCAN171" code="KEYCODE_2_SCAN171"/>
+				<item name="Z" token="SCAN172" code="KEYCODE_2_SCAN172"/>
+				<item name="X" token="SCAN173" code="KEYCODE_2_SCAN173"/>
+				<item name="C" token="SCAN174" code="KEYCODE_2_SCAN174"/>
+				<item name="V" token="SCAN175" code="KEYCODE_2_SCAN175"/>
+				<item name="B" token="SCAN176" code="KEYCODE_2_SCAN176"/>
+				<item name="N" token="SCAN177" code="KEYCODE_2_SCAN177"/>
+				<item name="M" token="SCAN178" code="KEYCODE_2_SCAN178"/>
+				<item name="." token="SCAN180" code="KEYCODE_2_SCAN180"/>
+				<item name="Scan182" token="SCAN182" code="KEYCODE_2_SCAN182"/>
+				<item name=" " token="SCAN185" code="KEYCODE_2_SCAN185"/>
+				<item name="Scan186" token="SCAN186" code="KEYCODE_2_SCAN186"/>
+				<item name="Scan187" token="SCAN187" code="KEYCODE_2_SCAN187"/>
+				<item name="Scan188" token="SCAN188" code="KEYCODE_2_SCAN188"/>
+				<item name="Scan189" token="SCAN189" code="KEYCODE_2_SCAN189"/>
+				<item name="Scan190" token="SCAN190" code="KEYCODE_2_SCAN190"/>
+				<item name="Scan191" token="SCAN191" code="KEYCODE_2_SCAN191"/>
+				<item name="Scan192" token="SCAN192" code="KEYCODE_2_SCAN192"/>
+				<item name="Scan193" token="SCAN193" code="KEYCODE_2_SCAN193"/>
+				<item name="Scan194" token="SCAN194" code="KEYCODE_2_SCAN194"/>
+				<item name="Scan195" token="SCAN195" code="KEYCODE_2_SCAN195"/>
+				<item name="Scan196" token="SCAN196" code="KEYCODE_2_SCAN196"/>
+				<item name="Break" token="SCAN198" code="KEYCODE_2_SCAN198"/>
+				<item name="-" token="SCAN202" code="KEYCODE_2_SCAN202"/>
+				<item name="Scan204" token="SCAN204" code="KEYCODE_2_SCAN204"/>
+				<item name="+" token="SCAN206" code="KEYCODE_2_SCAN206"/>
+				<item name="&lt;00&gt;" token="SCAN212" code="KEYCODE_2_SCAN212"/>
+				<item name="Scan213" token="SCAN213" code="KEYCODE_2_SCAN213"/>
+				<item name="Help" token="SCAN214" code="KEYCODE_2_SCAN214"/>
+				<item name="Scan215" token="SCAN215" code="KEYCODE_2_SCAN215"/>
+				<item name="Scan216" token="SCAN216" code="KEYCODE_2_SCAN216"/>
+				<item name="Scan217" token="SCAN217" code="KEYCODE_2_SCAN217"/>
+				<item name="Scan218" token="SCAN218" code="KEYCODE_2_SCAN218"/>
+				<item name="Scan222" token="SCAN222" code="KEYCODE_2_SCAN222"/>
+				<item name="Scan223" token="SCAN223" code="KEYCODE_2_SCAN223"/>
+				<item name="Scan224" token="SCAN224" code="KEYCODE_2_SCAN224"/>
+				<item name="Scan225" token="SCAN225" code="KEYCODE_2_SCAN225"/>
+				<item name="Scan226" token="SCAN226" code="KEYCODE_2_SCAN226"/>
+				<item name="Scan227" token="SCAN227" code="KEYCODE_2_SCAN227"/>
+				<item name="Scan228" token="SCAN228" code="KEYCODE_2_SCAN228"/>
+				<item name="Scan229" token="SCAN229" code="KEYCODE_2_SCAN229"/>
+				<item name="Scan230" token="SCAN230" code="KEYCODE_2_SCAN230"/>
+				<item name="Scan231" token="SCAN231" code="KEYCODE_2_SCAN231"/>
+				<item name="Scan232" token="SCAN232" code="KEYCODE_2_SCAN232"/>
+				<item name="Scan233" token="SCAN233" code="KEYCODE_2_SCAN233"/>
+				<item name="Scan234" token="SCAN234" code="KEYCODE_2_SCAN234"/>
+				<item name="Scan235" token="SCAN235" code="KEYCODE_2_SCAN235"/>
+				<item name="Scan236" token="SCAN236" code="KEYCODE_2_SCAN236"/>
+				<item name="Scan237" token="SCAN237" code="KEYCODE_2_SCAN237"/>
+				<item name="Scan238" token="SCAN238" code="KEYCODE_2_SCAN238"/>
+				<item name="Scan239" token="SCAN239" code="KEYCODE_2_SCAN239"/>
+				<item name="Scan240" token="SCAN240" code="KEYCODE_2_SCAN240"/>
+				<item name="Scan241" token="SCAN241" code="KEYCODE_2_SCAN241"/>
+				<item name="Scan242" token="SCAN242" code="KEYCODE_2_SCAN242"/>
+				<item name="Scan243" token="SCAN243" code="KEYCODE_2_SCAN243"/>
+				<item name="Scan244" token="SCAN244" code="KEYCODE_2_SCAN244"/>
+				<item name="Scan245" token="SCAN245" code="KEYCODE_2_SCAN245"/>
+				<item name="Scan246" token="SCAN246" code="KEYCODE_2_SCAN246"/>
+				<item name="Scan247" token="SCAN247" code="KEYCODE_2_SCAN247"/>
+				<item name="Scan248" token="SCAN248" code="KEYCODE_2_SCAN248"/>
+				<item name="Scan249" token="SCAN249" code="KEYCODE_2_SCAN249"/>
+				<item name="Scan250" token="SCAN250" code="KEYCODE_2_SCAN250"/>
+				<item name="Scan251" token="SCAN251" code="KEYCODE_2_SCAN251"/>
+				<item name="&#9;" token="SCAN252" code="KEYCODE_2_SCAN252"/>
+				<item name="Scan253" token="SCAN253" code="KEYCODE_2_SCAN253"/>
+				<item name="Scan254" token="SCAN254" code="KEYCODE_2_SCAN254"/>
+				<item name="Scan255" token="SCAN255" code="KEYCODE_2_SCAN255"/>
+			</device>
+			<device name="HID Keyboard Device" id="\\?\HID#VID_03F0&amp;PID_544A&amp;MI_01&amp;Col04#9&amp;11b0ef6b&amp;0&amp;0003#{884b96c3-56ef-11d1-bc8c-00a0c91405dd}" devindex="2">
+				<item name="A" token="A" code="KEYCODE_3_A"/>
+				<item name="B" token="B" code="KEYCODE_3_B"/>
+				<item name="C" token="C" code="KEYCODE_3_C"/>
+				<item name="D" token="D" code="KEYCODE_3_D"/>
+				<item name="E" token="E" code="KEYCODE_3_E"/>
+				<item name="F" token="F" code="KEYCODE_3_F"/>
+				<item name="G" token="G" code="KEYCODE_3_G"/>
+				<item name="H" token="H" code="KEYCODE_3_H"/>
+				<item name="I" token="I" code="KEYCODE_3_I"/>
+				<item name="J" token="J" code="KEYCODE_3_J"/>
+				<item name="K" token="K" code="KEYCODE_3_K"/>
+				<item name="L" token="L" code="KEYCODE_3_L"/>
+				<item name="M" token="M" code="KEYCODE_3_M"/>
+				<item name="N" token="N" code="KEYCODE_3_N"/>
+				<item name="O" token="O" code="KEYCODE_3_O"/>
+				<item name="P" token="P" code="KEYCODE_3_P"/>
+				<item name="Q" token="Q" code="KEYCODE_3_Q"/>
+				<item name="R" token="R" code="KEYCODE_3_R"/>
+				<item name="S" token="S" code="KEYCODE_3_S"/>
+				<item name="T" token="T" code="KEYCODE_3_T"/>
+				<item name="U" token="U" code="KEYCODE_3_U"/>
+				<item name="V" token="V" code="KEYCODE_3_V"/>
+				<item name="W" token="W" code="KEYCODE_3_W"/>
+				<item name="X" token="X" code="KEYCODE_3_X"/>
+				<item name="Y" token="Y" code="KEYCODE_3_Y"/>
+				<item name="Z" token="Z" code="KEYCODE_3_Z"/>
+				<item name="0" token="0" code="KEYCODE_3_0"/>
+				<item name="1" token="1" code="KEYCODE_3_1"/>
+				<item name="2" token="2" code="KEYCODE_3_2"/>
+				<item name="3" token="3" code="KEYCODE_3_3"/>
+				<item name="4" token="4" code="KEYCODE_3_4"/>
+				<item name="5" token="5" code="KEYCODE_3_5"/>
+				<item name="6" token="6" code="KEYCODE_3_6"/>
+				<item name="7" token="7" code="KEYCODE_3_7"/>
+				<item name="8" token="8" code="KEYCODE_3_8"/>
+				<item name="9" token="9" code="KEYCODE_3_9"/>
+				<item name="F1" token="F1" code="KEYCODE_3_F1"/>
+				<item name="F2" token="F2" code="KEYCODE_3_F2"/>
+				<item name="F3" token="F3" code="KEYCODE_3_F3"/>
+				<item name="F4" token="F4" code="KEYCODE_3_F4"/>
+				<item name="F5" token="F5" code="KEYCODE_3_F5"/>
+				<item name="F6" token="F6" code="KEYCODE_3_F6"/>
+				<item name="F7" token="F7" code="KEYCODE_3_F7"/>
+				<item name="F8" token="F8" code="KEYCODE_3_F8"/>
+				<item name="F9" token="F9" code="KEYCODE_3_F9"/>
+				<item name="F10" token="F10" code="KEYCODE_3_F10"/>
+				<item name="F11" token="F11" code="KEYCODE_3_F11"/>
+				<item name="F12" token="F12" code="KEYCODE_3_F12"/>
+				<item name="Scan100" token="F13" code="KEYCODE_3_F13"/>
+				<item name="Scan101" token="F14" code="KEYCODE_3_F14"/>
+				<item name="Scan102" token="F15" code="KEYCODE_3_F15"/>
+				<item name="Esc" token="ESC" code="KEYCODE_3_ESC"/>
+				<item name="`" token="TILDE" code="KEYCODE_3_TILDE"/>
+				<item name="-" token="MINUS" code="KEYCODE_3_MINUS"/>
+				<item name="=" token="EQUALS" code="KEYCODE_3_EQUALS"/>
+				<item name="Backspace" token="BACKSPACE" code="KEYCODE_3_BACKSPACE"/>
+				<item name="Tab" token="TAB" code="KEYCODE_3_TAB"/>
+				<item name="[" token="OPENBRACE" code="KEYCODE_3_OPENBRACE"/>
+				<item name="]" token="CLOSEBRACE" code="KEYCODE_3_CLOSEBRACE"/>
+				<item name="Enter" token="ENTER" code="KEYCODE_3_ENTER"/>
+				<item name=";" token="COLON" code="KEYCODE_3_COLON"/>
+				<item name="'" token="QUOTE" code="KEYCODE_3_QUOTE"/>
+				<item name="\" token="BACKSLASH" code="KEYCODE_3_BACKSLASH"/>
+				<item name="\" token="BACKSLASH2" code="KEYCODE_3_BACKSLASH2"/>
+				<item name="," token="COMMA" code="KEYCODE_3_COMMA"/>
+				<item name="." token="STOP" code="KEYCODE_3_STOP"/>
+				<item name="/" token="SLASH" code="KEYCODE_3_SLASH"/>
+				<item name="Space" token="SPACE" code="KEYCODE_3_SPACE"/>
+				<item name="Insert" token="INSERT" code="KEYCODE_3_INSERT"/>
+				<item name="Delete" token="DEL" code="KEYCODE_3_DEL"/>
+				<item name="Home" token="HOME" code="KEYCODE_3_HOME"/>
+				<item name="End" token="END" code="KEYCODE_3_END"/>
+				<item name="Page Up" token="PGUP" code="KEYCODE_3_PGUP"/>
+				<item name="Page Down" token="PGDN" code="KEYCODE_3_PGDN"/>
+				<item name="Left" token="LEFT" code="KEYCODE_3_LEFT"/>
+				<item name="Right" token="RIGHT" code="KEYCODE_3_RIGHT"/>
+				<item name="Up" token="UP" code="KEYCODE_3_UP"/>
+				<item name="Down" token="DOWN" code="KEYCODE_3_DOWN"/>
+				<item name="Num 0" token="0PAD" code="KEYCODE_3_0PAD"/>
+				<item name="Num 1" token="1PAD" code="KEYCODE_3_1PAD"/>
+				<item name="Num 2" token="2PAD" code="KEYCODE_3_2PAD"/>
+				<item name="Num 3" token="3PAD" code="KEYCODE_3_3PAD"/>
+				<item name="Num 4" token="4PAD" code="KEYCODE_3_4PAD"/>
+				<item name="Num 5" token="5PAD" code="KEYCODE_3_5PAD"/>
+				<item name="Num 6" token="6PAD" code="KEYCODE_3_6PAD"/>
+				<item name="Num 7" token="7PAD" code="KEYCODE_3_7PAD"/>
+				<item name="Num 8" token="8PAD" code="KEYCODE_3_8PAD"/>
+				<item name="Num 9" token="9PAD" code="KEYCODE_3_9PAD"/>
+				<item name="Num /" token="SLASHPAD" code="KEYCODE_3_SLASHPAD"/>
+				<item name="Num *" token="ASTERISK" code="KEYCODE_3_ASTERISK"/>
+				<item name="Num -" token="MINUSPAD" code="KEYCODE_3_MINUSPAD"/>
+				<item name="Num +" token="PLUSPAD" code="KEYCODE_3_PLUSPAD"/>
+				<item name="Num Del" token="DELPAD" code="KEYCODE_3_DELPAD"/>
+				<item name="Num Enter" token="ENTERPAD" code="KEYCODE_3_ENTERPAD"/>
+				<item name="," token="SCAN179" code="KEYCODE_3_SCAN179"/>
+				<item name="=" token="SCAN141" code="KEYCODE_3_SCAN141"/>
+				<item name="Prnt Scrn" token="PRTSCR" code="KEYCODE_3_PRTSCR"/>
+				<item name="Pause" token="PAUSE" code="KEYCODE_3_PAUSE"/>
+				<item name="Shift" token="LSHIFT" code="KEYCODE_3_LSHIFT"/>
+				<item name="Right Shift" token="RSHIFT" code="KEYCODE_3_RSHIFT"/>
+				<item name="Ctrl" token="LCONTROL" code="KEYCODE_3_LCONTROL"/>
+				<item name="Right Ctrl" token="RCONTROL" code="KEYCODE_3_RCONTROL"/>
+				<item name="Alt" token="LALT" code="KEYCODE_3_LALT"/>
+				<item name="Right Alt" token="RALT" code="KEYCODE_3_RALT"/>
+				<item name="Scroll Lock" token="SCRLOCK" code="KEYCODE_3_SCRLOCK"/>
+				<item name="Num Lock" token="NUMLOCK" code="KEYCODE_3_NUMLOCK"/>
+				<item name="Caps Lock" token="CAPSLOCK" code="KEYCODE_3_CAPSLOCK"/>
+				<item name="Left Windows" token="LWIN" code="KEYCODE_3_LWIN"/>
+				<item name="Right Windows" token="RWIN" code="KEYCODE_3_RWIN"/>
+				<item name="Application" token="MENU" code="KEYCODE_3_MENU"/>
+				<item name="Scan000" token="SCAN000" code="KEYCODE_3_SCAN000"/>
+				<item name="Sys Req" token="SCAN084" code="KEYCODE_3_SCAN084"/>
+				<item name="Scan085" token="SCAN085" code="KEYCODE_3_SCAN085"/>
+				<item name="Scan089" token="SCAN089" code="KEYCODE_3_SCAN089"/>
+				<item name="Scan090" token="SCAN090" code="KEYCODE_3_SCAN090"/>
+				<item name="Scan091" token="SCAN091" code="KEYCODE_3_SCAN091"/>
+				<item name="Scan092" token="SCAN092" code="KEYCODE_3_SCAN092"/>
+				<item name="Scan093" token="SCAN093" code="KEYCODE_3_SCAN093"/>
+				<item name="Scan094" token="SCAN094" code="KEYCODE_3_SCAN094"/>
+				<item name="Scan095" token="SCAN095" code="KEYCODE_3_SCAN095"/>
+				<item name="Scan096" token="SCAN096" code="KEYCODE_3_SCAN096"/>
+				<item name="Scan097" token="SCAN097" code="KEYCODE_3_SCAN097"/>
+				<item name="Scan098" token="SCAN098" code="KEYCODE_3_SCAN098"/>
+				<item name="Scan099" token="SCAN099" code="KEYCODE_3_SCAN099"/>
+				<item name="Scan103" token="SCAN103" code="KEYCODE_3_SCAN103"/>
+				<item name="Scan104" token="SCAN104" code="KEYCODE_3_SCAN104"/>
+				<item name="Scan105" token="SCAN105" code="KEYCODE_3_SCAN105"/>
+				<item name="Scan106" token="SCAN106" code="KEYCODE_3_SCAN106"/>
+				<item name="Scan107" token="SCAN107" code="KEYCODE_3_SCAN107"/>
+				<item name="Scan108" token="SCAN108" code="KEYCODE_3_SCAN108"/>
+				<item name="Scan109" token="SCAN109" code="KEYCODE_3_SCAN109"/>
+				<item name="Scan110" token="SCAN110" code="KEYCODE_3_SCAN110"/>
+				<item name="Scan111" token="SCAN111" code="KEYCODE_3_SCAN111"/>
+				<item name="Scan112" token="SCAN112" code="KEYCODE_3_SCAN112"/>
+				<item name="Scan113" token="SCAN113" code="KEYCODE_3_SCAN113"/>
+				<item name="Scan114" token="SCAN114" code="KEYCODE_3_SCAN114"/>
+				<item name="Scan115" token="SCAN115" code="KEYCODE_3_SCAN115"/>
+				<item name="Scan116" token="SCAN116" code="KEYCODE_3_SCAN116"/>
+				<item name="Scan117" token="SCAN117" code="KEYCODE_3_SCAN117"/>
+				<item name="Scan118" token="SCAN118" code="KEYCODE_3_SCAN118"/>
+				<item name="Scan119" token="SCAN119" code="KEYCODE_3_SCAN119"/>
+				<item name="Scan120" token="SCAN120" code="KEYCODE_3_SCAN120"/>
+				<item name="Scan121" token="SCAN121" code="KEYCODE_3_SCAN121"/>
+				<item name="Scan122" token="SCAN122" code="KEYCODE_3_SCAN122"/>
+				<item name="Scan123" token="SCAN123" code="KEYCODE_3_SCAN123"/>
+				<item name="F13" token="SCAN124" code="KEYCODE_3_SCAN124"/>
+				<item name="F14" token="SCAN125" code="KEYCODE_3_SCAN125"/>
+				<item name="F15" token="SCAN126" code="KEYCODE_3_SCAN126"/>
+				<item name="F16" token="SCAN127" code="KEYCODE_3_SCAN127"/>
+				<item name="Scan128" token="SCAN128" code="KEYCODE_3_SCAN128"/>
+				<item name="&#57371;" token="SCAN129" code="KEYCODE_3_SCAN129"/>
+				<item name="1" token="SCAN130" code="KEYCODE_3_SCAN130"/>
+				<item name="2" token="SCAN131" code="KEYCODE_3_SCAN131"/>
+				<item name="3" token="SCAN132" code="KEYCODE_3_SCAN132"/>
+				<item name="4" token="SCAN133" code="KEYCODE_3_SCAN133"/>
+				<item name="5" token="SCAN134" code="KEYCODE_3_SCAN134"/>
+				<item name="6" token="SCAN135" code="KEYCODE_3_SCAN135"/>
+				<item name="7" token="SCAN136" code="KEYCODE_3_SCAN136"/>
+				<item name="8" token="SCAN137" code="KEYCODE_3_SCAN137"/>
+				<item name="9" token="SCAN138" code="KEYCODE_3_SCAN138"/>
+				<item name="0" token="SCAN139" code="KEYCODE_3_SCAN139"/>
+				<item name="-" token="SCAN140" code="KEYCODE_3_SCAN140"/>
+				<item name="&#57352;" token="SCAN142" code="KEYCODE_3_SCAN142"/>
+				<item name="&#9;" token="SCAN143" code="KEYCODE_3_SCAN143"/>
+				<item name="Q" token="SCAN144" code="KEYCODE_3_SCAN144"/>
+				<item name="W" token="SCAN145" code="KEYCODE_3_SCAN145"/>
+				<item name="E" token="SCAN146" code="KEYCODE_3_SCAN146"/>
+				<item name="R" token="SCAN147" code="KEYCODE_3_SCAN147"/>
+				<item name="T" token="SCAN148" code="KEYCODE_3_SCAN148"/>
+				<item name="Y" token="SCAN149" code="KEYCODE_3_SCAN149"/>
+				<item name="U" token="SCAN150" code="KEYCODE_3_SCAN150"/>
+				<item name="I" token="SCAN151" code="KEYCODE_3_SCAN151"/>
+				<item name="O" token="SCAN152" code="KEYCODE_3_SCAN152"/>
+				<item name="P" token="SCAN153" code="KEYCODE_3_SCAN153"/>
+				<item name="[" token="SCAN154" code="KEYCODE_3_SCAN154"/>
+				<item name="]" token="SCAN155" code="KEYCODE_3_SCAN155"/>
+				<item name="A" token="SCAN158" code="KEYCODE_3_SCAN158"/>
+				<item name="S" token="SCAN159" code="KEYCODE_3_SCAN159"/>
+				<item name="D" token="SCAN160" code="KEYCODE_3_SCAN160"/>
+				<item name="F" token="SCAN161" code="KEYCODE_3_SCAN161"/>
+				<item name="G" token="SCAN162" code="KEYCODE_3_SCAN162"/>
+				<item name="H" token="SCAN163" code="KEYCODE_3_SCAN163"/>
+				<item name="J" token="SCAN164" code="KEYCODE_3_SCAN164"/>
+				<item name="K" token="SCAN165" code="KEYCODE_3_SCAN165"/>
+				<item name="L" token="SCAN166" code="KEYCODE_3_SCAN166"/>
+				<item name=";" token="SCAN167" code="KEYCODE_3_SCAN167"/>
+				<item name="'" token="SCAN168" code="KEYCODE_3_SCAN168"/>
+				<item name="`" token="SCAN169" code="KEYCODE_3_SCAN169"/>
+				<item name="Scan170" token="SCAN170" code="KEYCODE_3_SCAN170"/>
+				<item name="\" token="SCAN171" code="KEYCODE_3_SCAN171"/>
+				<item name="Z" token="SCAN172" code="KEYCODE_3_SCAN172"/>
+				<item name="X" token="SCAN173" code="KEYCODE_3_SCAN173"/>
+				<item name="C" token="SCAN174" code="KEYCODE_3_SCAN174"/>
+				<item name="V" token="SCAN175" code="KEYCODE_3_SCAN175"/>
+				<item name="B" token="SCAN176" code="KEYCODE_3_SCAN176"/>
+				<item name="N" token="SCAN177" code="KEYCODE_3_SCAN177"/>
+				<item name="M" token="SCAN178" code="KEYCODE_3_SCAN178"/>
+				<item name="." token="SCAN180" code="KEYCODE_3_SCAN180"/>
+				<item name="Scan182" token="SCAN182" code="KEYCODE_3_SCAN182"/>
+				<item name=" " token="SCAN185" code="KEYCODE_3_SCAN185"/>
+				<item name="Scan186" token="SCAN186" code="KEYCODE_3_SCAN186"/>
+				<item name="Scan187" token="SCAN187" code="KEYCODE_3_SCAN187"/>
+				<item name="Scan188" token="SCAN188" code="KEYCODE_3_SCAN188"/>
+				<item name="Scan189" token="SCAN189" code="KEYCODE_3_SCAN189"/>
+				<item name="Scan190" token="SCAN190" code="KEYCODE_3_SCAN190"/>
+				<item name="Scan191" token="SCAN191" code="KEYCODE_3_SCAN191"/>
+				<item name="Scan192" token="SCAN192" code="KEYCODE_3_SCAN192"/>
+				<item name="Scan193" token="SCAN193" code="KEYCODE_3_SCAN193"/>
+				<item name="Scan194" token="SCAN194" code="KEYCODE_3_SCAN194"/>
+				<item name="Scan195" token="SCAN195" code="KEYCODE_3_SCAN195"/>
+				<item name="Scan196" token="SCAN196" code="KEYCODE_3_SCAN196"/>
+				<item name="Break" token="SCAN198" code="KEYCODE_3_SCAN198"/>
+				<item name="-" token="SCAN202" code="KEYCODE_3_SCAN202"/>
+				<item name="Scan204" token="SCAN204" code="KEYCODE_3_SCAN204"/>
+				<item name="+" token="SCAN206" code="KEYCODE_3_SCAN206"/>
+				<item name="&lt;00&gt;" token="SCAN212" code="KEYCODE_3_SCAN212"/>
+				<item name="Scan213" token="SCAN213" code="KEYCODE_3_SCAN213"/>
+				<item name="Help" token="SCAN214" code="KEYCODE_3_SCAN214"/>
+				<item name="Scan215" token="SCAN215" code="KEYCODE_3_SCAN215"/>
+				<item name="Scan216" token="SCAN216" code="KEYCODE_3_SCAN216"/>
+				<item name="Scan217" token="SCAN217" code="KEYCODE_3_SCAN217"/>
+				<item name="Scan218" token="SCAN218" code="KEYCODE_3_SCAN218"/>
+				<item name="Scan222" token="SCAN222" code="KEYCODE_3_SCAN222"/>
+				<item name="Scan223" token="SCAN223" code="KEYCODE_3_SCAN223"/>
+				<item name="Scan224" token="SCAN224" code="KEYCODE_3_SCAN224"/>
+				<item name="Scan225" token="SCAN225" code="KEYCODE_3_SCAN225"/>
+				<item name="Scan226" token="SCAN226" code="KEYCODE_3_SCAN226"/>
+				<item name="Scan227" token="SCAN227" code="KEYCODE_3_SCAN227"/>
+				<item name="Scan228" token="SCAN228" code="KEYCODE_3_SCAN228"/>
+				<item name="Scan229" token="SCAN229" code="KEYCODE_3_SCAN229"/>
+				<item name="Scan230" token="SCAN230" code="KEYCODE_3_SCAN230"/>
+				<item name="Scan231" token="SCAN231" code="KEYCODE_3_SCAN231"/>
+				<item name="Scan232" token="SCAN232" code="KEYCODE_3_SCAN232"/>
+				<item name="Scan233" token="SCAN233" code="KEYCODE_3_SCAN233"/>
+				<item name="Scan234" token="SCAN234" code="KEYCODE_3_SCAN234"/>
+				<item name="Scan235" token="SCAN235" code="KEYCODE_3_SCAN235"/>
+				<item name="Scan236" token="SCAN236" code="KEYCODE_3_SCAN236"/>
+				<item name="Scan237" token="SCAN237" code="KEYCODE_3_SCAN237"/>
+				<item name="Scan238" token="SCAN238" code="KEYCODE_3_SCAN238"/>
+				<item name="Scan239" token="SCAN239" code="KEYCODE_3_SCAN239"/>
+				<item name="Scan240" token="SCAN240" code="KEYCODE_3_SCAN240"/>
+				<item name="Scan241" token="SCAN241" code="KEYCODE_3_SCAN241"/>
+				<item name="Scan242" token="SCAN242" code="KEYCODE_3_SCAN242"/>
+				<item name="Scan243" token="SCAN243" code="KEYCODE_3_SCAN243"/>
+				<item name="Scan244" token="SCAN244" code="KEYCODE_3_SCAN244"/>
+				<item name="Scan245" token="SCAN245" code="KEYCODE_3_SCAN245"/>
+				<item name="Scan246" token="SCAN246" code="KEYCODE_3_SCAN246"/>
+				<item name="Scan247" token="SCAN247" code="KEYCODE_3_SCAN247"/>
+				<item name="Scan248" token="SCAN248" code="KEYCODE_3_SCAN248"/>
+				<item name="Scan249" token="SCAN249" code="KEYCODE_3_SCAN249"/>
+				<item name="Scan250" token="SCAN250" code="KEYCODE_3_SCAN250"/>
+				<item name="Scan251" token="SCAN251" code="KEYCODE_3_SCAN251"/>
+				<item name="&#9;" token="SCAN252" code="KEYCODE_3_SCAN252"/>
+				<item name="Scan253" token="SCAN253" code="KEYCODE_3_SCAN253"/>
+				<item name="Scan254" token="SCAN254" code="KEYCODE_3_SCAN254"/>
+				<item name="Scan255" token="SCAN255" code="KEYCODE_3_SCAN255"/>
+			</device>
+			<device name="HID Keyboard Device" id="\\?\HID#VID_045E&amp;PID_00DB&amp;MI_00#9&amp;36765ae2&amp;0&amp;0000#{884b96c3-56ef-11d1-bc8c-00a0c91405dd}" devindex="3">
+				<item name="A" token="A" code="KEYCODE_4_A"/>
+				<item name="B" token="B" code="KEYCODE_4_B"/>
+				<item name="C" token="C" code="KEYCODE_4_C"/>
+				<item name="D" token="D" code="KEYCODE_4_D"/>
+				<item name="E" token="E" code="KEYCODE_4_E"/>
+				<item name="F" token="F" code="KEYCODE_4_F"/>
+				<item name="G" token="G" code="KEYCODE_4_G"/>
+				<item name="H" token="H" code="KEYCODE_4_H"/>
+				<item name="I" token="I" code="KEYCODE_4_I"/>
+				<item name="J" token="J" code="KEYCODE_4_J"/>
+				<item name="K" token="K" code="KEYCODE_4_K"/>
+				<item name="L" token="L" code="KEYCODE_4_L"/>
+				<item name="M" token="M" code="KEYCODE_4_M"/>
+				<item name="N" token="N" code="KEYCODE_4_N"/>
+				<item name="O" token="O" code="KEYCODE_4_O"/>
+				<item name="P" token="P" code="KEYCODE_4_P"/>
+				<item name="Q" token="Q" code="KEYCODE_4_Q"/>
+				<item name="R" token="R" code="KEYCODE_4_R"/>
+				<item name="S" token="S" code="KEYCODE_4_S"/>
+				<item name="T" token="T" code="KEYCODE_4_T"/>
+				<item name="U" token="U" code="KEYCODE_4_U"/>
+				<item name="V" token="V" code="KEYCODE_4_V"/>
+				<item name="W" token="W" code="KEYCODE_4_W"/>
+				<item name="X" token="X" code="KEYCODE_4_X"/>
+				<item name="Y" token="Y" code="KEYCODE_4_Y"/>
+				<item name="Z" token="Z" code="KEYCODE_4_Z"/>
+				<item name="0" token="0" code="KEYCODE_4_0"/>
+				<item name="1" token="1" code="KEYCODE_4_1"/>
+				<item name="2" token="2" code="KEYCODE_4_2"/>
+				<item name="3" token="3" code="KEYCODE_4_3"/>
+				<item name="4" token="4" code="KEYCODE_4_4"/>
+				<item name="5" token="5" code="KEYCODE_4_5"/>
+				<item name="6" token="6" code="KEYCODE_4_6"/>
+				<item name="7" token="7" code="KEYCODE_4_7"/>
+				<item name="8" token="8" code="KEYCODE_4_8"/>
+				<item name="9" token="9" code="KEYCODE_4_9"/>
+				<item name="F1" token="F1" code="KEYCODE_4_F1"/>
+				<item name="F2" token="F2" code="KEYCODE_4_F2"/>
+				<item name="F3" token="F3" code="KEYCODE_4_F3"/>
+				<item name="F4" token="F4" code="KEYCODE_4_F4"/>
+				<item name="F5" token="F5" code="KEYCODE_4_F5"/>
+				<item name="F6" token="F6" code="KEYCODE_4_F6"/>
+				<item name="F7" token="F7" code="KEYCODE_4_F7"/>
+				<item name="F8" token="F8" code="KEYCODE_4_F8"/>
+				<item name="F9" token="F9" code="KEYCODE_4_F9"/>
+				<item name="F10" token="F10" code="KEYCODE_4_F10"/>
+				<item name="F11" token="F11" code="KEYCODE_4_F11"/>
+				<item name="F12" token="F12" code="KEYCODE_4_F12"/>
+				<item name="Scan100" token="F13" code="KEYCODE_4_F13"/>
+				<item name="Scan101" token="F14" code="KEYCODE_4_F14"/>
+				<item name="Scan102" token="F15" code="KEYCODE_4_F15"/>
+				<item name="Esc" token="ESC" code="KEYCODE_4_ESC"/>
+				<item name="`" token="TILDE" code="KEYCODE_4_TILDE"/>
+				<item name="-" token="MINUS" code="KEYCODE_4_MINUS"/>
+				<item name="=" token="EQUALS" code="KEYCODE_4_EQUALS"/>
+				<item name="Backspace" token="BACKSPACE" code="KEYCODE_4_BACKSPACE"/>
+				<item name="Tab" token="TAB" code="KEYCODE_4_TAB"/>
+				<item name="[" token="OPENBRACE" code="KEYCODE_4_OPENBRACE"/>
+				<item name="]" token="CLOSEBRACE" code="KEYCODE_4_CLOSEBRACE"/>
+				<item name="Enter" token="ENTER" code="KEYCODE_4_ENTER"/>
+				<item name=";" token="COLON" code="KEYCODE_4_COLON"/>
+				<item name="'" token="QUOTE" code="KEYCODE_4_QUOTE"/>
+				<item name="\" token="BACKSLASH" code="KEYCODE_4_BACKSLASH"/>
+				<item name="\" token="BACKSLASH2" code="KEYCODE_4_BACKSLASH2"/>
+				<item name="," token="COMMA" code="KEYCODE_4_COMMA"/>
+				<item name="." token="STOP" code="KEYCODE_4_STOP"/>
+				<item name="/" token="SLASH" code="KEYCODE_4_SLASH"/>
+				<item name="Space" token="SPACE" code="KEYCODE_4_SPACE"/>
+				<item name="Insert" token="INSERT" code="KEYCODE_4_INSERT"/>
+				<item name="Delete" token="DEL" code="KEYCODE_4_DEL"/>
+				<item name="Home" token="HOME" code="KEYCODE_4_HOME"/>
+				<item name="End" token="END" code="KEYCODE_4_END"/>
+				<item name="Page Up" token="PGUP" code="KEYCODE_4_PGUP"/>
+				<item name="Page Down" token="PGDN" code="KEYCODE_4_PGDN"/>
+				<item name="Left" token="LEFT" code="KEYCODE_4_LEFT"/>
+				<item name="Right" token="RIGHT" code="KEYCODE_4_RIGHT"/>
+				<item name="Up" token="UP" code="KEYCODE_4_UP"/>
+				<item name="Down" token="DOWN" code="KEYCODE_4_DOWN"/>
+				<item name="Num 0" token="0PAD" code="KEYCODE_4_0PAD"/>
+				<item name="Num 1" token="1PAD" code="KEYCODE_4_1PAD"/>
+				<item name="Num 2" token="2PAD" code="KEYCODE_4_2PAD"/>
+				<item name="Num 3" token="3PAD" code="KEYCODE_4_3PAD"/>
+				<item name="Num 4" token="4PAD" code="KEYCODE_4_4PAD"/>
+				<item name="Num 5" token="5PAD" code="KEYCODE_4_5PAD"/>
+				<item name="Num 6" token="6PAD" code="KEYCODE_4_6PAD"/>
+				<item name="Num 7" token="7PAD" code="KEYCODE_4_7PAD"/>
+				<item name="Num 8" token="8PAD" code="KEYCODE_4_8PAD"/>
+				<item name="Num 9" token="9PAD" code="KEYCODE_4_9PAD"/>
+				<item name="Num /" token="SLASHPAD" code="KEYCODE_4_SLASHPAD"/>
+				<item name="Num *" token="ASTERISK" code="KEYCODE_4_ASTERISK"/>
+				<item name="Num -" token="MINUSPAD" code="KEYCODE_4_MINUSPAD"/>
+				<item name="Num +" token="PLUSPAD" code="KEYCODE_4_PLUSPAD"/>
+				<item name="Num Del" token="DELPAD" code="KEYCODE_4_DELPAD"/>
+				<item name="Num Enter" token="ENTERPAD" code="KEYCODE_4_ENTERPAD"/>
+				<item name="," token="SCAN179" code="KEYCODE_4_SCAN179"/>
+				<item name="=" token="SCAN141" code="KEYCODE_4_SCAN141"/>
+				<item name="Prnt Scrn" token="PRTSCR" code="KEYCODE_4_PRTSCR"/>
+				<item name="Pause" token="PAUSE" code="KEYCODE_4_PAUSE"/>
+				<item name="Shift" token="LSHIFT" code="KEYCODE_4_LSHIFT"/>
+				<item name="Right Shift" token="RSHIFT" code="KEYCODE_4_RSHIFT"/>
+				<item name="Ctrl" token="LCONTROL" code="KEYCODE_4_LCONTROL"/>
+				<item name="Right Ctrl" token="RCONTROL" code="KEYCODE_4_RCONTROL"/>
+				<item name="Alt" token="LALT" code="KEYCODE_4_LALT"/>
+				<item name="Right Alt" token="RALT" code="KEYCODE_4_RALT"/>
+				<item name="Scroll Lock" token="SCRLOCK" code="KEYCODE_4_SCRLOCK"/>
+				<item name="Num Lock" token="NUMLOCK" code="KEYCODE_4_NUMLOCK"/>
+				<item name="Caps Lock" token="CAPSLOCK" code="KEYCODE_4_CAPSLOCK"/>
+				<item name="Left Windows" token="LWIN" code="KEYCODE_4_LWIN"/>
+				<item name="Right Windows" token="RWIN" code="KEYCODE_4_RWIN"/>
+				<item name="Application" token="MENU" code="KEYCODE_4_MENU"/>
+				<item name="Scan000" token="SCAN000" code="KEYCODE_4_SCAN000"/>
+				<item name="Sys Req" token="SCAN084" code="KEYCODE_4_SCAN084"/>
+				<item name="Scan085" token="SCAN085" code="KEYCODE_4_SCAN085"/>
+				<item name="Scan089" token="SCAN089" code="KEYCODE_4_SCAN089"/>
+				<item name="Scan090" token="SCAN090" code="KEYCODE_4_SCAN090"/>
+				<item name="Scan091" token="SCAN091" code="KEYCODE_4_SCAN091"/>
+				<item name="Scan092" token="SCAN092" code="KEYCODE_4_SCAN092"/>
+				<item name="Scan093" token="SCAN093" code="KEYCODE_4_SCAN093"/>
+				<item name="Scan094" token="SCAN094" code="KEYCODE_4_SCAN094"/>
+				<item name="Scan095" token="SCAN095" code="KEYCODE_4_SCAN095"/>
+				<item name="Scan096" token="SCAN096" code="KEYCODE_4_SCAN096"/>
+				<item name="Scan097" token="SCAN097" code="KEYCODE_4_SCAN097"/>
+				<item name="Scan098" token="SCAN098" code="KEYCODE_4_SCAN098"/>
+				<item name="Scan099" token="SCAN099" code="KEYCODE_4_SCAN099"/>
+				<item name="Scan103" token="SCAN103" code="KEYCODE_4_SCAN103"/>
+				<item name="Scan104" token="SCAN104" code="KEYCODE_4_SCAN104"/>
+				<item name="Scan105" token="SCAN105" code="KEYCODE_4_SCAN105"/>
+				<item name="Scan106" token="SCAN106" code="KEYCODE_4_SCAN106"/>
+				<item name="Scan107" token="SCAN107" code="KEYCODE_4_SCAN107"/>
+				<item name="Scan108" token="SCAN108" code="KEYCODE_4_SCAN108"/>
+				<item name="Scan109" token="SCAN109" code="KEYCODE_4_SCAN109"/>
+				<item name="Scan110" token="SCAN110" code="KEYCODE_4_SCAN110"/>
+				<item name="Scan111" token="SCAN111" code="KEYCODE_4_SCAN111"/>
+				<item name="Scan112" token="SCAN112" code="KEYCODE_4_SCAN112"/>
+				<item name="Scan113" token="SCAN113" code="KEYCODE_4_SCAN113"/>
+				<item name="Scan114" token="SCAN114" code="KEYCODE_4_SCAN114"/>
+				<item name="Scan115" token="SCAN115" code="KEYCODE_4_SCAN115"/>
+				<item name="Scan116" token="SCAN116" code="KEYCODE_4_SCAN116"/>
+				<item name="Scan117" token="SCAN117" code="KEYCODE_4_SCAN117"/>
+				<item name="Scan118" token="SCAN118" code="KEYCODE_4_SCAN118"/>
+				<item name="Scan119" token="SCAN119" code="KEYCODE_4_SCAN119"/>
+				<item name="Scan120" token="SCAN120" code="KEYCODE_4_SCAN120"/>
+				<item name="Scan121" token="SCAN121" code="KEYCODE_4_SCAN121"/>
+				<item name="Scan122" token="SCAN122" code="KEYCODE_4_SCAN122"/>
+				<item name="Scan123" token="SCAN123" code="KEYCODE_4_SCAN123"/>
+				<item name="F13" token="SCAN124" code="KEYCODE_4_SCAN124"/>
+				<item name="F14" token="SCAN125" code="KEYCODE_4_SCAN125"/>
+				<item name="F15" token="SCAN126" code="KEYCODE_4_SCAN126"/>
+				<item name="F16" token="SCAN127" code="KEYCODE_4_SCAN127"/>
+				<item name="Scan128" token="SCAN128" code="KEYCODE_4_SCAN128"/>
+				<item name="&#57371;" token="SCAN129" code="KEYCODE_4_SCAN129"/>
+				<item name="1" token="SCAN130" code="KEYCODE_4_SCAN130"/>
+				<item name="2" token="SCAN131" code="KEYCODE_4_SCAN131"/>
+				<item name="3" token="SCAN132" code="KEYCODE_4_SCAN132"/>
+				<item name="4" token="SCAN133" code="KEYCODE_4_SCAN133"/>
+				<item name="5" token="SCAN134" code="KEYCODE_4_SCAN134"/>
+				<item name="6" token="SCAN135" code="KEYCODE_4_SCAN135"/>
+				<item name="7" token="SCAN136" code="KEYCODE_4_SCAN136"/>
+				<item name="8" token="SCAN137" code="KEYCODE_4_SCAN137"/>
+				<item name="9" token="SCAN138" code="KEYCODE_4_SCAN138"/>
+				<item name="0" token="SCAN139" code="KEYCODE_4_SCAN139"/>
+				<item name="-" token="SCAN140" code="KEYCODE_4_SCAN140"/>
+				<item name="&#57352;" token="SCAN142" code="KEYCODE_4_SCAN142"/>
+				<item name="&#9;" token="SCAN143" code="KEYCODE_4_SCAN143"/>
+				<item name="Q" token="SCAN144" code="KEYCODE_4_SCAN144"/>
+				<item name="W" token="SCAN145" code="KEYCODE_4_SCAN145"/>
+				<item name="E" token="SCAN146" code="KEYCODE_4_SCAN146"/>
+				<item name="R" token="SCAN147" code="KEYCODE_4_SCAN147"/>
+				<item name="T" token="SCAN148" code="KEYCODE_4_SCAN148"/>
+				<item name="Y" token="SCAN149" code="KEYCODE_4_SCAN149"/>
+				<item name="U" token="SCAN150" code="KEYCODE_4_SCAN150"/>
+				<item name="I" token="SCAN151" code="KEYCODE_4_SCAN151"/>
+				<item name="O" token="SCAN152" code="KEYCODE_4_SCAN152"/>
+				<item name="P" token="SCAN153" code="KEYCODE_4_SCAN153"/>
+				<item name="[" token="SCAN154" code="KEYCODE_4_SCAN154"/>
+				<item name="]" token="SCAN155" code="KEYCODE_4_SCAN155"/>
+				<item name="A" token="SCAN158" code="KEYCODE_4_SCAN158"/>
+				<item name="S" token="SCAN159" code="KEYCODE_4_SCAN159"/>
+				<item name="D" token="SCAN160" code="KEYCODE_4_SCAN160"/>
+				<item name="F" token="SCAN161" code="KEYCODE_4_SCAN161"/>
+				<item name="G" token="SCAN162" code="KEYCODE_4_SCAN162"/>
+				<item name="H" token="SCAN163" code="KEYCODE_4_SCAN163"/>
+				<item name="J" token="SCAN164" code="KEYCODE_4_SCAN164"/>
+				<item name="K" token="SCAN165" code="KEYCODE_4_SCAN165"/>
+				<item name="L" token="SCAN166" code="KEYCODE_4_SCAN166"/>
+				<item name=";" token="SCAN167" code="KEYCODE_4_SCAN167"/>
+				<item name="'" token="SCAN168" code="KEYCODE_4_SCAN168"/>
+				<item name="`" token="SCAN169" code="KEYCODE_4_SCAN169"/>
+				<item name="Scan170" token="SCAN170" code="KEYCODE_4_SCAN170"/>
+				<item name="\" token="SCAN171" code="KEYCODE_4_SCAN171"/>
+				<item name="Z" token="SCAN172" code="KEYCODE_4_SCAN172"/>
+				<item name="X" token="SCAN173" code="KEYCODE_4_SCAN173"/>
+				<item name="C" token="SCAN174" code="KEYCODE_4_SCAN174"/>
+				<item name="V" token="SCAN175" code="KEYCODE_4_SCAN175"/>
+				<item name="B" token="SCAN176" code="KEYCODE_4_SCAN176"/>
+				<item name="N" token="SCAN177" code="KEYCODE_4_SCAN177"/>
+				<item name="M" token="SCAN178" code="KEYCODE_4_SCAN178"/>
+				<item name="." token="SCAN180" code="KEYCODE_4_SCAN180"/>
+				<item name="Scan182" token="SCAN182" code="KEYCODE_4_SCAN182"/>
+				<item name=" " token="SCAN185" code="KEYCODE_4_SCAN185"/>
+				<item name="Scan186" token="SCAN186" code="KEYCODE_4_SCAN186"/>
+				<item name="Scan187" token="SCAN187" code="KEYCODE_4_SCAN187"/>
+				<item name="Scan188" token="SCAN188" code="KEYCODE_4_SCAN188"/>
+				<item name="Scan189" token="SCAN189" code="KEYCODE_4_SCAN189"/>
+				<item name="Scan190" token="SCAN190" code="KEYCODE_4_SCAN190"/>
+				<item name="Scan191" token="SCAN191" code="KEYCODE_4_SCAN191"/>
+				<item name="Scan192" token="SCAN192" code="KEYCODE_4_SCAN192"/>
+				<item name="Scan193" token="SCAN193" code="KEYCODE_4_SCAN193"/>
+				<item name="Scan194" token="SCAN194" code="KEYCODE_4_SCAN194"/>
+				<item name="Scan195" token="SCAN195" code="KEYCODE_4_SCAN195"/>
+				<item name="Scan196" token="SCAN196" code="KEYCODE_4_SCAN196"/>
+				<item name="Break" token="SCAN198" code="KEYCODE_4_SCAN198"/>
+				<item name="-" token="SCAN202" code="KEYCODE_4_SCAN202"/>
+				<item name="Scan204" token="SCAN204" code="KEYCODE_4_SCAN204"/>
+				<item name="+" token="SCAN206" code="KEYCODE_4_SCAN206"/>
+				<item name="&lt;00&gt;" token="SCAN212" code="KEYCODE_4_SCAN212"/>
+				<item name="Scan213" token="SCAN213" code="KEYCODE_4_SCAN213"/>
+				<item name="Help" token="SCAN214" code="KEYCODE_4_SCAN214"/>
+				<item name="Scan215" token="SCAN215" code="KEYCODE_4_SCAN215"/>
+				<item name="Scan216" token="SCAN216" code="KEYCODE_4_SCAN216"/>
+				<item name="Scan217" token="SCAN217" code="KEYCODE_4_SCAN217"/>
+				<item name="Scan218" token="SCAN218" code="KEYCODE_4_SCAN218"/>
+				<item name="Scan222" token="SCAN222" code="KEYCODE_4_SCAN222"/>
+				<item name="Scan223" token="SCAN223" code="KEYCODE_4_SCAN223"/>
+				<item name="Scan224" token="SCAN224" code="KEYCODE_4_SCAN224"/>
+				<item name="Scan225" token="SCAN225" code="KEYCODE_4_SCAN225"/>
+				<item name="Scan226" token="SCAN226" code="KEYCODE_4_SCAN226"/>
+				<item name="Scan227" token="SCAN227" code="KEYCODE_4_SCAN227"/>
+				<item name="Scan228" token="SCAN228" code="KEYCODE_4_SCAN228"/>
+				<item name="Scan229" token="SCAN229" code="KEYCODE_4_SCAN229"/>
+				<item name="Scan230" token="SCAN230" code="KEYCODE_4_SCAN230"/>
+				<item name="Scan231" token="SCAN231" code="KEYCODE_4_SCAN231"/>
+				<item name="Scan232" token="SCAN232" code="KEYCODE_4_SCAN232"/>
+				<item name="Scan233" token="SCAN233" code="KEYCODE_4_SCAN233"/>
+				<item name="Scan234" token="SCAN234" code="KEYCODE_4_SCAN234"/>
+				<item name="Scan235" token="SCAN235" code="KEYCODE_4_SCAN235"/>
+				<item name="Scan236" token="SCAN236" code="KEYCODE_4_SCAN236"/>
+				<item name="Scan237" token="SCAN237" code="KEYCODE_4_SCAN237"/>
+				<item name="Scan238" token="SCAN238" code="KEYCODE_4_SCAN238"/>
+				<item name="Scan239" token="SCAN239" code="KEYCODE_4_SCAN239"/>
+				<item name="Scan240" token="SCAN240" code="KEYCODE_4_SCAN240"/>
+				<item name="Scan241" token="SCAN241" code="KEYCODE_4_SCAN241"/>
+				<item name="Scan242" token="SCAN242" code="KEYCODE_4_SCAN242"/>
+				<item name="Scan243" token="SCAN243" code="KEYCODE_4_SCAN243"/>
+				<item name="Scan244" token="SCAN244" code="KEYCODE_4_SCAN244"/>
+				<item name="Scan245" token="SCAN245" code="KEYCODE_4_SCAN245"/>
+				<item name="Scan246" token="SCAN246" code="KEYCODE_4_SCAN246"/>
+				<item name="Scan247" token="SCAN247" code="KEYCODE_4_SCAN247"/>
+				<item name="Scan248" token="SCAN248" code="KEYCODE_4_SCAN248"/>
+				<item name="Scan249" token="SCAN249" code="KEYCODE_4_SCAN249"/>
+				<item name="Scan250" token="SCAN250" code="KEYCODE_4_SCAN250"/>
+				<item name="Scan251" token="SCAN251" code="KEYCODE_4_SCAN251"/>
+				<item name="&#9;" token="SCAN252" code="KEYCODE_4_SCAN252"/>
+				<item name="Scan253" token="SCAN253" code="KEYCODE_4_SCAN253"/>
+				<item name="Scan254" token="SCAN254" code="KEYCODE_4_SCAN254"/>
+				<item name="Scan255" token="SCAN255" code="KEYCODE_4_SCAN255"/>
+			</device>
+		</class>
+		<class name="joystick" enabled="1" multi="1">
+			<device name="Logitech WingMan Gamepad (USB)" id="Logitech WingMan Gamepad (USB) product_c209046d-0000-0000-0000-504944564944 instance_bc766cd0-b792-11ee-8001-444553540000" devindex="0">
+				<item name="Button 6" token="BUTTON7" code="JOYCODE_1_BUTTON7"/>
+				<item name="X Axis" token="XAXIS" code="JOYCODE_1_XAXIS"/>
+				<item name="Y Axis" token="YAXIS" code="JOYCODE_1_YAXIS"/>
+				<item name="Button 9" token="BUTTON10" code="JOYCODE_1_BUTTON10"/>
+				<item name="Button 10" token="BUTTON11" code="JOYCODE_1_BUTTON11"/>
+				<item name="Button 8" token="BUTTON9" code="JOYCODE_1_BUTTON9"/>
+				<item name="Button 0" token="BUTTON1" code="JOYCODE_1_BUTTON1"/>
+				<item name="Button 1" token="BUTTON2" code="JOYCODE_1_BUTTON2"/>
+				<item name="Button 2" token="BUTTON3" code="JOYCODE_1_BUTTON3"/>
+				<item name="Button 3" token="BUTTON4" code="JOYCODE_1_BUTTON4"/>
+				<item name="Button 4" token="BUTTON5" code="JOYCODE_1_BUTTON5"/>
+				<item name="Button 5" token="BUTTON6" code="JOYCODE_1_BUTTON6"/>
+				<item name="Button 7" token="BUTTON8" code="JOYCODE_1_BUTTON8"/>
+			</device>
+		</class>
+		<class name="mouse" enabled="0" multi="0">
+			<device name="HID-compliant mouse" id="\\?\HID#VID_03F0&amp;PID_544A&amp;MI_00#9&amp;382ebc84&amp;0&amp;0000#{378de44c-56ef-11d1-bc8c-00a0c91405dd}" devindex="0">
+				<item name="X" token="XAXIS" code="MOUSECODE_1_XAXIS"/>
+				<item name="Y" token="YAXIS" code="MOUSECODE_1_YAXIS"/>
+				<item name="Scroll V" token="ZAXIS" code="MOUSECODE_1_ZAXIS"/>
+				<item name="Scroll H" token="RZAXIS" code="MOUSECODE_1_RZAXIS"/>
+				<item name="Button 1" token="BUTTON1" code="MOUSECODE_1_BUTTON1"/>
+				<item name="Button 2" token="BUTTON2" code="MOUSECODE_1_BUTTON2"/>
+				<item name="Button 3" token="BUTTON3" code="MOUSECODE_1_BUTTON3"/>
+				<item name="Button 4" token="BUTTON4" code="MOUSECODE_1_BUTTON4"/>
+				<item name="Button 5" token="BUTTON5" code="MOUSECODE_1_BUTTON5"/>
+			</device>
+		</class>
+		<class name="lightgun" enabled="0" multi="1">
+			<device name="HID-compliant mouse" id="\\?\HID#VID_03F0&amp;PID_544A&amp;MI_00#9&amp;382ebc84&amp;0&amp;0000#{378de44c-56ef-11d1-bc8c-00a0c91405dd}" devindex="0">
+				<item name="Scroll V" token="ADDREL1" code="GUNCODE_1_ADDREL1"/>
+				<item name="Y" token="YAXIS" code="GUNCODE_1_YAXIS"/>
+				<item name="Button 1" token="BUTTON1" code="GUNCODE_1_BUTTON1"/>
+				<item name="Button 2" token="BUTTON2" code="GUNCODE_1_BUTTON2"/>
+				<item name="Button 3" token="BUTTON3" code="GUNCODE_1_BUTTON3"/>
+				<item name="Button 4" token="BUTTON4" code="GUNCODE_1_BUTTON4"/>
+				<item name="Button 5" token="BUTTON5" code="GUNCODE_1_BUTTON5"/>
+				<item name="Scroll H" token="ADDREL2" code="GUNCODE_1_ADDREL2"/>
+				<item name="X" token="XAXIS" code="GUNCODE_1_XAXIS"/>
+			</device>
+		</class>
+	</input_devices>
+</status>

--- a/src/version.rs
+++ b/src/version.rs
@@ -26,6 +26,12 @@ impl MameVersion {
 		self.major_minor.is_none() || !self.full_text.is_empty()
 	}
 
+	pub fn parse_simple(s: impl AsRef<str>) -> Option<Self> {
+		let (major, minor) = s.as_ref().split_once('.')?;
+		let (major, minor) = (major.parse().ok()?, minor.parse().ok()?);
+		Some(Self::new(major, minor))
+	}
+
 	fn proxy_key(self: &MameVersion) -> Option<impl Ord> {
 		self.major_minor
 			.map(|(major, minor)| (major, minor, self.is_dirty() as u8))


### PR DESCRIPTION
`Status` is of course the representation of MAME's state ultimately emitted by the LUA plugin.  These changes include:
* `Status::has_initialized` is gone
* `AppState` now tracks `Option<Status>` instead of `Status`
* `Status::merge()` has been changed to `Status::new()` so the old state can be optional
* `Status::build` is no longer optional (we will derive it from `app_version` if necessary)