### PR TITLE
When BletchMAME is misconfigured, buttons for fixing paths on the main window will launch the Paths Dialog

### DIFF
--- a/src/appcommand.rs
+++ b/src/appcommand.rs
@@ -33,7 +33,7 @@ pub enum AppCommand {
 	OptionsClassic,
 
 	// Settings menu
-	SettingsPaths,
+	SettingsPaths(Option<PathType>),
 	SettingsToggleBuiltinCollection(BuiltinCollection),
 	SettingsReset,
 
@@ -75,7 +75,6 @@ pub enum AppCommand {
 		index: usize,
 		new_name: String,
 	},
-	ChoosePath(PathType),
 	BookmarkCurrentCollection,
 	LoadImageDialog {
 		tag: String,

--- a/src/appstate.rs
+++ b/src/appstate.rs
@@ -616,7 +616,7 @@ impl AppState {
 						let text = problem.to_string().into();
 						let button = problem.problem_type().map(|path_type| {
 							let text = Cow::Owned(format!("Choose {path_type}"));
-							let command = AppCommand::ChoosePath(path_type);
+							let command = AppCommand::SettingsPaths(Some(path_type));
 							Button { text, command }
 						});
 						Issue { text, button }

--- a/src/dialogs/paths.rs
+++ b/src/dialogs/paths.rs
@@ -39,7 +39,11 @@ impl Debug for State {
 	}
 }
 
-pub async fn dialog_paths(parent: Weak<impl ComponentHandle + 'static>, paths: Rc<PrefsPaths>) -> Option<PrefsPaths> {
+pub async fn dialog_paths(
+	parent: Weak<impl ComponentHandle + 'static>,
+	paths: Rc<PrefsPaths>,
+	path_type: Option<PathType>,
+) -> Option<PrefsPaths> {
 	// prepare the dialog
 	let modal = Modal::new(&parent.unwrap(), || PathsDialog::new().unwrap());
 	let single_result = SingleResult::default();
@@ -106,6 +110,15 @@ pub async fn dialog_paths(parent: Weak<impl ComponentHandle + 'static>, paths: R
 		let dialog = state_clone.dialog_weak.unwrap();
 		update_paths_entries(&dialog, &state_clone.paths.borrow());
 	});
+
+	// set the index on the path type dropdown
+	let path_label_index = path_type.and_then(|path_type| PathType::all_values().iter().position(|&x| x == path_type));
+	if let Some(path_label_index) = path_label_index {
+		let path_label_index = i32::try_from(path_label_index).unwrap();
+		modal.dialog().set_path_label_index(path_label_index);
+	}
+
+	// fresh update of path entries
 	update_paths_entries(modal.dialog(), &state.paths.borrow());
 
 	// update buttons when selected entries changes

--- a/ui/paths.slint
+++ b/ui/paths.slint
@@ -9,7 +9,7 @@ export component PathsDialog inherits Window {
     in property <bool> ok-enabled;
     in property <bool> browse-enabled;
     in property <bool> delete-enabled;
-    out property <int> path-label-index;
+    in-out property <int> path-label-index;
     out property <int> path-entry-index <=> entries-view.current-index;
     callback ok-clicked();
     callback cancel-clicked();


### PR DESCRIPTION
Previously these would bring up a file dialog.  This works well for setting the MAME executable, but wasn't really good when setting the Plugins dialog, which requires specifying multiple paths.

Unfortunately when correcting a misconfiguration of the Plugins directory, the Paths Dialog will say "MAME Executable" even if it is showing the Plugins paths.  This seems to be a Slint bug:  https://github.com/slint-ui/slint/issues/7632