### PR TITLE
Partial fix to issue where we failed to report MAME failures

### DIFF
--- a/src/appstate.rs
+++ b/src/appstate.rs
@@ -449,7 +449,7 @@ impl AppState {
 		let session = live.session.as_ref().unwrap();
 
 		// join the thread and get the result
-		let result = session.job.join();
+		let result = session.job.join().unwrap();
 
 		// if we failed, we have to report the error
 		let failure = if let Err(e) = result {
@@ -471,6 +471,7 @@ impl AppState {
 		};
 		let new_state = Self {
 			live: Some(new_live),
+			failure,
 			..self.clone()
 		};
 


### PR DESCRIPTION
Including but not limited to "ROMs not found"

However, this is not fixed from the user's perspective, as not when you launch a machine where the ROM does not exist you get a blank screen.  There seems to be another issue pertaining to not being able to report messages to the user.  This same issue seems to cause the "Resetting MAME..." message that accompanies the spinner to not display.