### PR TITLE
Changing the casing of `software_list` ==> `softwareList` in preferences

### DIFF
--- a/src/prefs/mod.rs
+++ b/src/prefs/mod.rs
@@ -302,6 +302,7 @@ pub enum PrefsItem {
 		machine_name: String,
 	},
 	Software {
+		#[serde(rename = "softwareList")]
 		software_list: String,
 		software: String,
 	},


### PR DESCRIPTION
Not sure why this is not covered by `#[serde(rename_all = "camelCase")]` but go figure