### PR TITLE
Various Fixes

### DIFF
--- a/plugins/worker_ui/init.lua
+++ b/plugins/worker_ui/init.lua
@@ -1188,7 +1188,7 @@ local commands =
 function protected_call(callback, callback_name)
 	local status, err = pcall(callback)
 	if (not status) then
-		print("@ERROR ## Lua runtime error on " .. callback_name .. " " .. tostring(err))
+		print("@ERROR ### Lua runtime error on " .. callback_name .. " " .. tostring(err))
 	end
 end
 

--- a/src/runtime/command.rs
+++ b/src/runtime/command.rs
@@ -55,7 +55,7 @@ fn pairs_command_text(base: &[&str], args: &[(&str, &str)]) -> Cow<'static, str>
 		.map(Cow::Borrowed)
 		.chain(args.iter().flat_map(|(name, value)| {
 			let name = Cow::Borrowed(*name);
-			let value = if value.contains(' ') {
+			let value = if value.is_empty() || value.contains(' ') {
 				Cow::Owned(format!("\"{}\"", value))
 			} else {
 				Cow::Borrowed(*value)
@@ -73,8 +73,10 @@ mod test {
 	use super::MameCommand;
 
 	#[test_case(0, MameCommand::Stop, "STOP")]
-	#[test_case(1, MameCommand::Start { machine_name: "coco2b", initial_loads: &[("ext:fdc:wd17xx:0", "foo.dsk")]}, "START coco2b ext:fdc:wd17xx:0 foo.dsk")]
-	#[test_case(2, MameCommand::LoadImage(&[("ext:fdc:wd17xx:0", "foo bar.dsk")]), "LOAD ext:fdc:wd17xx:0 \"foo bar.dsk\"")]
+	#[test_case(1, MameCommand::Start { machine_name: "coco2b", initial_loads: &[("-ramsize", "")]}, "START coco2b -ramsize \"\"")]
+	#[test_case(2, MameCommand::Start { machine_name: "coco2b", initial_loads: &[("-ramsize", "64k")]}, "START coco2b -ramsize 64k")]
+	#[test_case(3, MameCommand::Start { machine_name: "coco2b", initial_loads: &[("ext:fdc:wd17xx:0", "foo.dsk")]}, "START coco2b ext:fdc:wd17xx:0 foo.dsk")]
+	#[test_case(4, MameCommand::LoadImage(&[("ext:fdc:wd17xx:0", "foo bar.dsk")]), "LOAD ext:fdc:wd17xx:0 \"foo bar.dsk\"")]
 	fn command_test(_index: usize, command: MameCommand<'_>, expected: &str) {
 		let actual = command.text();
 		assert_eq!(expected, actual);

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -99,6 +99,11 @@ fn execute_mame(
 	// interact with MAME, do our thing
 	let mame_result = interact_with_mame(&mut child, receiver, &event_callback);
 
+	// if we either errored, try to kill the process
+	if mame_result.is_err() {
+		let _ = child.kill();
+	}
+
 	// await the exit status
 	let exit_status = child.wait();
 	event!(LOG, "execute_mame(): MAME exited exit_status={:?}", exit_status);

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -37,7 +37,7 @@ const LOG: Level = Level::DEBUG;
 enum ThisError {
 	#[error("MAME Error Response: {0:?}")]
 	MameErrorResponse(String),
-	#[error("Problems found during MAME preflight: {0:?}")]
+	#[error("Unexpected Response from MAME: {0:?}")]
 	MameResponseNotUnderstood(String),
 	#[error("Unexpected EOF from MAME: {0}")]
 	EofFromMame(String),


### PR DESCRIPTION
* Ensuring that if MAME errors and we're closing out, that we kill the MAME process
* Fixing text for `ThisError::MameResponseNotUnderstood`
* `worker_ui`: Fixing error response
* Fixing issue when sending blank commands with blank arguments to MAME