### PR TITLE
The "Configure Machine" dialog now supports images

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -40,6 +40,7 @@ use crate::collections::toggle_builtin_collection;
 use crate::devimageconfig::DevicesImagesConfig;
 use crate::dialogs::configure::dialog_configure;
 use crate::dialogs::devimages::dialog_devices_and_images;
+use crate::dialogs::image::Format;
 use crate::dialogs::image::dialog_load_image;
 use crate::dialogs::messagebox::OkCancel;
 use crate::dialogs::messagebox::OkOnly;
@@ -918,7 +919,11 @@ fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 				.iter()
 				.find(|x| x.tag == tag)
 				.unwrap();
-			if let Some(filename) = dialog_load_image(parent, image) {
+			let format_iter = image.details.formats.iter().map(|f| Format {
+				description: &f.description,
+				extensions: &f.extensions,
+			});
+			if let Some(filename) = dialog_load_image(parent, format_iter) {
 				let command = AppCommand::LoadImage { tag, filename };
 				handle_command(model, command);
 			}

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -54,6 +54,7 @@ use crate::guiutils::menuing::MenuExt;
 use crate::guiutils::menuing::MenuItemUpdate;
 use crate::guiutils::menuing::accel;
 use crate::guiutils::modal::Modal;
+use crate::guiutils::modal::filter_command;
 use crate::history::History;
 use crate::models::collectionsview::CollectionsViewModel;
 use crate::models::itemstable::EmptyReason;
@@ -451,7 +452,9 @@ pub fn create(args: AppArgs) -> AppWindow {
 			let packet = packet.clone();
 			invoke_from_event_loop(move || {
 				let model = packet.unwrap();
-				handle_command(&model, command);
+				if let Some(command) = filter_command(command) {
+					handle_command(&model, command);
+				}
 			})
 			.unwrap();
 		}

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -982,7 +982,8 @@ fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 
 			let fut = async move {
 				let parent = model_clone.app_window_weak.clone();
-				if let Some(item) = dialog_configure(parent, info_db, item).await {
+				let menuing_type = model_clone.menuing_type;
+				if let Some(item) = dialog_configure(parent, info_db, item, menuing_type).await {
 					let item = PrefsItem::Machine(item);
 					model_clone.modify_prefs(|prefs| {
 						let old_collection = prefs.collections[folder_index].clone();

--- a/src/devimageconfig.rs
+++ b/src/devimageconfig.rs
@@ -105,9 +105,8 @@ impl DevicesImagesConfig {
 				let (_, slot) = core
 					.machine_configs
 					.current_config()
-					.lookup_tag(&internal_entry.tag)
+					.lookup_slot_tag(&internal_entry.tag)
 					.unwrap();
-				let slot = slot.unwrap();
 
 				let none_option = EntryOption {
 					name: None,

--- a/src/dialogs/configure.rs
+++ b/src/dialogs/configure.rs
@@ -125,6 +125,7 @@ fn machine_item_from_model(model: &DevicesAndImagesModel, dialog: &ConfigureDial
 		let machine = diconfig.machine().unwrap();
 		let machine_name = machine.name().to_string();
 		let slots = diconfig.changed_slots(false);
+		let images = Default::default();
 		let ram_sizes_index = dialog.get_ram_sizes_index();
 		let ram_size = usize::try_from(ram_sizes_index - 1)
 			.ok()
@@ -132,6 +133,7 @@ fn machine_item_from_model(model: &DevicesAndImagesModel, dialog: &ConfigureDial
 		PrefsMachineItem {
 			machine_name,
 			slots,
+			images,
 			ram_size,
 		}
 	})

--- a/src/guiutils/modal.rs
+++ b/src/guiutils/modal.rs
@@ -67,7 +67,6 @@ where
 		self.dialog.window()
 	}
 
-	#[allow(dead_code)]
 	pub fn set_command_filter(&self, callback: impl Fn(AppCommand) -> Option<AppCommand> + 'static) {
 		let callback = Box::new(callback) as Box<dyn Fn(AppCommand) -> Option<AppCommand> + 'static>;
 		CURRENT_FILTERS.with_borrow_mut(|filters| {

--- a/src/guiutils/modal.rs
+++ b/src/guiutils/modal.rs
@@ -1,3 +1,5 @@
+use std::cell::Cell;
+use std::cell::RefCell;
 use std::future::Future;
 use std::rc::Rc;
 
@@ -6,13 +8,20 @@ use slint::ComponentHandle;
 use slint::Window;
 use winit::window::WindowAttributes;
 
+use crate::appcommand::AppCommand;
 use crate::guiutils::hook::with_attributes_hook;
 use crate::platform::WindowAttributesExt;
 use crate::platform::WindowExt;
 
+thread_local! {
+	#[allow(clippy::type_complexity)]
+	static CURRENT_FILTERS: RefCell<Vec<Box<dyn Fn(AppCommand) -> Option<AppCommand> + 'static>>> = RefCell::new(Default::default());
+}
+
 pub struct Modal<D> {
 	reenable_parent: Rc<dyn Fn() + 'static>,
 	dialog: D,
+	must_drop_filter: Cell<bool>,
 }
 
 impl<D> Modal<D>
@@ -46,6 +55,7 @@ where
 		Self {
 			reenable_parent,
 			dialog,
+			must_drop_filter: Cell::new(false),
 		}
 	}
 
@@ -55,6 +65,15 @@ where
 
 	pub fn window(&self) -> &'_ Window {
 		self.dialog.window()
+	}
+
+	#[allow(dead_code)]
+	pub fn set_command_filter(&self, callback: impl Fn(AppCommand) -> Option<AppCommand> + 'static) {
+		let callback = Box::new(callback) as Box<dyn Fn(AppCommand) -> Option<AppCommand> + 'static>;
+		CURRENT_FILTERS.with_borrow_mut(|filters| {
+			filters.push(callback);
+		});
+		self.must_drop_filter.set(true);
 	}
 
 	pub fn launch(self) {
@@ -87,6 +106,16 @@ where
 	}
 }
 
+impl<D> Drop for Modal<D> {
+	fn drop(&mut self) {
+		if self.must_drop_filter.get() {
+			CURRENT_FILTERS.with_borrow_mut(|filters| {
+				let _ = filters.pop().unwrap();
+			});
+		}
+	}
+}
+
 fn set_window_attributes_for_modal_parent(
 	mut window_attributes: WindowAttributes,
 	parent: &Window,
@@ -103,4 +132,14 @@ fn set_window_attributes_for_modal_parent(
 
 fn reenable_modal_parent(parent: &impl ComponentHandle) {
 	parent.window().set_enabled_for_modal(true);
+}
+
+pub fn filter_command(command: AppCommand) -> Option<AppCommand> {
+	CURRENT_FILTERS.with_borrow(|filters| {
+		if let Some(filter) = filters.last() {
+			filter(command)
+		} else {
+			Some(command)
+		}
+	})
 }

--- a/src/prefs/mod.rs
+++ b/src/prefs/mod.rs
@@ -4,6 +4,7 @@ mod serde_slots;
 mod var;
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs::File;
 use std::fs::create_dir_all;
@@ -314,6 +315,9 @@ pub struct PrefsMachineItem {
 
 	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default", with = "serde_slots")]
 	pub slots: Vec<(String, Option<String>)>,
+
+	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
+	pub images: HashMap<String, String>,
 
 	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
 	pub ram_size: Option<u64>,

--- a/ui/configure.slint
+++ b/ui/configure.slint
@@ -16,6 +16,13 @@ export component ConfigureDialog inherits Window {
     // callbacks
     callback ok-clicked();
     callback entry-option-changed(int, string);
+    callback entry-button-clicked(int, Point);
+    callback menu-entry-activated(MenuEntry);
+
+    // functions
+    public function show-context-menu(entries: [MenuEntry], point: Point) {
+        dev-images-list.show-context-menu(entries, point);
+    }
 
     // control hierarchy
     VerticalBox {
@@ -25,11 +32,18 @@ export component ConfigureDialog inherits Window {
                 GridBox {
                     preferred-width: 100%;
                     preferred-height: 100%;
-                    DevicesAndImagesList {
+                    dev-images-list := DevicesAndImagesList {
                         visible: root.dev-images-error == "";
                         state: root.dev-images-state;
+                        images-button-enabled: true;
                         entry-option-changed(index, option-name) => {
                             root.entry-option-changed(index, option-name);
+                        }
+                        entry-button-clicked(index, point) => {
+                            root.entry-button-clicked(index, point);
+                        }
+                        menu-entry-activated(entry) => {
+                            root.menu-entry-activated(entry);
                         }
                     }
 


### PR DESCRIPTION
- Images are persisted in the configuration
- Images are loaded when MAME starts
    
Limitations:  We're somewhat limited by what `-listxml` emits.  The `<device>` and `<instance>` tags do not really make sense are seem to behave inconsistently.  But this is good enough for now and there is an active discussion about replacing this mechanism.
