### PR TITLE
Fixed issues pertaining to identifying images for the "Configure Machine" dialog

### DIFF
--- a/src/devimageconfig.rs
+++ b/src/devimageconfig.rs
@@ -72,7 +72,7 @@ impl DevicesImagesConfig {
 
 	pub fn with_machine_name(info_db: Rc<InfoDb>, machine_name: Option<&str>) -> Option<Self> {
 		let result = if let Some(machine_name) = machine_name {
-			let machine_index = info_db.machines().find_index(machine_name)?;
+			let machine_index = info_db.machines().find_index(machine_name).ok()?;
 			let machine_config = MachineConfig::new(info_db.clone(), machine_index);
 			Self::from(machine_config)
 		} else {
@@ -299,10 +299,7 @@ fn internal_update_status(
 	};
 
 	// find the machine index identified in the status
-	let machine_index = info_db
-		.machines()
-		.find_index(&running.machine_name)
-		.unwrap_or_else(|| panic!("Unknown machine {:?}", running.machine_name));
+	let machine_index = info_db.machines().find_index(&running.machine_name).unwrap();
 
 	// the machine_configs passed in is only relevant if the machine_index matches; if we don't
 	// have one we need to create it

--- a/src/devimageconfig.rs
+++ b/src/devimageconfig.rs
@@ -239,7 +239,7 @@ impl DevicesImagesConfig {
 				let (_, slot) = machine_config.lookup_slot_tag(&entry.tag).unwrap();
 				let slot_option = slot.options().get(current_option_index).unwrap();
 				let machine = info_db.machines().find(slot_option.devname()).unwrap();
-				let tag = format!("{}:{}:{}:", entry.tag, slot.name(), slot_option.name());
+				let tag = format!("{}:{}:", entry.tag, slot_option.name());
 				Some((machine, tag))
 			});
 			let machines_iter = once((self.machine().unwrap(), "".to_string())).chain(machines_iter);
@@ -247,6 +247,7 @@ impl DevicesImagesConfig {
 				machine
 					.devices()
 					.iter()
+					.filter(|device| !device.tag().contains(':'))
 					.map(|device| format!("{}{}", tag, device.tag()))
 					.collect::<Vec<_>>()
 			});

--- a/src/devimageconfig.rs
+++ b/src/devimageconfig.rs
@@ -228,11 +228,7 @@ impl DevicesImagesConfig {
 			return Self::new(info_db);
 		};
 
-		let machine_config = core
-			.machine_configs
-			.dirty
-			.as_ref()
-			.unwrap_or(&core.machine_configs.clean);
+		let machine_config = self.machine_config().unwrap();
 
 		let images = {
 			let machines_iter = core.entries.iter().filter_map(|entry| {

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -606,7 +606,8 @@ mod test {
 		let actual = db
 			.machines()
 			.find(target)
-			.map(|x| (String::from(x.manufacturer()), String::from(x.year())));
+			.map(|x| (String::from(x.manufacturer()), String::from(x.year())))
+			.ok();
 
 		let expected = expected.map(|(manufacturer, year)| (manufacturer.to_string(), year.to_string()));
 		assert_eq!(expected, actual);
@@ -616,8 +617,8 @@ mod test {
 	pub fn machines_find_everything(_index: usize, xml: &str) {
 		let db = InfoDb::from_listxml_output(xml.as_bytes(), |_| false).unwrap().unwrap();
 		for machine in db.machines().iter() {
-			let other_machine = db.machines().find(machine.name());
-			assert_eq!(other_machine.map(|m| m.name()), Some(machine.name()));
+			let other_machine = db.machines().find(machine.name()).unwrap();
+			assert_eq!(other_machine.name(), machine.name());
 		}
 	}
 

--- a/src/mconfig.rs
+++ b/src/mconfig.rs
@@ -53,8 +53,6 @@ enum ThisError {
 	CannotFindSlotOption(String, String, String),
 	#[error("Machine {0:?}: Cannot set option on machine")]
 	CantSetOptionOnMachine(String),
-	#[error("Cannot find machine {0}")]
-	CannotFindMachine(String),
 	#[error("Cannot find device {0}")]
 	CannotFindDevice(String),
 	#[error("Expected tag {0:?} on machine {1:?} to be {2:?} but was {3:?}")]
@@ -126,10 +124,7 @@ impl MachineConfig {
 		machine_name: &str,
 		opts: &[(impl AsRef<str>, Option<impl AsRef<str>>)],
 	) -> Result<Self> {
-		let machine_index = info_db
-			.machines()
-			.find_index(machine_name)
-			.ok_or_else(|| ThisError::CannotFindMachine(machine_name.to_string()))?;
+		let machine_index = info_db.machines().find_index(machine_name)?;
 		Self::from_machine_index_and_slots(info_db, machine_index, opts)
 	}
 

--- a/src/status/validate.rs
+++ b/src/status/validate.rs
@@ -27,7 +27,7 @@ pub fn validate_status(status: &Status, info_db: &InfoDb) -> Result<(), Validati
 }
 
 fn validate_running(running: &Running, info_db: &InfoDb, mut emit: impl FnMut(UpdateXmlProblem)) {
-	if info_db.machines().find(&running.machine_name).is_none() {
+	if info_db.machines().find(&running.machine_name).is_err() {
 		emit(UpdateXmlProblem::UnknownMachine(running.machine_name.clone()));
 	}
 }


### PR DESCRIPTION
These issues could cause:
- Incorrectly identified device (media) tags (e.g. - `rs232:rs232:rs_printer:printout`)
- Devices not appropriate for the current configuration