### PR TITLE
Fixing a failure to handle scenarios where slot options in `-listxml` output referenced non-existent machines

### DIFF
--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -460,6 +460,16 @@ pub struct Object<'a, B> {
 	phantom: PhantomData<B>,
 }
 
+impl<B> Object<'_, B> {
+	pub fn index(&self) -> usize {
+		self.index
+	}
+
+	fn proxy(&self) -> impl PartialEq {
+		(self.db as *const _, self.byte_offset, self.index)
+	}
+}
+
 impl<'a, B> Object<'a, B>
 where
 	B: BinarySerde,
@@ -475,9 +485,11 @@ where
 		let offset = func(self.obj());
 		self.db.string(offset)
 	}
+}
 
-	pub fn index(&self) -> usize {
-		self.index
+impl<B> PartialEq for Object<'_, B> {
+	fn eq(&self, other: &Self) -> bool {
+		self.proxy() == other.proxy()
 	}
 }
 


### PR DESCRIPTION
Machine Configurations will now ignore default slot options if the slot device machine does not exist

This is ultimately a work around for a MAME bug being fixed (25fa1ff89a95cde45eda378e177806ef80dffa04) for MAME 0.276.  But we're guarding against it anyways.
