### PR TITLE
General improvements to our usage of the `tracing` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,6 +3265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4352,8 +4361,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -4364,8 +4382,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -5479,10 +5503,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ tracing = { version = "0.1.41", features = [
     "max_level_trace",
     "release_max_level_info",
 ] }
-tracing-subscriber = "0.3.19"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 slint = { git = "https://github.com/npwoods/slint.git", rev = "69b43975246dbbf4cbba4372b98dde1ce64dca79", features = [
     "raw-window-handle-06",
 ] }

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -77,8 +77,8 @@ use crate::ui::AboutDialog;
 use crate::ui::AppWindow;
 use crate::ui::ReportIssue;
 
-const LOG_COMMANDS: Level = Level::DEBUG;
-const LOG_PREFS: Level = Level::DEBUG;
+const LOG_COMMANDS: Level = Level::INFO;
+const LOG_PREFS: Level = Level::INFO;
 
 const SOUND_ATTENUATION_OFF: i32 = -32;
 const SOUND_ATTENUATION_ON: i32 = 0;

--- a/src/childwindow.rs
+++ b/src/childwindow.rs
@@ -11,7 +11,7 @@ use winit::window::WindowAttributes;
 
 use crate::platform::WindowExt;
 
-const LOG: Level = Level::TRACE;
+const LOG: Level = Level::DEBUG;
 
 pub struct ChildWindow(Option<winit::window::Window>);
 

--- a/src/dialogs/paths.rs
+++ b/src/dialogs/paths.rs
@@ -26,7 +26,7 @@ use crate::prefs::pathtype::PathType;
 use crate::ui::MagicListViewItem;
 use crate::ui::PathsDialog;
 
-const LOG: Level = Level::DEBUG;
+const LOG: Level = Level::INFO;
 
 struct State {
 	dialog_weak: Weak<PathsDialog>,

--- a/src/info/build.rs
+++ b/src/info/build.rs
@@ -27,7 +27,7 @@ use crate::xml::XmlElement;
 use crate::xml::XmlEvent;
 use crate::xml::XmlReader;
 
-const LOG: Level = Level::TRACE;
+const LOG: Level = Level::DEBUG;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Phase {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ use guiutils::MenuingType;
 use muda::Menu;
 use slint::ComponentHandle;
 use structopt::StructOpt;
-use tracing::Level;
+use tracing_subscriber::EnvFilter;
 
 use crate::appwindow::AppArgs;
 use crate::diagnostics::info_db_from_xml_file;
@@ -57,7 +57,7 @@ struct Opt {
 	process_xml: Option<PathBuf>,
 
 	#[cfg_attr(feature = "diagnostics", structopt(long))]
-	log_level: Option<Level>,
+	log: Option<String>,
 
 	#[cfg_attr(feature = "diagnostics", structopt(long))]
 	no_capture_mame_stderr: bool,
@@ -74,10 +74,10 @@ fn main() {
 	let opts = Opt::from_args();
 
 	// set up logging
-	tracing_subscriber::fmt()
-		.with_max_level(opts.log_level.unwrap_or(Level::INFO))
-		.with_target(false)
-		.init();
+	let log = opts.log.or_else(|| std::env::var("RUST_ENV").ok());
+	if let Some(log) = log {
+		tracing_subscriber::fmt().with_env_filter(EnvFilter::new(log)).init();
+	}
 
 	// are we doing diagnostics
 	if let Some(path) = opts.process_xml {

--- a/src/mconfig.rs
+++ b/src/mconfig.rs
@@ -14,7 +14,7 @@ use crate::info::Machine;
 use crate::info::Slot;
 use crate::info::View;
 
-const LOG: Level = Level::DEBUG;
+const LOG: Level = Level::INFO;
 
 #[derive(Clone, Debug)]
 pub struct MachineConfig {

--- a/src/models/itemstable.rs
+++ b/src/models/itemstable.rs
@@ -42,7 +42,7 @@ use crate::software::Software;
 use crate::software::SoftwareList;
 use crate::software::SoftwareListDispenser;
 
-const LOG: Level = Level::TRACE;
+const LOG: Level = Level::DEBUG;
 
 pub struct ItemsTableModel {
 	info_db: RefCell<Option<Rc<InfoDb>>>,

--- a/src/prefs/mod.rs
+++ b/src/prefs/mod.rs
@@ -41,7 +41,7 @@ use crate::prefs::preflight::preflight_checks;
 use crate::prefs::var::resolve_path;
 use crate::prefs::var::resolve_paths_string;
 
-const LOG: Level = Level::DEBUG;
+const LOG: Level = Level::INFO;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/src/prefs/preflight.rs
+++ b/src/prefs/preflight.rs
@@ -8,7 +8,7 @@ use tracing::event;
 
 use crate::prefs::PreflightProblem;
 
-const LOG: Level = Level::DEBUG;
+const LOG: Level = Level::INFO;
 
 pub fn preflight_checks<T>(
 	mame_executable_path: Option<&Path>,

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -32,7 +32,7 @@ use crate::runtime::args::MameArguments;
 use crate::status::Update;
 use crate::threadlocalbubble::ThreadLocalBubble;
 
-const LOG: Level = Level::DEBUG;
+const LOG: Level = Level::INFO;
 
 #[derive(thiserror::Error, Debug)]
 enum ThisError {

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -18,7 +18,7 @@ use crate::status::parse::parse_update;
 use crate::status::validate::validate_status;
 use crate::version::MameVersion;
 
-const LOG: Level = Level::TRACE;
+const LOG: Level = Level::DEBUG;
 
 #[derive(Clone)]
 pub struct Status {

--- a/src/status/parse.rs
+++ b/src/status/parse.rs
@@ -21,7 +21,7 @@ use crate::xml::XmlElement;
 use crate::xml::XmlEvent;
 use crate::xml::XmlReader;
 
-const LOG: Level = Level::TRACE;
+const LOG: Level = Level::DEBUG;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Phase {

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -14,7 +14,7 @@ use quick_xml::name::QName;
 use tracing::Level;
 use tracing::event;
 
-const LOG: Level = Level::TRACE;
+const LOG: Level = Level::DEBUG;
 
 /// quick-xml events are at a slightly different granularity than what we would prefer
 #[derive(Debug)]


### PR DESCRIPTION
Learned a bit more about best practices:
* Now using `EnvFilter` for increased flexibility
* Changed `src/runtime/session.rs` to use tracing spans
* Changed logging levels (`TRACE` ==> `DEBUG`, `DEBUG` ==> `INFO`)