### PR TITLE
Adding support for toggling full screen

### DIFF
--- a/src/appcommand.rs
+++ b/src/appcommand.rs
@@ -29,6 +29,7 @@ pub enum AppCommand {
 	// Options menu
 	OptionsThrottleRate(f32),
 	OptionsToggleWarp,
+	OptionsToggleFullScreen,
 	OptionsToggleSound,
 	#[strum(props(MinimumMame = "0.274"))]
 	OptionsClassic,

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -300,6 +300,7 @@ pub fn create(args: AppArgs) -> AppWindow {
 		let physical_size = LogicalSize::from(*window_size).to_physical(app_window.window().scale_factor());
 		app_window.window().set_size(physical_size);
 	}
+	app_window.window().set_fullscreen(preferences.is_fullscreen);
 
 	// create the model
 	let model = AppModel {
@@ -730,6 +731,7 @@ fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 			let app_window = model.app_window();
 			let window = app_window.window();
 			let is_fullscreen = window.is_fullscreen();
+			model.preferences.borrow_mut().is_fullscreen = !is_fullscreen;
 			window.set_fullscreen(!is_fullscreen);
 		}
 		AppCommand::OptionsToggleSound => {

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -628,7 +628,7 @@ fn create_menu_bar() -> Menu {
 					],
 				)
 				.unwrap(),
-				&MenuItem::new("Full Screen", false, accel("F11")),
+				&CheckMenuItem::with_id(AppCommand::OptionsToggleFullScreen,"Full Screen", true, false, accel("F11")),
 				&CheckMenuItem::with_id(AppCommand::OptionsToggleSound, "Sound", false, false,None),
 				&MenuItem::new("Cheats...", false, None),
 				&MenuItem::with_id(AppCommand::OptionsClassic,"Classic MAME Menu", false, None),
@@ -725,6 +725,12 @@ fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 				.map(|r| r.is_throttled)
 				.unwrap_or_default();
 			model.issue_command(MameCommand::Throttled(!is_throttled));
+		}
+		AppCommand::OptionsToggleFullScreen => {
+			let app_window = model.app_window();
+			let window = app_window.window();
+			let is_fullscreen = window.is_fullscreen();
+			window.set_fullscreen(!is_fullscreen);
 		}
 		AppCommand::OptionsToggleSound => {
 			if let Some(sound_attenuation) = model
@@ -1025,6 +1031,7 @@ fn update_menus(model: &AppModel) {
 		.map(|r| r.sound_attenuation > SOUND_ATTENUATION_OFF)
 		.unwrap_or_default();
 	let can_refresh_info_db = has_mame_executable && !state.is_building_infodb();
+	let is_fullscreen = model.app_window().window().is_fullscreen();
 
 	// update the menu bar
 	model.menu_bar.update(|id| {
@@ -1037,6 +1044,7 @@ fn update_menus(model: &AppModel) {
 			Ok(AppCommand::FileResetHard) => (Some(is_running), None),
 			Ok(AppCommand::OptionsThrottleRate(x)) => (Some(is_running), Some(Some(x) == throttle_rate)),
 			Ok(AppCommand::OptionsToggleWarp) => (Some(is_running), Some(!is_throttled)),
+			Ok(AppCommand::OptionsToggleFullScreen) => (None, Some(is_fullscreen)),
 			Ok(AppCommand::OptionsToggleSound) => (Some(is_running), Some(is_sound_enabled)),
 			Ok(AppCommand::OptionsClassic) => (Some(is_running), None),
 			Ok(AppCommand::HelpRefreshInfoDb) => (Some(can_refresh_info_db), None),

--- a/src/prefs/mod.rs
+++ b/src/prefs/mod.rs
@@ -53,6 +53,9 @@ pub struct Preferences {
 	pub window_size: Option<PrefsSize>,
 
 	#[serde(default)]
+	pub is_fullscreen: bool,
+
+	#[serde(default)]
 	pub items_columns: Vec<PrefsColumn>,
 
 	#[serde(default)]

--- a/src/prefs/prefs_fresh.json
+++ b/src/prefs/prefs_fresh.json
@@ -5,6 +5,7 @@
       "$(MAMEPATH)\\plugins"
     ]
   },
+  "isFullscreen": false,
   "itemsColumns": [
     {
       "type": "name",


### PR DESCRIPTION
Limitations:
- In full screen mode, the menu bar is invisible (but present)
- For some reason the menu hot keys are not working
    
This will likely be easier when Slint's menu bar support is up to snuff