### PR TITLE
Recognizing `<device>` tags with multiple `interface` declarations in `-listxml` output

### DIFF
--- a/src/info/binary.rs
+++ b/src/info/binary.rs
@@ -79,7 +79,7 @@ pub struct Device {
 	pub type_strindex: u32,
 	pub tag_strindex: u32,
 	pub mandatory: bool,
-	pub interface_strindex: u32,
+	pub interfaces_strindex: u32,
 	pub extensions_strindex: u32,
 }
 

--- a/src/info/build.rs
+++ b/src/info/build.rs
@@ -190,12 +190,13 @@ impl State {
 				let type_strindex = self.strings.lookup(&device_type.unwrap_or_default());
 				let tag_strindex = self.strings.lookup(&tag);
 				let mandatory = mandatory.map(parse_mame_bool).transpose()?.unwrap_or(false);
-				let interface_strindex = self.strings.lookup(&interface.unwrap_or_default());
+				let interfaces = interface.unwrap_or_default().split(',').sorted().join("\0");
+				let interfaces_strindex = self.strings.lookup(&interfaces);
 				let device = binary::Device {
 					type_strindex,
 					tag_strindex,
 					mandatory,
-					interface_strindex,
+					interfaces_strindex,
 					extensions_strindex: 0,
 				};
 				self.devices.push(device);
@@ -691,7 +692,7 @@ where
 }
 
 pub fn calculate_sizes_hash() -> u64 {
-	let multiplicand = 4729; // arbitrary prime number
+	let multiplicand = 4733; // arbitrary prime number
 	[
 		binary::Header::SERIALIZED_SIZE,
 		binary::Machine::SERIALIZED_SIZE,

--- a/src/info/entities.rs
+++ b/src/info/entities.rs
@@ -132,8 +132,8 @@ impl<'a> Device<'a> {
 		self.obj().mandatory
 	}
 
-	pub fn interface(&self) -> &'a str {
-		self.string(|x| x.interface_strindex)
+	pub fn interfaces(&self) -> impl Iterator<Item = &'a str> + use<'a> {
+		self.string(|x| x.interfaces_strindex).split('\0')
 	}
 
 	pub fn extensions(&self) -> impl Iterator<Item = &'a str> + use<'a> {

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -654,15 +654,17 @@ mod test {
 		assert_eq!(expected, actual);
 	}
 
-	#[test_case(0, include_str!("test_data/listxml_coco.xml"), "coco2b", "ext:fdc:wd17xx:0:525dd", "floppydisk", "floppy_5_25",
+	#[test_case(0, include_str!("test_data/listxml_coco.xml"), "coco2b", "ext:fdc:wd17xx:0:525dd", "floppydisk", &["floppy_5_25"],
 		&["1dd", "86f", "cqi", "cqm", "d77", "d88", "dfi", "dmk", "dsk", "imd", "jvc", "mfi", "mfm", "os9", "sdf", "td0", "vdk"])]
+	#[test_case(1, include_str!("test_data/listxml_c64.xml"), "c64", "exp", "cartridge", &["c64_cart" ,"vic10_cart"],
+		&["80", "a0", "crt", "e0"])]
 	pub fn devices(
 		_index: usize,
 		xml: &str,
 		machine: &str,
 		device_tag: &str,
 		expected_type: &str,
-		expected_interface: &str,
+		expected_interfaces: &[&str],
 		expected_extensions: &[&str],
 	) {
 		let db = InfoDb::from_listxml_output(xml.as_bytes(), |_| false).unwrap().unwrap();
@@ -678,13 +680,13 @@ mod test {
 			.unwrap();
 		let actual = (
 			device.device_type().to_string(),
-			device.interface().to_string(),
+			device.interfaces().map(|x| x.to_string()).collect::<Vec<_>>(),
 			device.extensions().map(|x| x.to_string()).collect::<Vec<_>>(),
 		);
 
 		let expected = (
 			expected_type.to_string(),
-			expected_interface.to_string(),
+			expected_interfaces.iter().map(|x| x.to_string()).collect::<Vec<_>>(),
 			expected_extensions.iter().map(|x| x.to_string()).collect::<Vec<_>>(),
 		);
 		assert_eq!(expected, actual);

--- a/src/models/itemstable.rs
+++ b/src/models/itemstable.rs
@@ -324,7 +324,7 @@ impl ItemsTableModel {
 								machine
 									.devices()
 									.iter()
-									.find(|dev| part.interface.as_ref() == dev.interface())
+									.find(|dev| dev.interfaces().any(|x| x == part.interface.as_ref()))
 									.map(|dev| (Arc::<str>::from(dev.tag()), software.name.clone()))
 									.ok_or(())
 							})


### PR DESCRIPTION
An example from C64:  `<device type="cartridge" tag=":exp" interface="c64_cart,vic10_cart">`