### PR TITLE
Ensuring that the MAME child window is placed below the menu bar

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -370,7 +370,8 @@ pub fn create(args: AppArgs) -> AppWindow {
 	app_window.on_size_changed(move || {
 		if let Some(model) = model_weak.upgrade() {
 			// set the child window size
-			model.child_window.update(model.app_window().window(), 0.0);
+			let top = model.app_window().invoke_menubar_height();
+			model.child_window.update(model.app_window().window(), top);
 		}
 	});
 

--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -47,11 +47,18 @@ export component AppWindow inherits Window {
     callback menu-item-activated(string, string);
     callback menu-item-command(string);
     in property <[string]> menu-items-builtin-collections;
+    public function menubar-height() -> length {
+        return hbox.absolute-position.y;
+    }
+
+    // collections context menu
     in-out property <CollectionContextMenuInfo> collection-context-menu-info;
     public function show-collection-context-menu(info: CollectionContextMenuInfo, point: Point) {
         self.collection-context-menu-info = info;
         collection-context-menu.show(point);
     }
+
+    // items context menu
     in-out property <ItemContextMenuInfo> item-context-menu-info;
     public function show-item-context-menu(info: ItemContextMenuInfo, point: Point) {
         self.item-context-menu-info = info;


### PR DESCRIPTION
This is in practice not an issue on Windows, where the menu bar is not in the window's client area