### PR TITLE
Changing tracing to use `info!()` and `debug!()` directly

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -21,8 +21,8 @@ use slint::invoke_from_event_loop;
 use slint::quit_event_loop;
 use slint::spawn_local;
 use strum::EnumString;
-use tracing::Level;
-use tracing::event;
+use tracing::debug;
+use tracing::info;
 
 use crate::appcommand::AppCommand;
 use crate::appstate::AppState;
@@ -75,10 +75,6 @@ use crate::status::Status;
 use crate::ui::AboutDialog;
 use crate::ui::AppWindow;
 use crate::ui::ReportIssue;
-
-const LOG_COMMANDS: Level = Level::INFO;
-const LOG_PREFS: Level = Level::INFO;
-const LOG_MENUING: Level = Level::DEBUG;
 
 const SOUND_ATTENUATION_OFF: i32 = -32;
 const SOUND_ATTENUATION_ON: i32 = 0;
@@ -165,22 +161,22 @@ impl AppModel {
 		// react to all of the possible changes
 		self.update_state(|state| state.update_paths(&prefs.paths));
 		if prefs.collections != old_prefs.collections {
-			event!(LOG_PREFS, "modify_prefs(): prefs.collection changed");
+			info!("modify_prefs(): prefs.collection changed");
 			let info_db = self.state.borrow().info_db().cloned();
 			self.with_collections_view_model(|x| x.update(info_db, &prefs.collections));
 		}
 		if prefs.current_history_entry() != old_prefs.current_history_entry()
 			|| prefs.current_collection() != old_prefs.current_collection()
 		{
-			event!(LOG_PREFS, "modify_prefs(): current history_entry/collection] changed");
+			info!("modify_prefs(): current history_entry/collection] changed");
 			update_ui_for_current_history_item(self);
 		}
 		if prefs.items_columns != old_prefs.items_columns {
-			event!(LOG_PREFS, "modify_prefs(): items_columns changed");
+			info!("modify_prefs(): items_columns changed");
 			update_ui_for_sort_changes(self);
 		}
 		if prefs.paths.software_lists != old_prefs.paths.software_lists {
-			event!(LOG_PREFS, "modify_prefs(): paths.software_lists changed");
+			info!("modify_prefs(): paths.software_lists changed");
 			software_paths_updated(self);
 		}
 	}
@@ -646,12 +642,12 @@ fn menu_item_info(parent_title: Option<&str>, title: &str) -> (Option<AppCommand
 		// Anything else
 		(_, _) => (None, None),
 	};
-	event!(LOG_MENUING, parent_title=?parent_title, title=?title, command=?command, accelerator=?accelerator, "menu_item_info");
+	debug!(parent_title=?parent_title, title=?title, command=?command, accelerator=?accelerator, "menu_item_info");
 	(command, accelerator.and_then(accel))
 }
 
 fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
-	event!(LOG_COMMANDS, command=?&command, "handle_command()");
+	info!(command=?&command, "handle_command()");
 	match command {
 		AppCommand::FileStop => {
 			model.issue_command(MameCommand::Stop);

--- a/src/childwindow.rs
+++ b/src/childwindow.rs
@@ -5,13 +5,10 @@ use raw_window_handle::RawWindowHandle;
 use slint::PhysicalPosition;
 use slint::PhysicalSize;
 use slint::Window;
-use tracing::Level;
-use tracing::event;
+use tracing::debug;
 use winit::window::WindowAttributes;
 
 use crate::platform::WindowExt;
-
-const LOG: Level = Level::DEBUG;
 
 #[derive(thiserror::Error, Debug)]
 enum ThisError {
@@ -78,7 +75,7 @@ impl ChildWindow {
 		};
 		let size = container.size();
 		let size = PhysicalSize::new(size.width, size.height - (position.y as u32));
-		event!(LOG, position=?position, size=?size, "ChildWindow::update()");
+		debug!(position=?position, size=?size, "ChildWindow::update()");
 
 		match &self.0 {
 			ChildWindowInternal::Winit(window) => {

--- a/src/dialogs/paths.rs
+++ b/src/dialogs/paths.rs
@@ -14,8 +14,7 @@ use slint::SharedString;
 use slint::VecModel;
 use slint::Weak;
 use slint::spawn_local;
-use tracing::Level;
-use tracing::event;
+use tracing::info;
 
 use crate::dialogs::SingleResult;
 use crate::dialogs::file::choose_path_by_type_dialog;
@@ -25,8 +24,6 @@ use crate::prefs::PrefsPaths;
 use crate::prefs::pathtype::PathType;
 use crate::ui::MagicListViewItem;
 use crate::ui::PathsDialog;
-
-const LOG: Level = Level::INFO;
 
 struct State {
 	dialog_weak: Weak<PathsDialog>,
@@ -193,8 +190,7 @@ async fn browse_clicked(state: Rc<State>) {
 		.as_ref()
 		.and_then(|path| state.paths.borrow().resolve(path));
 	let resolved_existing_path = resolved_existing_path.as_deref();
-	event!(
-		LOG,
+	info!(
 		existing_path=?existing_path,
 		resolved_existing_path=?resolved_existing_path,
 		"browse_clicked()"

--- a/src/mconfig.rs
+++ b/src/mconfig.rs
@@ -5,16 +5,13 @@ use std::rc::Rc;
 use anyhow::Error;
 use anyhow::Result;
 use more_asserts::assert_le;
-use tracing::Level;
-use tracing::event;
+use tracing::info;
 
 use crate::info::Device;
 use crate::info::InfoDb;
 use crate::info::Machine;
 use crate::info::Slot;
 use crate::info::View;
-
-const LOG: Level = Level::INFO;
 
 #[derive(Clone, Debug)]
 pub struct MachineConfig {
@@ -209,7 +206,7 @@ impl MachineConfig {
 	}
 
 	pub fn set_slot_option(&self, tag: &str, new_option_name: Option<&str>) -> Result<Option<Self>> {
-		event!(LOG, tag=?tag, new_option_name=?new_option_name, "MachineConfig::set_option()");
+		info!(tag=?tag, new_option_name=?new_option_name, "MachineConfig::set_option()");
 
 		let machine = self.machine();
 		let changes = match self.traverse_tag(tag)? {

--- a/src/models/itemstable.rs
+++ b/src/models/itemstable.rs
@@ -20,8 +20,7 @@ use slint::ModelTracker;
 use slint::SharedString;
 use slint::StandardListViewItem;
 use slint::VecModel;
-use tracing::Level;
-use tracing::event;
+use tracing::debug;
 use unicase::UniCase;
 
 use crate::appcommand::AppCommand;
@@ -41,8 +40,6 @@ use crate::software::Software;
 use crate::software::SoftwareList;
 use crate::software::SoftwareListDispenser;
 use crate::ui::ItemContextMenuInfo;
-
-const LOG: Level = Level::DEBUG;
 
 pub struct ItemsTableModel {
 	info_db: RefCell<Option<Rc<InfoDb>>>,
@@ -425,8 +422,7 @@ impl ItemsTableModel {
 			self.sorting.set(sorting);
 		}
 
-		event!(
-			LOG,
+		debug!(
 			search=?search,
 			sorting=?sorting,
 			search_changed=?search_changed,

--- a/src/prefs/mod.rs
+++ b/src/prefs/mod.rs
@@ -28,8 +28,7 @@ use serde::Serialize;
 use slint::LogicalSize;
 use strum::EnumProperty;
 use strum_macros::EnumString;
-use tracing::Level;
-use tracing::event;
+use tracing::info;
 
 use crate::history::History;
 use crate::icon::Icon;
@@ -39,8 +38,6 @@ use crate::prefs::pathtype::PickType;
 use crate::prefs::preflight::preflight_checks;
 use crate::prefs::var::resolve_path;
 use crate::prefs::var::resolve_paths_string;
-
-const LOG: Level = Level::INFO;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -347,14 +344,14 @@ impl Preferences {
 		// try to load the preferences
 		let path = prefs_filename(prefs_path, PREFS)?;
 		let result = load_prefs(&path);
-		event!(LOG, "result" = ?result.as_ref().map(|_| ()), "Preferences::load()");
+		info!("result" = ?result.as_ref().map(|_| ()), "Preferences::load()");
 
 		// did we error?
 		if result.is_err() {
 			// we did; back up this file
 			if let Ok(renamed) = prefs_filename(prefs_path, PREFS_BACKUP) {
 				let rc = rename(&path, &renamed);
-				event!(LOG, path=?path, renamed=?renamed, rc=?rc, "Preferences::load()");
+				info!(path=?path, renamed=?renamed, rc=?rc, "Preferences::load()");
 			}
 		}
 

--- a/src/prefs/preflight.rs
+++ b/src/prefs/preflight.rs
@@ -3,12 +3,9 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use is_executable::IsExecutable;
-use tracing::Level;
-use tracing::event;
+use tracing::info;
 
 use crate::prefs::PreflightProblem;
-
-const LOG: Level = Level::INFO;
 
 pub fn preflight_checks<T>(
 	mame_executable_path: Option<&Path>,
@@ -60,7 +57,7 @@ where
 		problems.push(PreflightProblem::NoPluginsPaths);
 	}
 
-	event!(LOG, "preflight_checks(): problems={problems:?}");
+	info!(problems=?problems, "preflight_checks()");
 	problems
 }
 

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -9,16 +9,13 @@ use std::sync::Arc;
 use anyhow::Result;
 use serde::Deserialize;
 use serde::Serialize;
-use tracing::Level;
-use tracing::event;
+use tracing::debug;
 
 use crate::debugstr::DebugString;
 use crate::info::InfoDb;
 use crate::status::parse::parse_update;
 use crate::status::validate::validate_status;
 use crate::version::MameVersion;
-
-const LOG: Level = Level::DEBUG;
 
 #[derive(Clone)]
 pub struct Status {
@@ -80,7 +77,7 @@ impl Status {
 				slots,
 			}
 		});
-		event!(LOG, running=?running, "Status::merge()");
+		debug!(running=?running, "Status::merge()");
 		Self {
 			running,
 			build: update.build,

--- a/src/status/parse.rs
+++ b/src/status/parse.rs
@@ -4,8 +4,7 @@ use std::sync::Arc;
 
 use anyhow::Error;
 use anyhow::Result;
-use tracing::Level;
-use tracing::event;
+use tracing::debug;
 
 use crate::parse::normalize_tag;
 use crate::parse::parse_mame_bool;
@@ -20,8 +19,6 @@ use crate::version::MameVersion;
 use crate::xml::XmlElement;
 use crate::xml::XmlEvent;
 use crate::xml::XmlReader;
-
-const LOG: Level = Level::DEBUG;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Phase {
@@ -68,8 +65,7 @@ impl State {
 					evt.find_attributes([b"romname", b"paused", b"app_build", b"app_version"])?;
 				let machine_name = romname.unwrap_or_default().to_string();
 				let is_paused = is_paused.map(|x| parse_mame_bool(x.as_ref())).transpose()?;
-				event!(
-					LOG,
+				debug!(
 					machine_name=?machine_name,
 					is_paused=?is_paused,
 					"status State::handle_start()"
@@ -90,8 +86,7 @@ impl State {
 				let throttle_rate = throttle_rate.map(|x| x.parse::<f32>()).transpose()?;
 				let is_recording = is_recording.map(parse_mame_bool).transpose()?;
 
-				event!(
-					LOG,
+				debug!(
 					throttled=?throttled,
 					throttle_rate=?throttle_rate,
 					"status State::handle_start()"

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -11,10 +11,7 @@ use quick_xml::escape::unescape;
 use quick_xml::events::BytesStart;
 use quick_xml::events::Event;
 use quick_xml::name::QName;
-use tracing::Level;
-use tracing::event;
-
-const LOG: Level = Level::DEBUG;
+use tracing::debug;
 
 /// quick-xml events are at a slightly different granularity than what we would prefer
 #[derive(Debug)]
@@ -61,7 +58,7 @@ where
 			self.set_done();
 		}
 
-		event!(LOG, result=?result, "XmlReader::next()");
+		debug!(result=?result, "XmlReader::next()");
 		result
 	}
 


### PR DESCRIPTION
The pattern of having `const LOG: Level::XYZ` is not a useful pattern, and this change brings things more in line with best practice.