### PR TITLE
Fixing sporadic keyboard input problem by disabling the child window

### DIFF
--- a/src/childwindow/winit.rs
+++ b/src/childwindow/winit.rs
@@ -39,6 +39,9 @@ impl WinitChildWindow {
 impl ChildWindowImpl for WinitChildWindow {
 	fn set_visible(&self, is_visible: bool) {
 		self.0.set_visible(is_visible);
+
+		#[cfg(target_os = "windows")]
+		winit::platform::windows::WindowExtWindows::set_enable(&self.0, is_visible);
 	}
 
 	fn update(&self, position: dpi::PhysicalPosition<u32>, size: dpi::PhysicalSize<u32>) {


### PR DESCRIPTION
Specifically, this ensures that the child window is disabled if not visible and active

The fix is Windows-specific