### PR TITLE
Retiring usage of the `derive-enum-all-values` crate in favor of `strum`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,6 @@ dependencies = [
  "cpp",
  "cpp_build",
  "default-ext",
- "derive-enum-all-values",
  "dirs",
  "dpi",
  "easy-ext",
@@ -1403,17 +1402,6 @@ name = "default-ext"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2078c7996bb61be756e89ecda0557d4bfdadc3f66a5ae8a3ea698b21b8af8a98"
-
-[[package]]
-name = "derive-enum-all-values"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9819d820ecd7f0c6644d01c5a083b030379fb43ff23af8c235b569126d9b7499"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
 
 [[package]]
 name = "derive_more"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ smallvec = "1.15.0"
 derive-enum-all-values = "0.1.0"
 default-ext = "0.1.0"
 num = "0.4.3"
-strum = "0.27.1"
+strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"
 structopt = "0.3.26"
 win32job = "2.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ levenshtein = "1.0.5"
 unicase = "2.8.1"
 binary-search = "0.1.2"
 smallvec = "1.15.0"
-derive-enum-all-values = "0.1.0"
 default-ext = "0.1.0"
 num = "0.4.3"
 strum = { version = "0.27.1", features = ["derive"] }

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -21,6 +21,7 @@ use slint::invoke_from_event_loop;
 use slint::quit_event_loop;
 use slint::spawn_local;
 use strum::EnumString;
+use strum::IntoEnumIterator;
 use tracing::debug;
 use tracing::info;
 
@@ -315,10 +316,8 @@ pub fn create(args: AppArgs) -> AppWindow {
 
 	// prepare the menu bar
 	app_window.set_menu_items_builtin_collections(ModelRc::new(VecModel::from(
-		BuiltinCollection::all_values()
-			.iter()
-			.map(BuiltinCollection::to_string)
-			.map(SharedString::from)
+		BuiltinCollection::iter()
+			.map(|x| SharedString::from(x.to_string()))
 			.collect::<Vec<_>>(),
 	)));
 	let app_window_weak = app_window.as_weak();
@@ -769,10 +768,7 @@ fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 				let fut = async move {
 					let model = model_clone.as_ref();
 					let title = "Record Movie";
-					let file_types = MovieFormat::all_values()
-						.iter()
-						.map(MovieFormat::to_string)
-						.collect::<Vec<_>>();
+					let file_types = MovieFormat::iter().map(|x| x.to_string()).collect::<Vec<_>>();
 					let file_types = file_types.iter().map(|ext| (None, ext.as_str())).collect::<Vec<_>>();
 					let initial_file = model.suggested_initial_save_filename(&MovieFormat::default().to_string());
 					if let Some(filename) =

--- a/src/dialogs/messagebox.rs
+++ b/src/dialogs/messagebox.rs
@@ -21,7 +21,7 @@ pub trait MessageBoxDefaults {
 		Self: std::marker::Sized;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, AllValues, strum_macros::Display)]
+#[derive(Debug, Clone, Copy, PartialEq, AllValues, strum::Display)]
 pub enum OkOnly {
 	#[strum(to_string = "OK")]
 	Ok,
@@ -41,7 +41,7 @@ impl MessageBoxDefaults for OkOnly {
 	}
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, AllValues, strum_macros::Display)]
+#[derive(Debug, Clone, Copy, PartialEq, AllValues, strum::Display)]
 pub enum OkCancel {
 	#[strum(to_string = "OK")]
 	Ok,

--- a/src/dialogs/messagebox.rs
+++ b/src/dialogs/messagebox.rs
@@ -1,27 +1,24 @@
 use std::default::Default;
 use std::fmt::Display;
 
-use derive_enum_all_values::AllValues;
 use slint::CloseRequestResponse;
 use slint::ComponentHandle;
 use slint::ModelRc;
 use slint::SharedString;
 use slint::VecModel;
 use slint::Weak;
+use strum::VariantArray;
 
 use crate::dialogs::SingleResult;
 use crate::guiutils::modal::Modal;
 use crate::ui::MessageBoxDialog;
 
-pub trait MessageBoxDefaults {
+pub trait MessageBoxDefaults: VariantArray {
 	fn accept() -> Self;
 	fn abort() -> Self;
-	fn all_values() -> &'static [Self]
-	where
-		Self: std::marker::Sized;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, AllValues, strum::Display)]
+#[derive(Debug, Clone, Copy, PartialEq, VariantArray, strum::Display)]
 pub enum OkOnly {
 	#[strum(to_string = "OK")]
 	Ok,
@@ -35,13 +32,9 @@ impl MessageBoxDefaults for OkOnly {
 	fn abort() -> Self {
 		Self::Ok
 	}
-
-	fn all_values() -> &'static [Self] {
-		Self::all_values()
-	}
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, AllValues, strum::Display)]
+#[derive(Debug, Clone, Copy, PartialEq, VariantArray, strum::Display)]
 pub enum OkCancel {
 	#[strum(to_string = "OK")]
 	Ok,
@@ -56,10 +49,6 @@ impl MessageBoxDefaults for OkCancel {
 
 	fn abort() -> Self {
 		Self::Cancel
-	}
-
-	fn all_values() -> &'static [Self] {
-		Self::all_values()
 	}
 }
 
@@ -76,7 +65,7 @@ where
 	let message = message.into();
 
 	// get the values
-	let values = T::all_values();
+	let values = T::VARIANTS;
 	let value_texts = values.iter().map(|x| format!("{}", x).into()).collect::<Vec<_>>();
 
 	// determine accept/abort indexes

--- a/src/dialogs/paths.rs
+++ b/src/dialogs/paths.rs
@@ -14,6 +14,8 @@ use slint::SharedString;
 use slint::VecModel;
 use slint::Weak;
 use slint::spawn_local;
+use strum::IntoEnumIterator;
+use strum::VariantArray;
 use tracing::info;
 
 use crate::dialogs::SingleResult;
@@ -56,10 +58,7 @@ pub async fn dialog_paths(
 	let state = Rc::new(state);
 
 	// set up the "path labels" combo box
-	let path_labels = PathType::all_values()
-		.iter()
-		.map(|x| format!("{}", *x).into())
-		.collect::<Vec<_>>();
+	let path_labels = PathType::iter().map(|x| x.to_string().into()).collect::<Vec<_>>();
 	let path_labels = VecModel::from(path_labels);
 	let path_labels = ModelRc::new(path_labels);
 	modal.dialog().set_path_labels(path_labels);
@@ -113,7 +112,7 @@ pub async fn dialog_paths(
 
 	// set the index on the path type dropdown
 	let path_label_index = path_type
-		.and_then(|path_type| PathType::all_values().iter().position(|&x| x == path_type))
+		.and_then(|path_type| PathType::iter().position(|x| x == path_type))
 		.unwrap_or_default();
 	if path_label_index != 0 {
 		let path_label_index = i32::try_from(path_label_index).unwrap();
@@ -152,7 +151,7 @@ fn path_type(dialog: &PathsDialog) -> PathType {
 		.get_path_label_index()
 		.try_into()
 		.ok()
-		.and_then(|x: usize| PathType::all_values().get(x))
+		.and_then(|x: usize| PathType::VARIANTS.get(x))
 		.cloned()
 		.unwrap_or_default()
 }

--- a/src/info/binary.rs
+++ b/src/info/binary.rs
@@ -1,6 +1,6 @@
 use binary_serde::BinarySerde;
 use serde::Deserialize;
-use strum_macros::EnumString;
+use strum::EnumString;
 
 pub trait Fixup {
 	fn identify_machine_indexes(&mut self) -> impl IntoIterator<Item = &mut u32> {

--- a/src/models/itemstable.rs
+++ b/src/models/itemstable.rs
@@ -577,7 +577,7 @@ fn software_folder_item(dispenser: &mut SoftwareListDispenser, item: &PrefsSoftw
 }
 
 /// Sometimes, the items view is empty - we can (try to) report why
-#[derive(Clone, Copy, Debug, strum_macros::Display)]
+#[derive(Clone, Copy, Debug, strum::Display)]
 pub enum EmptyReason {
 	#[strum(to_string = "BletchMAME needs a working MAME to function")]
 	NoInfoDb,

--- a/src/prefs/mod.rs
+++ b/src/prefs/mod.rs
@@ -27,7 +27,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use slint::LogicalSize;
 use strum::EnumProperty;
-use strum_macros::EnumString;
+use strum::EnumString;
 use tracing::info;
 
 use crate::history::History;
@@ -157,7 +157,7 @@ fn access_paths(path_type: PathType) -> (fn(&PrefsPaths) -> &[String], PathsStor
 	}
 }
 
-#[derive(AllValues, Copy, Clone, Debug, strum_macros::Display, EnumString, EnumProperty)]
+#[derive(AllValues, Copy, Clone, Debug, strum::Display, EnumString, EnumProperty)]
 pub enum PreflightProblem {
 	#[strum(to_string = "No MAME executable path specified", props(ProblemType = "MAME Executable"))]
 	NoMameExecutablePath,
@@ -224,7 +224,7 @@ pub enum SortOrder {
 	Descending,
 }
 
-#[derive(AllValues, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, strum_macros::Display)]
+#[derive(AllValues, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, strum::Display)]
 #[serde(rename_all = "camelCase")]
 pub enum ColumnType {
 	#[strum(to_string = "Name")]
@@ -275,9 +275,7 @@ impl PrefsCollection {
 	}
 }
 
-#[derive(
-	AllValues, Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, strum_macros::Display, EnumString,
-)]
+#[derive(AllValues, Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, strum::Display, EnumString)]
 #[serde(rename_all = "camelCase", tag = "subtype")]
 pub enum BuiltinCollection {
 	#[strum(to_string = "All Systems")]

--- a/src/prefs/mod.rs
+++ b/src/prefs/mod.rs
@@ -20,12 +20,12 @@ use std::str::FromStr;
 
 use anyhow::Error;
 use anyhow::Result;
-use derive_enum_all_values::AllValues;
 use itertools::Itertools;
 use num::clamp;
 use serde::Deserialize;
 use serde::Serialize;
 use slint::LogicalSize;
+use strum::EnumIter;
 use strum::EnumProperty;
 use strum::EnumString;
 use tracing::info;
@@ -157,7 +157,7 @@ fn access_paths(path_type: PathType) -> (fn(&PrefsPaths) -> &[String], PathsStor
 	}
 }
 
-#[derive(AllValues, Copy, Clone, Debug, strum::Display, EnumString, EnumProperty)]
+#[derive(Copy, Clone, Debug, strum::Display, EnumIter, EnumString, EnumProperty)]
 pub enum PreflightProblem {
 	#[strum(to_string = "No MAME executable path specified", props(ProblemType = "MAME Executable"))]
 	NoMameExecutablePath,
@@ -224,7 +224,7 @@ pub enum SortOrder {
 	Descending,
 }
 
-#[derive(AllValues, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, strum::Display)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, strum::Display)]
 #[serde(rename_all = "camelCase")]
 pub enum ColumnType {
 	#[strum(to_string = "Name")]
@@ -275,7 +275,7 @@ impl PrefsCollection {
 	}
 }
 
-#[derive(AllValues, Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, strum::Display, EnumString)]
+#[derive(EnumIter, Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, strum::Display, EnumString)]
 #[serde(rename_all = "camelCase", tag = "subtype")]
 pub enum BuiltinCollection {
 	#[strum(to_string = "All Systems")]

--- a/src/prefs/pathtype.rs
+++ b/src/prefs/pathtype.rs
@@ -1,8 +1,9 @@
-use derive_enum_all_values::AllValues;
 use serde::Deserialize;
 use serde::Serialize;
+use strum::EnumIter;
 use strum::EnumProperty;
 use strum::EnumString;
+use strum::VariantArray;
 
 use crate::prefs::PathsStore;
 use crate::prefs::access_paths;
@@ -10,7 +11,8 @@ use crate::prefs::access_paths;
 const EXE_EXTENSION: &str = if cfg!(target_os = "windows") { "exe" } else { "" };
 
 #[derive(
-	AllValues,
+	EnumIter,
+	VariantArray,
 	Clone,
 	Copy,
 	Debug,

--- a/src/prefs/pathtype.rs
+++ b/src/prefs/pathtype.rs
@@ -2,7 +2,7 @@ use derive_enum_all_values::AllValues;
 use serde::Deserialize;
 use serde::Serialize;
 use strum::EnumProperty;
-use strum_macros::EnumString;
+use strum::EnumString;
 
 use crate::prefs::PathsStore;
 use crate::prefs::access_paths;
@@ -15,7 +15,7 @@ const EXE_EXTENSION: &str = if cfg!(target_os = "windows") { "exe" } else { "" }
 	Copy,
 	Debug,
 	Default,
-	strum_macros::Display,
+	strum::Display,
 	EnumString,
 	EnumProperty,
 	PartialEq,

--- a/src/prefs/preflight.rs
+++ b/src/prefs/preflight.rs
@@ -71,13 +71,12 @@ fn rel_path(path: &Path, children: &[impl AsRef<Path>]) -> PathBuf {
 
 #[cfg(test)]
 mod test {
+	use strum::IntoEnumIterator;
+
 	use crate::prefs::PreflightProblem;
 
 	#[test]
 	fn preflight_problem_type() {
-		let _ = PreflightProblem::all_values()
-			.iter()
-			.map(PreflightProblem::problem_type)
-			.collect::<Vec<_>>();
+		let _ = PreflightProblem::iter().map(|x| x.problem_type()).collect::<Vec<_>>();
 	}
 }

--- a/src/runtime/args.rs
+++ b/src/runtime/args.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 
+use strum::IntoEnumIterator;
+
 use crate::prefs::PrefsPaths;
 use crate::prefs::pathtype::PathType;
 use crate::runtime::MameWindowing;
@@ -15,11 +17,10 @@ pub struct MameArguments {
 impl MameArguments {
 	pub fn new(prefs_paths: &PrefsPaths, windowing: &MameWindowing) -> Self {
 		// convert all path vec's to the appropriate MAME arguments
-		let path_args = PathType::all_values()
-			.iter()
+		let path_args = PathType::iter()
 			.filter_map(|path_type| {
 				let arg = path_type.mame_argument()?;
-				let value = prefs_paths.full_string(*path_type)?;
+				let value = prefs_paths.full_string(path_type)?;
 				Some((arg, value))
 			})
 			.flat_map(|(arg, value)| [Cow::Borrowed(OsStr::new(arg)), Cow::Owned(value)]);

--- a/src/runtime/command.rs
+++ b/src/runtime/command.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::path::Path;
 
-use derive_enum_all_values::AllValues;
 use itertools::Itertools;
+use strum::EnumIter;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum MameCommand<'a> {
@@ -63,7 +63,7 @@ impl MameCommand<'_> {
 	}
 }
 
-#[derive(AllValues, Copy, Clone, Debug, Default, PartialEq, strum::Display)]
+#[derive(EnumIter, Copy, Clone, Debug, Default, PartialEq, strum::Display)]
 pub enum MovieFormat {
 	#[default]
 	#[strum(to_string = "avi")]

--- a/src/runtime/command.rs
+++ b/src/runtime/command.rs
@@ -63,7 +63,7 @@ impl MameCommand<'_> {
 	}
 }
 
-#[derive(AllValues, Copy, Clone, Debug, Default, PartialEq, strum_macros::Display)]
+#[derive(AllValues, Copy, Clone, Debug, Default, PartialEq, strum::Display)]
 pub enum MovieFormat {
 	#[default]
 	#[strum(to_string = "avi")]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -4,7 +4,7 @@ pub mod session;
 
 use std::rc::Rc;
 
-use strum_macros::EnumString;
+use strum::EnumString;
 
 #[derive(Clone, Debug)]
 pub enum MameWindowing {


### PR DESCRIPTION
`strum` is more mainstream and has all of the pertinent functionality.  And we're already using it