### PR TITLE
Improvements to InfoDb validation

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,12 +1,73 @@
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
+use std::process::ExitCode;
+use std::time::Duration;
+use std::time::Instant;
+
+use anyhow::Error;
+use byte_unit::Byte;
 
 use crate::info::InfoDb;
 
-pub fn info_db_from_xml_file(path: impl AsRef<Path>) {
-	let file = File::open(path).unwrap();
+#[derive(Clone, Copy, Debug)]
+struct Metrics {
+	byte_count: usize,
+	elapsed_time: Duration,
+}
+
+#[derive(thiserror::Error, Debug)]
+enum ThisError {
+	#[error("Error reading XML: {0:?}")]
+	ReadingPath(std::io::Error),
+	#[error("Error building InfoDb: {0:?}")]
+	BuildingInfoDb(Error),
+	#[error("InfoDb build process created corrupt database")]
+	Validation(Vec<Error>),
+}
+
+pub fn info_db_from_xml_file(path: impl AsRef<Path>) -> ExitCode {
+	match internal_info_db_from_xml_file(path) {
+		Ok(metrics) => {
+			let byte_count = Byte::from(metrics.byte_count);
+			let (byte_count, unit) = byte_count.get_exact_unit(true);
+			let elapsed_time = metrics.elapsed_time;
+			println!("\x1B[KSuccess ({elapsed_time:?} elapsed; total size {byte_count} {unit})");
+			ExitCode::SUCCESS
+		}
+		Err(e) => {
+			println!("Error:  {e}");
+			if let ThisError::Validation(errors) = e {
+				for e in errors {
+					println!("\t{e:?}");
+				}
+			}
+			ExitCode::FAILURE
+		}
+	}
+}
+
+fn internal_info_db_from_xml_file(path: impl AsRef<Path>) -> std::result::Result<Metrics, ThisError> {
+	let start_instant = Instant::now();
+	let file = File::open(path).map_err(ThisError::ReadingPath)?;
 	let mut reader = BufReader::new(file);
-	let _ = InfoDb::from_listxml_output(&mut reader, |_| false).unwrap().unwrap();
-	println!("Success");
+
+	let info_db = InfoDb::from_listxml_output(&mut reader, |machine_name| {
+		print!("\x1B[KProcessing {machine_name}...\r");
+		false
+	})
+	.map_err(ThisError::BuildingInfoDb)?;
+
+	// cancellation should never happen
+	let info_db = info_db.unwrap();
+
+	// validate the results (which is not normally invoked on this path)
+	info_db.validate().map_err(ThisError::Validation)?;
+
+	// and return!
+	let metrics = Metrics {
+		byte_count: info_db.data_len(),
+		elapsed_time: start_instant.elapsed(),
+	};
+	Ok(metrics)
 }

--- a/src/info/entities.rs
+++ b/src/info/entities.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 use anyhow::Result;
+use anyhow::ensure;
 use binary_search::Direction;
 use binary_search::binary_search;
 
@@ -7,6 +8,7 @@ use crate::info::ChipType;
 use crate::info::IndirectView;
 use crate::info::Object;
 use crate::info::SimpleView;
+use crate::info::Validatable;
 use crate::info::View;
 use crate::info::binary;
 
@@ -213,6 +215,14 @@ impl<'a> MachineSoftwareList<'a> {
 	pub fn software_list(&self) -> SoftwareList<'a> {
 		let software_list_index = self.obj().software_list_index.try_into().unwrap();
 		self.db.software_lists().get(software_list_index).unwrap()
+	}
+}
+
+impl Validatable for MachineSoftwareList<'_> {
+	fn validate(&self) -> Result<()> {
+		let software_list_index = usize::try_from(self.obj().software_list_index)?;
+		ensure!(software_list_index < self.db.software_lists().len());
+		Ok(())
 	}
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod version;
 mod xml;
 
 use std::path::PathBuf;
+use std::process::ExitCode;
 
 use appwindow::AppWindowing;
 use dirs::config_local_dir;
@@ -68,7 +69,7 @@ struct Opt {
 	no_capture_mame_stderr: bool,
 }
 
-fn main() {
+fn main() -> ExitCode {
 	// platform-specific stuff
 	let _platform_specific = platform_init().unwrap();
 
@@ -83,8 +84,7 @@ fn main() {
 
 	// are we doing diagnostics
 	if let Some(path) = opts.process_xml {
-		info_db_from_xml_file(path);
-		return;
+		return info_db_from_xml_file(path);
 	}
 
 	// identify the preferences directory
@@ -125,6 +125,7 @@ fn main() {
 
 	// ...and run run run!
 	app_window.run().unwrap();
+	ExitCode::SUCCESS
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- `--process-xml` will now enumerate validations
- `--process-xml` will now return non-zero if an error is found (validation or otherwise)
- Machine-SoftwareList indexes are now validated
- There is now a `Validatable` trait to make it easy to drop in new per-entity validations