### PR TITLE
Fixing an obnoxious problem where MAME seems to steal focus on initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,6 @@ dependencies = [
  "vivi_ui",
  "win32job",
  "windows 0.61.1",
- "windows-sys 0.59.0",
  "winit",
  "winresource",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ features = [
     "Win32_System_Console",
     "Win32_System_Threading",
     "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_WindowsAndMessaging",
 ]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,11 +67,8 @@ features = [
     "Win32_System",
     "Win32_System_Console",
     "Win32_System_Threading",
+    "Win32_UI_Input_KeyboardAndMouse",
 ]
-
-[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.59"
-features = ["Win32_UI_Input_KeyboardAndMouse"]
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -76,6 +76,7 @@ use crate::runtime::command::MameCommand;
 use crate::runtime::command::MovieFormat;
 use crate::selection::SelectionManager;
 use crate::status::Status;
+use crate::threadlocalbubble::ThreadLocalBubble;
 use crate::ui::AboutDialog;
 use crate::ui::AppWindow;
 use crate::ui::ReportIssue;
@@ -241,10 +242,9 @@ impl AppModel {
 			if let RuntimeWindowing::Child(child_window) = &self.windowing {
 				child_window.set_active(running.is_some());
 
-				// the running window should have focus
-				if running.is_some() {
-					child_window.ensure_child_focus(app_window.window());
-				}
+				// ensure that if we're running the child window has focus, and if not, the
+				// app window has focus
+				child_window.ensure_proper_focus();
 			}
 
 			// report view
@@ -571,6 +571,23 @@ pub fn create(args: AppArgs) -> AppWindow {
 	let state = AppState::new(prefs_path, paths, mame_windowing, args.mame_stderr, move |command| {
 		let model = model_weak.upgrade().unwrap();
 		handle_command(&model, command);
+	});
+
+	// on `winit`, ensure that if the focus changes we call `ChildWindow::ensure_proper_focus()`
+	let model_weak = Rc::downgrade(&model);
+	i_slint_backend_winit::WinitWindowAccessor::on_winit_window_event(app_window.window(), move |_, event| {
+		if let winit::event::WindowEvent::Focused(_) = event {
+			let model_bubble = ThreadLocalBubble::new(model_weak.clone());
+			invoke_from_event_loop(move || {
+				if let Some(model) = model_bubble.unwrap().upgrade() {
+					if let RuntimeWindowing::Child(child_window) = &model.windowing {
+						child_window.ensure_proper_focus();
+					}
+				}
+			})
+			.unwrap();
+		}
+		i_slint_backend_winit::WinitWindowEventResult::Propagate
 	});
 
 	// initial updates

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -239,7 +239,7 @@ impl AppModel {
 
 			// child window visibility
 			if let RuntimeWindowing::Child(child_window) = &self.windowing {
-				child_window.set_visible(running.is_some());
+				child_window.set_active(running.is_some());
 
 				// the running window should have focus
 				if running.is_some() {

--- a/src/childwindow/mod.rs
+++ b/src/childwindow/mod.rs
@@ -14,7 +14,7 @@ use crate::childwindow::winit::WinitChildWindow;
 use crate::childwindow::qt::QtChildWindow;
 
 trait ChildWindowImpl {
-	fn set_visible(&self, is_visible: bool);
+	fn set_active(&self, active: bool);
 	fn update(&self, position: dpi::PhysicalPosition<u32>, size: dpi::PhysicalSize<u32>);
 	fn text(&self) -> String;
 
@@ -45,8 +45,8 @@ impl ChildWindow {
 		Ok(Self(result))
 	}
 
-	pub fn set_visible(&self, is_visible: bool) {
-		self.0.set_visible(is_visible);
+	pub fn set_active(&self, active: bool) {
+		self.0.set_active(active);
 	}
 
 	pub fn update(&self, container: &Window, top: f32) {

--- a/src/childwindow/mod.rs
+++ b/src/childwindow/mod.rs
@@ -19,7 +19,7 @@ trait ChildWindowImpl {
 	fn text(&self) -> String;
 
 	/// Hackish (and platform specific) method to "ensure" focus
-	fn ensure_child_focus(&self, container: &Window);
+	fn ensure_proper_focus(&self);
 }
 
 #[cfg(not(feature = "slint-qt-backend"))]
@@ -68,7 +68,7 @@ impl ChildWindow {
 		self.0.text()
 	}
 
-	pub fn ensure_child_focus(&self, container: &Window) {
-		self.0.ensure_child_focus(container);
+	pub fn ensure_proper_focus(&self) {
+		self.0.ensure_proper_focus();
 	}
 }

--- a/src/childwindow/qt.rs
+++ b/src/childwindow/qt.rs
@@ -65,7 +65,7 @@ impl ChildWindowImpl for QtChildWindow {
 		self.qt_widget.win_id().to_string()
 	}
 
-	fn ensure_child_focus(&self, _container: &Window) {
+	fn ensure_proper_focus(&self) {
 		// do nothing
 	}
 }

--- a/src/childwindow/qt.rs
+++ b/src/childwindow/qt.rs
@@ -28,13 +28,13 @@ impl QtChildWindow {
 		Ok(result)
 	}
 
-	fn internal_update(&self, visible: Option<bool>) {
-		if let Some(visible) = visible {
-			self.qt_widget.set_visible(visible);
+	fn internal_update(&self, active: Option<bool>) {
+		if let Some(active) = active {
+			self.qt_widget.set_visible(active);
 		}
 
-		let visible = visible.unwrap_or_else(|| self.qt_widget.is_visible());
-		let (x, y, w, h) = if visible {
+		let active = active.unwrap_or_else(|| self.qt_widget.is_visible());
+		let (x, y, w, h) = if active {
 			self.geometry.get()
 		} else {
 			(-200, -200, 100, 100)
@@ -44,9 +44,9 @@ impl QtChildWindow {
 }
 
 impl ChildWindowImpl for QtChildWindow {
-	fn set_visible(&self, visible: bool) {
-		if visible != self.qt_widget.is_visible() {
-			self.internal_update(Some(visible));
+	fn set_active(&self, active: bool) {
+		if active != self.qt_widget.is_visible() {
+			self.internal_update(Some(active));
 		}
 	}
 

--- a/src/childwindow/winit.rs
+++ b/src/childwindow/winit.rs
@@ -37,7 +37,7 @@ impl WinitChildWindow {
 }
 
 impl ChildWindowImpl for WinitChildWindow {
-	fn set_visible(&self, is_visible: bool) {
+	fn set_active(&self, is_visible: bool) {
 		self.0.set_visible(is_visible);
 
 		#[cfg(target_os = "windows")]

--- a/src/platform/other.rs
+++ b/src/platform/other.rs
@@ -32,10 +32,6 @@ pub impl Window {
 		// do nothing for now
 	}
 
-	fn ensure_child_focus(&self, _child: &winit::window::Window) {
-		// do nothing for now
-	}
-
 	fn with_muda_menu<T>(&self, _callback: impl FnOnce(&::muda::Menu) -> T) -> Option<T> {
 		None
 	}

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -11,12 +11,12 @@ use raw_window_handle::RawWindowHandle;
 use raw_window_handle::Win32WindowHandle;
 use slint::Window;
 use win32job::Job;
+use windows::Win32::Foundation::HWND;
 use windows::Win32::System::Console::ATTACH_PARENT_PROCESS;
 use windows::Win32::System::Console::AttachConsole;
 use windows::Win32::System::Threading::CREATE_NO_WINDOW;
-use windows_sys::Win32::Foundation::HWND;
-use windows_sys::Win32::UI::Input::KeyboardAndMouse::GetFocus;
-use windows_sys::Win32::UI::Input::KeyboardAndMouse::SetFocus;
+use windows::Win32::UI::Input::KeyboardAndMouse::GetFocus;
+use windows::Win32::UI::Input::KeyboardAndMouse::SetFocus;
 use winit::platform::windows::WindowAttributesExtWindows;
 use winit::platform::windows::WindowExtWindows;
 use winit::window::WindowAttributes;
@@ -76,13 +76,13 @@ pub impl Window {
 		if child.is_visible().unwrap_or_default() {
 			let do_set_focus = get_win32_window_handle(self)
 				.ok()
-				.map(|x| unsafe { GetFocus() } == isize::from(x.hwnd) as HWND)
+				.map(|x| unsafe { GetFocus() } == HWND(isize::from(x.hwnd) as *mut std::ffi::c_void))
 				.unwrap_or_default();
 
 			if do_set_focus {
 				if let RawWindowHandle::Win32(child_hwnd) = child.window_handle().unwrap().as_raw() {
 					unsafe {
-						SetFocus(isize::from(child_hwnd.hwnd) as HWND);
+						let _ = SetFocus(Some(HWND(isize::from(child_hwnd.hwnd) as *mut std::ffi::c_void)));
 					}
 				}
 			}

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -11,12 +11,9 @@ use raw_window_handle::RawWindowHandle;
 use raw_window_handle::Win32WindowHandle;
 use slint::Window;
 use win32job::Job;
-use windows::Win32::Foundation::HWND;
 use windows::Win32::System::Console::ATTACH_PARENT_PROCESS;
 use windows::Win32::System::Console::AttachConsole;
 use windows::Win32::System::Threading::CREATE_NO_WINDOW;
-use windows::Win32::UI::Input::KeyboardAndMouse::GetFocus;
-use windows::Win32::UI::Input::KeyboardAndMouse::SetFocus;
 use winit::platform::windows::WindowAttributesExtWindows;
 use winit::platform::windows::WindowExtWindows;
 use winit::window::WindowAttributes;
@@ -65,28 +62,6 @@ pub impl Window {
 
 	fn set_enabled_for_modal(&self, enabled: bool) {
 		self.with_winit_window(|window| window.set_enable(enabled));
-	}
-
-	fn ensure_child_focus(&self, child: &winit::window::Window) {
-		// hackish method that ensures so-called "appropriate focus"; this really needs
-		// to be generalized
-
-		// note that we avoid `Window::focus_window()`, as `winit` has a nasty hack that blasts
-		// keystrokes into the window
-		if child.is_visible().unwrap_or_default() {
-			let do_set_focus = get_win32_window_handle(self)
-				.ok()
-				.map(|x| unsafe { GetFocus() } == HWND(isize::from(x.hwnd) as *mut std::ffi::c_void))
-				.unwrap_or_default();
-
-			if do_set_focus {
-				if let RawWindowHandle::Win32(child_hwnd) = child.window_handle().unwrap().as_raw() {
-					unsafe {
-						let _ = SetFocus(Some(HWND(isize::from(child_hwnd.hwnd) as *mut std::ffi::c_void)));
-					}
-				}
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
The fix is to generalize the logic previously in `ChildWindow::ensure_child_focus()` (now called `ChildWindow::ensure_proper_focus()`) to gauge whether the child window is active or not, and scrutinize whether the parent or child window is focused, and switch the focus if the wrong one is focused.

Other notes:
* `ChildWindow::ensure_proper_focus()` is now also invoked when the main window receives a `WindowEvent::Focused` event
* `ChildWindow::set_visible()` was renamed to `ChildWindow::set_active()`
