### PR TITLE
Improvements to `-listxml` processing diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,6 +712,7 @@ dependencies = [
  "binary-search",
  "binary_serde",
  "byte-unit",
+ "console",
  "cpp",
  "cpp_build",
  "default-ext",
@@ -1075,7 +1076,7 @@ dependencies = [
  "bitflags 1.3.2",
  "strsim",
  "textwrap",
- "unicode-width",
+ "unicode-width 0.1.14",
  "vec_map",
 ]
 
@@ -1134,6 +1135,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1621,6 +1635,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "endi"
@@ -5604,7 +5624,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -6004,6 +6024,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ easy-ext = "1.0.2"
 qttypes = { version = "0.2.12", optional = true }
 cpp = "0.5.10"
 nu-utils = "0.104.0"
+console = { version = "0.15.11", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.61.1"
@@ -94,5 +95,5 @@ panic = "abort"
 
 [features]
 default = ["diagnostics"]
-diagnostics = []
+diagnostics = ["dep:console"]
 slint-qt-backend = ["dep:i-slint-backend-qt", "dep:qttypes"]

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -215,6 +215,10 @@ impl InfoDb {
 		self.data.len()
 	}
 
+	pub fn strings_len(&self) -> usize {
+		self.data.len() - self.strings_offset
+	}
+
 	pub fn build(&self) -> &MameVersion {
 		&self.build
 	}

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,11 @@ struct Opt {
 	#[cfg_attr(feature = "slint-qt-backend", structopt(long))]
 	slint_backend: Option<SlintBackend>,
 
+	#[cfg_attr(feature = "diagnostics", structopt(long))]
+	process_listxml: bool,
+
 	#[cfg_attr(feature = "diagnostics", structopt(long, parse(from_os_str)))]
-	process_xml: Option<PathBuf>,
+	process_listxml_file: Option<PathBuf>,
 
 	#[cfg_attr(feature = "diagnostics", structopt(long))]
 	log: Option<String>,
@@ -83,7 +86,13 @@ fn main() -> ExitCode {
 	}
 
 	// are we doing diagnostics
-	if let Some(path) = opts.process_xml {
+	let process_listxml = match (opts.process_listxml, opts.process_listxml_file.as_deref()) {
+		(false, None) => None,
+		(true, None) => Some(None),
+		(false, Some(path)) => Some(Some(path)),
+		(true, Some(_)) => panic!("Cannot specify --process-listxml and --process-listxml-file simultaneously"),
+	};
+	if let Some(path) = process_listxml {
 		return info_db_from_xml_file(path);
 	}
 


### PR DESCRIPTION
* Instead of `--process-xml`, we now have `--process-listxml` (which reads from standard input) and `--process-listxml-file <<FILE>>`
* Now returning diagnostic information (machine count, slot count, string table length etc)
* The intermediate progress display while processing is cleaner (using ANSI control codes to clear lines)