### PR TITLE
Changing InfoDb to use `zerocopy` instead of `binaryserde`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,12 +245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "array-init"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,29 +602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bea0ab2808834a04d4ae0d831f476217fdbee35cb620bf6b2e5807a4e9435776"
 
 [[package]]
-name = "binary_serde"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e797ab922c4fbffef715a90f3a7514deaf1e3976385b2c8f3acda024b9cc569"
-dependencies = [
- "array-init",
- "binary_serde_macros",
- "recursive_array",
- "thiserror-no-std",
-]
-
-[[package]]
-name = "binary_serde_macros"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dadd7c2e1366d63f8ddc66ef72d1eb04a24a1ea29b7b0457ba0861da9b8505f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,7 +692,6 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "binary-search",
- "binary_serde",
  "byte-unit",
  "console",
  "cpp",
@@ -770,6 +740,7 @@ dependencies = [
  "windows 0.61.1",
  "winit",
  "winresource",
+ "zerocopy",
 ]
 
 [[package]]
@@ -4666,12 +4637,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "recursive_array"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69bad83913c3b39011ad9d43b7ac0cae139cec5d7e7288fbea5bb4b4e3cc78f6"
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5632,26 +5597,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "thiserror-impl-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "thiserror-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
-dependencies = [
- "thiserror-impl-no-std",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ raw-window-handle = "0.6.2"
 rfd = "0.15.1"
 serde = { version = "1.0.219", features = ["rc"] }
 quick-xml = "0.37.4"
-binary_serde = "1.0.24"
 itertools = "0.14.0"
 winit = "0.30.3"
 tokio = { version = "1.44.2", features = [
@@ -59,6 +58,7 @@ qttypes = { version = "0.2.12", optional = true }
 cpp = "0.5.10"
 nu-utils = "0.104.0"
 console = { version = "0.15.11", optional = true }
+zerocopy = { version = "0.8.25", features = ["derive"] }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 version = "0.61.1"

--- a/src/info/binary.rs
+++ b/src/info/binary.rs
@@ -1,72 +1,83 @@
-use binary_serde::BinarySerde;
 use serde::Deserialize;
 use strum::EnumString;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+use zerocopy::TryFromBytes;
+use zerocopy::little_endian::U64;
+
+use crate::info::usize_db;
 
 pub trait Fixup {
-	fn identify_machine_indexes(&mut self) -> impl IntoIterator<Item = &mut u32> {
+	fn identify_machine_indexes(&mut self) -> impl IntoIterator<Item = &mut usize_db> {
 		[]
 	}
-	fn identify_software_list_indexes(&mut self) -> impl IntoIterator<Item = &mut u32> {
+	fn identify_software_list_indexes(&mut self) -> impl IntoIterator<Item = &mut usize_db> {
 		[]
 	}
 }
 
-#[derive(Clone, Copy, Debug, Default, BinarySerde)]
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, Default, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct Header {
 	pub magic: [u8; 8],
-	pub sizes_hash: u64,
-	pub build_strindex: u32,
-	pub machine_count: u32,
-	pub chips_count: u32,
-	pub device_count: u32,
-	pub slot_count: u32,
-	pub slot_option_count: u32,
-	pub software_list_count: u32,
-	pub software_list_machine_count: u32,
-	pub machine_software_lists_count: u32,
-	pub ram_option_count: u32,
+	pub sizes_hash: U64,
+	pub build_strindex: usize_db,
+	pub machine_count: usize_db,
+	pub chips_count: usize_db,
+	pub device_count: usize_db,
+	pub slot_count: usize_db,
+	pub slot_option_count: usize_db,
+	pub software_list_count: usize_db,
+	pub software_list_machine_count: usize_db,
+	pub machine_software_lists_count: usize_db,
+	pub ram_option_count: usize_db,
 }
 
-#[derive(Clone, Copy, Debug, Default, BinarySerde)]
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, Default, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct Machine {
-	pub name_strindex: u32,
-	pub source_file_strindex: u32,
-	pub clone_of_machine_index: u32,
-	pub rom_of_machine_index: u32,
-	pub description_strindex: u32,
-	pub year_strindex: u32,
-	pub manufacturer_strindex: u32,
-	pub chips_start: u32,
-	pub chips_end: u32,
-	pub devices_start: u32,
-	pub devices_end: u32,
-	pub slots_start: u32,
-	pub slots_end: u32,
-	pub slot_options_start: u32,
-	pub slot_options_end: u32,
-	pub machine_software_lists_start: u32,
-	pub machine_software_lists_end: u32,
-	pub ram_options_start: u32,
-	pub ram_options_end: u32,
+	pub name_strindex: usize_db,
+	pub source_file_strindex: usize_db,
+	pub clone_of_machine_index: usize_db,
+	pub rom_of_machine_index: usize_db,
+	pub description_strindex: usize_db,
+	pub year_strindex: usize_db,
+	pub manufacturer_strindex: usize_db,
+	pub chips_start: usize_db,
+	pub chips_end: usize_db,
+	pub devices_start: usize_db,
+	pub devices_end: usize_db,
+	pub slots_start: usize_db,
+	pub slots_end: usize_db,
+	pub slot_options_start: usize_db,
+	pub slot_options_end: usize_db,
+	pub machine_software_lists_start: usize_db,
+	pub machine_software_lists_end: usize_db,
+	pub ram_options_start: usize_db,
+	pub ram_options_end: usize_db,
 	pub runnable: bool,
 }
 
 impl Fixup for Machine {
-	fn identify_machine_indexes(&mut self) -> impl IntoIterator<Item = &mut u32> {
+	fn identify_machine_indexes(&mut self) -> impl IntoIterator<Item = &mut usize_db> {
 		[&mut self.clone_of_machine_index, &mut self.rom_of_machine_index]
 	}
 }
 
-#[derive(Clone, Copy, Debug, BinarySerde)]
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct Chip {
-	pub clock: u64,
-	pub tag_strindex: u32,
-	pub name_strindex: u32,
+	pub clock: U64,
+	pub tag_strindex: usize_db,
+	pub name_strindex: usize_db,
 	pub chip_type: ChipType,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, BinarySerde, EnumString, PartialEq, Eq)]
 #[repr(u8)]
+#[derive(
+	Clone, Copy, Debug, Deserialize, TryFromBytes, IntoBytes, Immutable, KnownLayout, EnumString, PartialEq, Eq,
+)]
 pub enum ChipType {
 	#[strum(serialize = "cpu")]
 	Cpu,
@@ -74,51 +85,58 @@ pub enum ChipType {
 	Audio,
 }
 
-#[derive(Clone, Copy, Debug, BinarySerde)]
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct Device {
-	pub type_strindex: u32,
-	pub tag_strindex: u32,
+	pub type_strindex: usize_db,
+	pub tag_strindex: usize_db,
 	pub mandatory: bool,
-	pub interfaces_strindex: u32,
-	pub extensions_strindex: u32,
+	pub interfaces_strindex: usize_db,
+	pub extensions_strindex: usize_db,
 }
 
-#[derive(Clone, Copy, Debug, BinarySerde)]
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct Slot {
-	pub name_strindex: u32,
-	pub options_start: u32,
-	pub options_end: u32,
-	pub default_option_index: u32,
+	pub name_strindex: usize_db,
+	pub options_start: usize_db,
+	pub options_end: usize_db,
+	pub default_option_index: usize_db,
 }
 
-#[derive(Clone, Copy, Debug, BinarySerde)]
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct SlotOption {
-	pub name_strindex: u32,
-	pub devname_strindex: u32,
+	pub name_strindex: usize_db,
+	pub devname_strindex: usize_db,
 }
 
-#[derive(Clone, Copy, Debug, BinarySerde)]
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct MachineSoftwareList {
-	pub tag_strindex: u32,
-	pub software_list_index: u32,
+	pub tag_strindex: usize_db,
+	pub software_list_index: usize_db,
 	pub status: SoftwareListStatus,
-	pub filter_strindex: u32,
+	pub filter_strindex: usize_db,
 }
 
-#[derive(Clone, Copy, Debug, BinarySerde)]
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct RamOption {
-	pub size: u64,
+	pub size: U64,
 	pub is_default: bool,
 }
 
 impl Fixup for MachineSoftwareList {
-	fn identify_software_list_indexes(&mut self) -> impl IntoIterator<Item = &mut u32> {
+	fn identify_software_list_indexes(&mut self) -> impl IntoIterator<Item = &mut usize_db> {
 		[&mut self.software_list_index]
 	}
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, BinarySerde, EnumString, PartialEq, Eq)]
 #[repr(u8)]
+#[derive(
+	Clone, Copy, Debug, Deserialize, TryFromBytes, IntoBytes, Immutable, KnownLayout, EnumString, PartialEq, Eq,
+)]
 pub enum SoftwareListStatus {
 	#[strum(serialize = "original")]
 	Original,
@@ -126,12 +144,13 @@ pub enum SoftwareListStatus {
 	Compatible,
 }
 
-#[derive(Clone, Copy, Debug, BinarySerde)]
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct SoftwareList {
-	pub name_strindex: u32,
-	pub software_list_original_machines_start: u32,
-	pub software_list_compatible_machines_start: u32,
-	pub software_list_compatible_machines_end: u32,
+	pub name_strindex: usize_db,
+	pub software_list_original_machines_start: usize_db,
+	pub software_list_compatible_machines_start: usize_db,
+	pub software_list_compatible_machines_end: usize_db,
 }
 
 #[cfg(test)]

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -29,6 +29,7 @@ use binary_serde::DeserializeError;
 use binary_serde::Endianness;
 use entities::SoftwareListsView;
 use internment::Arena;
+use more_asserts::assert_le;
 
 use crate::platform::CommandExt;
 use crate::prefs::prefs_filename;
@@ -438,9 +439,9 @@ where
 	fn sub_view(&self, range: Range<u32>) -> Self {
 		let range = usize::try_from(range.start).unwrap()..usize::try_from(range.end).unwrap();
 
-		assert!(range.start <= range.end);
-		assert!(range.start <= self.end - self.start);
-		assert!(range.end <= self.end - self.start);
+		assert_le!(range.start, range.end);
+		assert_le!(range.start, self.end - self.start);
+		assert_le!(range.end, self.end - self.start);
 
 		Self {
 			start: self.start + range.start,

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -24,12 +24,13 @@ use std::process::Stdio;
 use anyhow::Error;
 use anyhow::Result;
 use anyhow::ensure;
-use binary_serde::BinarySerde;
-use binary_serde::DeserializeError;
-use binary_serde::Endianness;
+use easy_ext::ext;
 use entities::SoftwareListsView;
 use internment::Arena;
 use more_asserts::assert_le;
+use zerocopy::Immutable;
+use zerocopy::KnownLayout;
+use zerocopy::TryFromBytes;
 
 use crate::platform::CommandExt;
 use crate::prefs::prefs_filename;
@@ -52,13 +53,16 @@ use self::build::data_from_listxml_output;
 use self::strings::read_string;
 use self::strings::validate_string_table;
 
+use zerocopy::little_endian::U32 as usize_db;
+
 const MAGIC_HDR: &[u8; 8] = b"MAMEINFO";
-const ENDIANNESS: Endianness = Endianness::Little;
 
 #[derive(thiserror::Error, Debug)]
 enum ThisError {
 	#[error("InfoDb is corrupted")]
 	Validation(Vec<Error>),
+	#[error("Cannot deserialize InfoDb header")]
+	CannotDeserializeHeader,
 }
 
 pub struct InfoDb {
@@ -69,7 +73,7 @@ pub struct InfoDb {
 	slots: RootView<binary::Slot>,
 	slot_options: RootView<binary::SlotOption>,
 	software_lists: RootView<binary::SoftwareList>,
-	software_list_machine_indexes: RootView<u32>,
+	software_list_machine_indexes: RootView<usize_db>,
 	machine_software_lists: RootView<binary::MachineSoftwareList>,
 	ram_options: RootView<binary::RamOption>,
 	strings_offset: usize,
@@ -87,7 +91,7 @@ impl InfoDb {
 		let hdr = decode_header(&data)?;
 
 		// now walk the views
-		let mut cursor = binary::Header::SERIALIZED_SIZE..data.len();
+		let mut cursor = size_of::<binary::Header>()..data.len();
 		let machines = next_root_view(&mut cursor, hdr.machine_count)?;
 		let chips = next_root_view(&mut cursor, hdr.chips_count)?;
 		let devices = next_root_view(&mut cursor, hdr.device_count)?;
@@ -197,7 +201,7 @@ impl InfoDb {
 			&mut emit,
 			"SoftwareListMachineIndex",
 			|x| {
-				ensure!(x.obj() < self.machines().len().try_into().unwrap());
+				ensure!(x.obj().from_db() < self.machines().len());
 				Ok(())
 			},
 		);
@@ -252,7 +256,7 @@ impl InfoDb {
 		self.make_view(&self.machine_software_lists)
 	}
 
-	pub fn software_list_machine_indexes(&self) -> impl View<'_, Object<'_, u32>> {
+	pub fn software_list_machine_indexes(&self) -> impl View<'_, Object<'_, usize_db>> {
 		self.make_view(&self.software_list_machine_indexes)
 	}
 
@@ -260,24 +264,19 @@ impl InfoDb {
 		self.make_view(&self.ram_options)
 	}
 
-	fn string(&self, offset: u32) -> &'_ str {
+	fn string(&self, offset: usize_db) -> &'_ str {
 		match read_string(&self.data[self.strings_offset..], offset).unwrap_or_default() {
 			Cow::Borrowed(s) => s,
 			Cow::Owned(s) => self.strings_arena.intern_string(s).into_ref(),
 		}
 	}
 
-	fn make_view<B>(&self, root_view: &RootView<B>) -> SimpleView<'_, B>
-	where
-		B: BinarySerde,
-	{
-		let byte_offset = root_view.offset.try_into().unwrap();
-		let count = root_view.count.try_into().unwrap();
+	fn make_view<B>(&self, root_view: &RootView<B>) -> SimpleView<'_, B> {
 		SimpleView {
 			db: self,
-			byte_offset,
+			byte_offset: root_view.offset,
 			start: 0,
-			end: count,
+			end: root_view.count,
 			phantom: PhantomData,
 		}
 	}
@@ -291,25 +290,20 @@ impl Debug for InfoDb {
 	}
 }
 
-fn next_root_view<T>(cursor: &mut Range<usize>, count: u32) -> Result<RootView<T>>
-where
-	T: BinarySerde,
-{
+fn next_root_view<T>(cursor: &mut Range<usize>, count: usize_db) -> Result<RootView<T>> {
 	let error_message = "Cannot deserialize InfoDB header";
 
 	// get the result
-	let offset = cursor
-		.start
-		.try_into()
-		.map_err(|e| Error::new(e).context(error_message))?;
+	let offset = cursor.start;
 
 	// advance the cursor
+	let count = count.from_db();
 	let count_bytes = count
-		.checked_mul(T::SERIALIZED_SIZE.try_into().unwrap())
+		.checked_mul(size_of::<T>())
 		.ok_or_else(|| Error::msg(error_message))?;
 	let new_start = cursor
 		.start
-		.checked_add(count_bytes.try_into().unwrap())
+		.checked_add(count_bytes)
 		.ok_or_else(|| Error::msg(error_message))?;
 	if new_start > cursor.end {
 		return Err(Error::msg(error_message));
@@ -323,8 +317,8 @@ where
 
 #[derive(Clone, Copy, Debug)]
 struct RootView<T> {
-	offset: u32,
-	count: u32,
+	offset: usize,
+	count: usize,
 	phantom: PhantomData<T>,
 }
 
@@ -349,15 +343,12 @@ fn infodb_filename_error() -> Error {
 	Error::msg("Cannot determine InfoDB filename")
 }
 
-fn infodb_deserialize_header_error(error: DeserializeError) -> Error {
-	Error::msg(error).context("Cannot deserialize InfoDB header")
-}
-
-fn decode_header(data: &[u8]) -> Result<binary::Header> {
-	let header_data = &data[0..min(binary::Header::SERIALIZED_SIZE, data.len())];
-	let header =
-		binary::Header::binary_deserialize(header_data, ENDIANNESS).map_err(infodb_deserialize_header_error)?;
-	if &header.magic != MAGIC_HDR {
+fn decode_header(data: &[u8]) -> Result<&binary::Header> {
+	let header_data = &data[0..min(size_of::<binary::Header>(), data.len())];
+	let header = binary::Header::try_ref_from_bytes(header_data)
+		.ok()
+		.ok_or(ThisError::CannotDeserializeHeader)?;
+	if header.magic != *MAGIC_HDR {
 		return Err(Error::msg("Bad InfoDB Magic Value In Header"));
 	}
 	if header.sizes_hash != calculate_sizes_hash() {
@@ -372,7 +363,7 @@ where
 {
 	fn get(&self, index: usize) -> Option<T>;
 	fn len(&self) -> usize;
-	fn sub_view(&self, range: Range<u32>) -> Self;
+	fn sub_view(&self, range: Range<usize>) -> Self;
 
 	fn iter(&self) -> impl Iterator<Item = T> {
 		ViewIter {
@@ -421,7 +412,7 @@ pub struct SimpleView<'a, B> {
 
 impl<'a, B> View<'a, Object<'a, B>> for SimpleView<'a, B>
 where
-	B: BinarySerde + Clone,
+	B: TryFromBytes + Clone,
 {
 	fn len(&self) -> usize {
 		self.end - self.start
@@ -436,9 +427,7 @@ where
 		})
 	}
 
-	fn sub_view(&self, range: Range<u32>) -> Self {
-		let range = usize::try_from(range.start).unwrap()..usize::try_from(range.end).unwrap();
-
+	fn sub_view(&self, range: Range<usize>) -> Self {
 		assert_le!(range.start, range.end);
 		assert_le!(range.start, self.end - self.start);
 		assert_le!(range.end, self.end - self.start);
@@ -459,8 +448,8 @@ pub struct IndirectView<V, W> {
 
 impl<'a, B, VI, VO> View<'a, Object<'a, B>> for IndirectView<VI, VO>
 where
-	B: BinarySerde + Clone + 'a,
-	VI: View<'a, Object<'a, u32>> + 'a,
+	B: TryFromBytes + Clone + 'a,
+	VI: View<'a, Object<'a, usize_db>> + 'a,
 	VO: View<'a, Object<'a, B>> + 'a,
 {
 	fn len(&self) -> usize {
@@ -468,7 +457,7 @@ where
 	}
 
 	fn get(&self, index: usize) -> Option<Object<'a, B>> {
-		let object_index = self.index_view.get(index)?.obj().try_into().unwrap();
+		let object_index = self.index_view.get(index)?.obj().from_db();
 		let obj = self
 			.object_view
 			.get(object_index)
@@ -476,7 +465,7 @@ where
 		Some(obj)
 	}
 
-	fn sub_view(&self, range: Range<u32>) -> Self {
+	fn sub_view(&self, range: Range<usize>) -> Self {
 		let index_view = self.index_view.sub_view(range);
 		let object_view = self.object_view.clone();
 		Self {
@@ -506,16 +495,16 @@ impl<B> Object<'_, B> {
 
 impl<'a, B> Object<'a, B>
 where
-	B: BinarySerde,
+	B: TryFromBytes + KnownLayout + Immutable,
 {
-	fn obj(&self) -> B {
-		let start = self.byte_offset + self.index * B::SERIALIZED_SIZE;
-		let end = start + B::SERIALIZED_SIZE;
+	fn obj(&self) -> &'_ B {
+		let start = self.byte_offset + self.index * size_of::<B>();
+		let end = start + size_of::<B>();
 		let buf = &self.db.data[start..end];
-		B::binary_deserialize(buf, ENDIANNESS).unwrap()
+		TryFromBytes::try_ref_from_bytes(buf).unwrap()
 	}
 
-	fn string(&self, func: impl FnOnce(B) -> u32) -> &'a str {
+	fn string(&self, func: impl FnOnce(&B) -> usize_db) -> &'a str {
 		let offset = func(self.obj());
 		self.db.string(offset)
 	}
@@ -529,7 +518,7 @@ impl<B> PartialEq for Object<'_, B> {
 
 impl<B> Debug for Object<'_, B>
 where
-	B: BinarySerde + Debug,
+	B: TryFromBytes + KnownLayout + Immutable + Debug,
 {
 	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("Object")
@@ -567,6 +556,29 @@ fn validate_view_custom<'a, T>(
 			let message = format!("{}[{}]: {}", type_name, index, e);
 			emit(Error::msg(message));
 		}
+	}
+}
+
+#[ext(UsizeImpl)]
+impl usize {
+	fn to_db(self) -> usize_db {
+		self.try_to_db().unwrap()
+	}
+
+	fn try_to_db(self) -> Result<usize_db> {
+		Ok(u32::try_from(self).map_err(|_| Error::msg("usize too large"))?.into())
+	}
+}
+
+#[ext(UsizeDbImpl)]
+impl usize_db {
+	#[allow(clippy::wrong_self_convention)]
+	fn from_db(self) -> usize {
+		self.try_from_db().unwrap()
+	}
+
+	fn try_from_db(self) -> Result<usize> {
+		usize::try_from(self.get()).map_err(|_| Error::msg("unexpected usize::try_from() failure"))
 	}
 }
 


### PR DESCRIPTION
Using `binaryserde` to deserialize bytes in InfoDb on a record-by-record basis has always been awkward.  With these changes we can:
1. Eliminate record-by-record deserializations and copying
2. Get rid of `BinBuilder` (`Vec` does the trick)
3. Reduce the amount of packages we use (we were already pulling in `zerocopy`)
4. Simplify the system as a whole