### PR TITLE
Changing Software List parsing code to dispense strings centrally

### DIFF
--- a/src/software/strings.rs
+++ b/src/software/strings.rs
@@ -1,0 +1,17 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+#[derive(Debug, Default)]
+pub struct StringDispenser(Mutex<HashSet<Arc<str>>>);
+
+impl StringDispenser {
+	pub fn get(&self, s: &str) -> Arc<str> {
+		let mut guard = self.0.lock().unwrap();
+		guard.get(s).cloned().unwrap_or_else(|| {
+			let result = Arc::<str>::from(s);
+			guard.insert(result.clone());
+			result
+		})
+	}
+}


### PR DESCRIPTION
This should yield (extremely minor) improvements preventing strings from being duplicated when we're loading multiple software lists