### PR TITLE
Created an initial (i.e. - incomplete) reimplementation of the Inputs dialog

### DIFF
--- a/src/appcommand.rs
+++ b/src/appcommand.rs
@@ -12,6 +12,7 @@ use crate::prefs::PrefsCollection;
 use crate::prefs::PrefsItem;
 use crate::prefs::SortOrder;
 use crate::prefs::pathtype::PathType;
+use crate::status::InputClass;
 use crate::status::Update;
 use crate::version::MameVersion;
 
@@ -42,6 +43,7 @@ pub enum AppCommand {
 	OptionsClassic,
 
 	// Settings menu
+	SettingsInput(InputClass),
 	SettingsPaths(Option<PathType>),
 	SettingsToggleBuiltinCollection(BuiltinCollection),
 	SettingsReset,

--- a/src/dialogs/input.rs
+++ b/src/dialogs/input.rs
@@ -1,0 +1,153 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use itertools::Itertools;
+use slint::CloseRequestResponse;
+use slint::ComponentHandle;
+use slint::ModelRc;
+use slint::SharedString;
+use slint::VecModel;
+use slint::Weak;
+use strum::EnumString;
+
+use crate::dialogs::SingleResult;
+use crate::guiutils::modal::Modal;
+use crate::status::Input;
+use crate::status::InputClass;
+use crate::status::InputDeviceClass;
+use crate::status::InputDeviceClassName;
+use crate::ui::InputDialog;
+use crate::ui::InputDialogEntry;
+
+pub async fn dialog_input(
+	parent: Weak<impl ComponentHandle + 'static>,
+	inputs: impl AsRef<[Input]>,
+	input_device_classes: impl AsRef<[InputDeviceClass]>,
+	class: InputClass,
+) {
+	// prepare the dialog
+	let modal = Modal::new(&parent.unwrap(), || InputDialog::new().unwrap());
+	let single_result = SingleResult::default();
+
+	// set the title
+	modal.dialog().set_dialog_title(class.title().into());
+
+	// set up the close handler
+	let signaller = single_result.signaller();
+	modal.window().on_close_requested(move || {
+		signaller.signal(());
+		CloseRequestResponse::KeepWindowShown
+	});
+
+	// set up the "ok" button
+	let signaller = single_result.signaller();
+	modal.dialog().on_ok_clicked(move || {
+		signaller.signal(());
+	});
+
+	// build the codes map
+	let codes = build_codes(input_device_classes.as_ref());
+
+	// set up entries
+	let entries = inputs
+		.as_ref()
+		.iter()
+		.filter(move |x| x.class == Some(class))
+		.sorted_by_key(|input| {
+			(
+				input.group,
+				input.input_type,
+				input.first_keyboard_code.unwrap_or_default(),
+				&input.name,
+			)
+		})
+		.coalesce(|a, b| {
+			// because of how the LUA "fields" property works, there may be dupes in this data, and
+			// this logic removes the dupes
+			if a.port_tag == b.port_tag && a.mask == b.mask {
+				Ok(a)
+			} else {
+				Err((a, b))
+			}
+		})
+		.map(|x| {
+			let name = SharedString::from(&x.name);
+			let seq_tokens = x.seq_standard_tokens.as_deref().unwrap_or_default();
+			let text = seq_text_from_tokens(seq_tokens, &codes).into();
+			InputDialogEntry { name, text }
+		})
+		.collect::<Vec<_>>();
+	let entries = VecModel::from(entries);
+	let entries = ModelRc::new(entries);
+	modal.dialog().set_entries(entries);
+
+	// present the modal dialog
+	modal.run(async { single_result.wait().await }).await
+}
+
+fn build_codes(input_device_classes: &[InputDeviceClass]) -> HashMap<&'_ str, Cow<str>> {
+	input_device_classes
+		.iter()
+		.flat_map(|device_class| {
+			let device_class_name = match (&device_class.name, device_class.devices.len() > 1) {
+				(InputDeviceClassName::Keyboard, false) => None,
+				(InputDeviceClassName::Keyboard, true) => Some("Kbd"),
+				(InputDeviceClassName::Joystick, _) => Some("Joy"),
+				(InputDeviceClassName::Lightgun, _) => Some("Gun"),
+				(InputDeviceClassName::Mouse, _) => Some("Mouse"),
+				(InputDeviceClassName::Other(x), _) => Some(x.as_ref()),
+			};
+			device_class
+				.devices
+				.iter()
+				.map(move |device| (device_class_name, device))
+		})
+		.flat_map(|(device_class_name, device)| {
+			device
+				.items
+				.iter()
+				.map(move |item| (device_class_name, device.devindex, item))
+		})
+		.map(|(device_class_name, device_index, item)| {
+			let label = if let Some(device_class_name) = device_class_name {
+				Cow::Owned(format!("{} #{} {}", device_class_name, device_index + 1, item.name))
+			} else {
+				Cow::Borrowed(item.name.as_str())
+			};
+			(item.code.as_str(), label)
+		})
+		.collect::<HashMap<_, _>>()
+}
+
+fn seq_text_from_tokens(seq_tokens: &str, codes: &HashMap<&str, Cow<str>>) -> String {
+	#[derive(Debug, strum::Display, EnumString, PartialEq)]
+	enum Token<'a> {
+		#[strum(to_string = "{0}")]
+		Named(&'a str),
+		#[strum(to_string = "or")]
+		Or,
+		#[strum(to_string = "not")]
+		Not,
+		#[strum(to_string = "default")]
+		Default,
+	}
+
+	seq_tokens
+		.split(' ')
+		.map(|token| {
+			// modifier tokens like OR/NOT/DEFAULT should just be "lowercaseed" (this
+			// will need to be reevaluated when it is time to localize this)
+			match token {
+				"OR" => Token::Or,
+				"NOT" => Token::Not,
+				"DEFAULT" => Token::Default,
+				token => {
+					let text = codes.get(token).map(|x| x.as_ref()).unwrap_or(token);
+					Token::Named(text)
+				}
+			}
+		})
+		.skip_while(|token| *token == Token::Or)
+		.map(|x| x.to_string())
+		.join(" ")
+}

--- a/src/dialogs/mod.rs
+++ b/src/dialogs/mod.rs
@@ -7,6 +7,7 @@ pub mod configure;
 pub mod devimages;
 pub mod file;
 pub mod image;
+pub mod input;
 pub mod messagebox;
 pub mod namecollection;
 pub mod paths;

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -250,6 +250,12 @@ pub enum InputClass {
 	DipSwitch,
 }
 
+impl InputClass {
+	pub fn title(&self) -> &'static str {
+		self.get_str("Title").unwrap()
+	}
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct InputDeviceClass {
 	pub name: InputDeviceClassName,

--- a/src/status/parse.rs
+++ b/src/status/parse.rs
@@ -364,7 +364,6 @@ impl State {
 				input_device.items.push(item);
 				None
 			}
-
 			_ => None,
 		};
 		Ok(new_phase)

--- a/src/status/parse.rs
+++ b/src/status/parse.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use anyhow::Error;
 use anyhow::Result;
+use strum::EnumString;
 use tracing::debug;
 
 use crate::parse::normalize_tag;
@@ -11,6 +12,7 @@ use crate::parse::parse_mame_bool;
 use crate::status::ImageDetails;
 use crate::status::ImageFormat;
 use crate::status::ImageUpdate;
+use crate::status::Input;
 use crate::status::RunningUpdate;
 use crate::status::Slot;
 use crate::status::SlotOption;
@@ -26,11 +28,13 @@ enum Phase {
 	Status,
 	StatusImages,
 	StatusSlots,
+	StatusInputs,
 	Image,
 	ImageDetails,
 	ImageDetailsFormat,
 	ImageDetailsFormatExtension,
 	Slot,
+	Input,
 }
 
 const TEXT_CAPTURE_PHASES: &[Phase] = &[Phase::ImageDetailsFormatExtension];
@@ -54,6 +58,14 @@ enum PhaseSpecificState {
 enum ThisError {
 	#[error("Missing mandatory attribute {0} when parsing status XML")]
 	MissingMandatoryAttribute(&'static str),
+}
+
+#[derive(Copy, Clone, Debug, EnumString)]
+#[strum(ascii_case_insensitive)]
+enum SeqType {
+	Standard,
+	Increment,
+	Decrement,
 }
 
 impl State {
@@ -112,6 +124,10 @@ impl State {
 			(Phase::Status, b"slots") => {
 				self.running.slots = Some(Vec::new());
 				Some(Phase::StatusSlots)
+			}
+			(Phase::Status, b"inputs") => {
+				self.running.inputs = Some(Vec::new());
+				Some(Phase::StatusInputs)
 			}
 			(Phase::StatusImages, b"image") => {
 				let [tag, filename] = evt.find_attributes([b"tag", b"filename"])?;
@@ -223,6 +239,74 @@ impl State {
 				current_slot.options.push(option);
 				None
 			}
+			(Phase::StatusInputs, b"input") => {
+				let [
+					port_tag,
+					mask,
+					class,
+					group,
+					input_type,
+					player,
+					is_analog,
+					name,
+					first_keyboard_code,
+				] = evt.find_attributes([
+					b"port_tag",
+					b"mask",
+					b"class",
+					b"group",
+					b"type",
+					b"player",
+					b"is_analog",
+					b"name",
+					b"first_keyboard_code",
+				])?;
+
+				let port_tag = port_tag.ok_or(ThisError::MissingMandatoryAttribute("port_tag"))?;
+				let port_tag = normalize_tag(port_tag).into_owned();
+				let mask = mask.ok_or(ThisError::MissingMandatoryAttribute("mask"))?.parse()?;
+				let class = class.ok_or(ThisError::MissingMandatoryAttribute("class"))?.parse().ok();
+				let group = group.ok_or(ThisError::MissingMandatoryAttribute("group"))?.parse()?;
+				let input_type = input_type
+					.ok_or(ThisError::MissingMandatoryAttribute("type"))?
+					.parse()?;
+				let player = player.ok_or(ThisError::MissingMandatoryAttribute("player"))?.parse()?;
+				let is_analog = parse_mame_bool(is_analog.ok_or(ThisError::MissingMandatoryAttribute("is_analog"))?)?;
+				let name = name.ok_or(ThisError::MissingMandatoryAttribute("name"))?.into_owned();
+				let first_keyboard_code = first_keyboard_code.map(|x| x.parse()).transpose()?;
+
+				let input = Input {
+					port_tag,
+					mask,
+					class,
+					group,
+					input_type,
+					player,
+					is_analog,
+					name,
+					first_keyboard_code,
+					seq_standard_tokens: None,
+					seq_increment_tokens: None,
+					seq_decrement_tokens: None,
+				};
+				self.running.inputs.as_mut().unwrap().push(input);
+				Some(Phase::Input)
+			}
+			(Phase::Input, b"seq") => {
+				let [seq_type, tokens] = evt.find_attributes([b"type", b"tokens"])?;
+				let seq_type = seq_type.ok_or(ThisError::MissingMandatoryAttribute("seq_type"))?;
+				let seq_type = seq_type.parse::<SeqType>()?;
+				let tokens = tokens.ok_or(ThisError::MissingMandatoryAttribute("tokens"))?;
+
+				let current_input = self.running.inputs.as_mut().unwrap().last_mut().unwrap();
+				let current_input_tokens = match seq_type {
+					SeqType::Standard => &mut current_input.seq_standard_tokens,
+					SeqType::Increment => &mut current_input.seq_increment_tokens,
+					SeqType::Decrement => &mut current_input.seq_decrement_tokens,
+				};
+				*current_input_tokens = Some(tokens.into());
+				None
+			}
 
 			_ => None,
 		};
@@ -315,6 +399,8 @@ mod test {
 	use assert_matches::assert_matches;
 	use test_case::test_case;
 
+	use crate::status::InputClass;
+
 	use super::parse_update;
 
 	#[test_case(0, include_str!("test_data/status_mame0226_coco2b_1.xml"))]
@@ -344,6 +430,65 @@ mod test {
 		let reader = BufReader::new(xml.as_bytes());
 		let running = parse_update(reader).unwrap().running.unwrap();
 		let actual = (running.is_throttled, running.throttle_rate);
+		assert_eq!(expected, actual);
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	#[test_case(0, include_str!("test_data/status_mame0226_coco2b_1.xml"), "row0", 128, InputClass::Keyboard, 11, 49, 0, false, 
+		"g  G", Some(103), Some("KEYCODE_G"), None, None)]
+	#[test_case(1, include_str!("test_data/status_mame0226_coco2b_1.xml"), "joystick_rx", 255, InputClass::Controller, 1, 152, 0, true,
+		"Right Joystick X", None, Some("JOYCODE_1_XAXIS"), Some("KEYCODE_6PAD OR JOYCODE_1_XAXIS_RIGHT_SWITCH"), Some("KEYCODE_4PAD OR JOYCODE_1_XAXIS_LEFT_SWITCH"))]
+	fn inputs(
+		_index: usize,
+		xml: &str,
+		port_tag: &str,
+		mask: u32,
+		expected_class: InputClass,
+		expected_group: u8,
+		expected_type: u32,
+		expected_player: u8,
+		expected_is_analog: bool,
+		expected_name: &str,
+		expected_first_keyboard_code: Option<u32>,
+		expected_seq_standard_tokens: Option<&str>,
+		expected_seq_increment_tokens: Option<&str>,
+		expected_seq_decrement_tokens: Option<&str>,
+	) {
+		let expected = (
+			Some(expected_class),
+			expected_group,
+			expected_type,
+			expected_player,
+			expected_is_analog,
+			expected_name,
+			expected_first_keyboard_code,
+			expected_seq_standard_tokens,
+			expected_seq_increment_tokens,
+			expected_seq_decrement_tokens,
+		);
+
+		let reader = BufReader::new(xml.as_bytes());
+		let running = parse_update(reader).unwrap().running.unwrap();
+		let input = running
+			.inputs
+			.as_deref()
+			.unwrap()
+			.iter()
+			.find(|x| x.port_tag == port_tag && x.mask == mask)
+			.expect("could not find specified port_tag and mask");
+		let actual = (
+			input.class,
+			input.group,
+			input.input_type,
+			input.player,
+			input.is_analog,
+			input.name.as_ref(),
+			input.first_keyboard_code,
+			input.seq_standard_tokens.as_deref(),
+			input.seq_increment_tokens.as_deref(),
+			input.seq_decrement_tokens.as_deref(),
+		);
+
 		assert_eq!(expected, actual);
 	}
 }

--- a/ui/input.slint
+++ b/ui/input.slint
@@ -1,0 +1,53 @@
+import { GridBox, VerticalBox, HorizontalBox, Button, StandardButton } from "std-widgets.slint";
+
+export struct InputDialogEntry {
+    name: string,
+    text: string}
+
+export component InputDialog inherits Window {
+    title: dialog-title;
+    icon: @image-url("bletchmame.png");
+    preferred-width: 600px;
+    preferred-height: 500px;
+
+    // properties
+    in property <string> dialog-title;
+    in property <[InputDialogEntry]> entries;
+
+    // callbacks
+    callback ok-clicked();
+
+    // control hierarchy
+    VerticalBox {
+        for entry in root.entries: HorizontalLayout {
+            Button {
+                text: entry.name;
+                enabled: false;
+            }
+
+            Button {
+                text: "▼";
+                enabled: false;
+            }
+
+            Button {
+                text: entry.text;
+                enabled: false;
+            }
+        }
+        HorizontalBox {
+            Button {
+                text: @tr("Restore Defaults");
+                enabled: false;
+            }
+
+            StandardButton {
+                kind: ok;
+                enabled: false;
+                clicked => {
+                    root.ok-clicked();
+                }
+            }
+        }
+    }
+}

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -8,5 +8,6 @@ import { DevicesAndImagesDialog } from "devimages.slint";
 import { DeviceAndImageEntry } from "devimageslist.slint";
 import { AppWindow } from "appwindow.slint";
 import { ConfigureDialog } from "configure.slint";
+import { InputDialog, InputDialogEntry } from "input.slint";
 
-export { AboutDialog, AppWindow, ConfigureDialog, ConnectToSocketDialog, MessageBoxDialog, NameCollectionDialog, PathsDialog, DevicesAndImagesDialog, DeviceAndImageEntry, Icons }
+export { AboutDialog, AppWindow, ConfigureDialog, ConnectToSocketDialog, MessageBoxDialog, NameCollectionDialog, PathsDialog, DevicesAndImagesDialog, DeviceAndImageEntry, InputDialog, InputDialogEntry, Icons }


### PR DESCRIPTION
This is in NO WAY done yet; more or less all we do at this point is acknowledge the input and input device related information from status updates, and build a non functional dialog vaguely resembling what the old BletchMAME had.  The code for interpreting input tokens is recognizable but not yet complete, and we are not yet doing anything special for analog inputs.
    
This is being checked in just because the foundational work was somewhat large, and even if it is non functional this represents a bit of work.  Just digesting the status updates is not trivial.
