### PR TITLE
Refactored `MameCommand`

### DIFF
--- a/src/appcommand.rs
+++ b/src/appcommand.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use itertools::Itertools;
 use serde::Deserialize;
 use serde::Serialize;
@@ -12,6 +10,7 @@ use crate::prefs::PrefsCollection;
 use crate::prefs::PrefsItem;
 use crate::prefs::SortOrder;
 use crate::prefs::pathtype::PathType;
+use crate::runtime::command::MameCommand;
 use crate::status::InputClass;
 use crate::status::Update;
 use crate::version::MameVersion;
@@ -59,10 +58,7 @@ pub enum AppCommand {
 	ErrorMessageBox(String),
 
 	// Other
-	RunMame {
-		machine_name: String,
-		initial_loads: Vec<(Arc<str>, Arc<str>)>,
-	},
+	IssueMameCommand(MameCommand),
 	Browse(PrefsCollection),
 	HistoryAdvance(isize),
 	SearchText(String),
@@ -90,17 +86,12 @@ pub enum AppCommand {
 	LoadImageDialog {
 		tag: String,
 	},
-	LoadImage {
-		tag: String,
-		filename: String,
-	},
 	UnloadImage {
 		tag: String,
 	},
 	ConnectToSocketDialog {
 		tag: String,
 	},
-	ChangeSlots(Vec<(String, Option<String>)>),
 	InfoDbBuildProgress {
 		machine_description: String,
 	},
@@ -133,5 +124,11 @@ impl AppCommand {
 			let json = s.strip_prefix(MENU_PREFIX).expect("not a menu string");
 			serde_json::from_str(json).unwrap()
 		})
+	}
+}
+
+impl From<MameCommand> for AppCommand {
+	fn from(value: MameCommand) -> Self {
+		Self::IssueMameCommand(value)
 	}
 }

--- a/src/appstate.rs
+++ b/src/appstate.rs
@@ -60,7 +60,7 @@ struct Live {
 #[derive(Clone)]
 struct Session {
 	job: Job<Result<()>>,
-	command_sender: Option<Arc<Sender<Cow<'static, str>>>>,
+	command_sender: Option<Arc<Sender<MameCommand>>>,
 	status: Option<Rc<Status>>,
 	pending_status: Option<Rc<Status>>,
 	pending_paths_update: Option<Rc<PrefsPaths>>,
@@ -273,10 +273,10 @@ impl AppState {
 	}
 
 	/// Issues a command to MAME
-	pub fn issue_command(&self, command: MameCommand<'_>) {
+	pub fn issue_command(&self, command: MameCommand) {
 		let session = self.live.as_ref().unwrap().session.as_ref().unwrap();
 		if let Some(command_sender) = session.command_sender.as_deref() {
-			command_sender.send(command.text()).unwrap();
+			command_sender.send(command).unwrap();
 		}
 	}
 

--- a/src/dialogs/devimages.rs
+++ b/src/dialogs/devimages.rs
@@ -11,6 +11,7 @@ use crate::devimageconfig::EntryDetails;
 use crate::dialogs::SingleResult;
 use crate::guiutils::modal::Modal;
 use crate::models::devimages::DevicesAndImagesModel;
+use crate::runtime::command::MameCommand;
 use crate::status::Status;
 use crate::ui::DevicesAndImagesContextMenuInfo;
 use crate::ui::DevicesAndImagesDialog;
@@ -48,7 +49,7 @@ pub async fn dialog_devices_and_images(
 	modal.dialog().on_apply_changes_clicked(move || {
 		let model = DevicesAndImagesModel::get_model(&model_clone);
 		let changed_slots = model.with_diconfig(|diconfig| diconfig.changed_slots(true));
-		let command = AppCommand::ChangeSlots(changed_slots);
+		let command = MameCommand::change_slots(&changed_slots).into();
 		invoke_command_clone(command);
 	});
 

--- a/src/runtime/command.rs
+++ b/src/runtime/command.rs
@@ -1,71 +1,140 @@
 use std::borrow::Cow;
 use std::ffi::OsStr;
+use std::iter::once;
 use std::path::Path;
 
 use itertools::Itertools;
+use serde::Deserialize;
+use serde::Serialize;
 use strum::EnumIter;
+use strum::IntoStaticStr;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum MameCommand<'a> {
-	Start {
-		machine_name: &'a str,
-		initial_loads: &'a [(&'a str, &'a str)],
-	},
-	Stop,
-	SoftReset,
-	HardReset,
-	Pause,
-	Resume,
-	ClassicMenu,
-	Throttled(bool),
-	ThrottleRate(f32),
-	SetSystemMute(bool),
-	SetAttenuation(i32),
-	LoadImage(&'a [(&'a str, &'a str)]),
-	UnloadImage(&'a str),
-	ChangeSlots(&'a [(&'a str, &'a str)]),
-	StateLoad(&'a str),
-	StateSave(&'a str),
-	SaveSnapshot(u32, &'a str),
-	BeginRecording(&'a str, MovieFormat),
-	EndRecording,
-	Debugger,
-}
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct MameCommand(Cow<'static, str>);
 
-impl MameCommand<'_> {
-	pub fn text(&self) -> Cow<'static, str> {
-		match self {
-			MameCommand::Start {
-				machine_name,
-				initial_loads,
-			} => pairs_command_text(&["START", machine_name], initial_loads),
-			MameCommand::Stop => "STOP".into(),
-			MameCommand::SoftReset => "SOFT_RESET".into(),
-			MameCommand::HardReset => "HARD_RESET".into(),
-			MameCommand::Pause => "PAUSE".into(),
-			MameCommand::Resume => "RESUME".into(),
-			MameCommand::ClassicMenu => "CLASSIC_MENU".into(),
-			MameCommand::Throttled(throttled) => format!("THROTTLED {}", bool_str(*throttled)).into(),
-			MameCommand::ThrottleRate(throttle) => format!("THROTTLE_RATE {}", throttle).into(),
-			MameCommand::SetSystemMute(system_mute) => format!("SET_SYSTEM_MUTE {}", system_mute).into(),
-			MameCommand::SetAttenuation(attenuation) => format!("SET_ATTENUATION {}", attenuation).into(),
-			MameCommand::LoadImage(loads) => pairs_command_text(&["LOAD"], loads),
-			MameCommand::UnloadImage(tag) => format!("UNLOAD {}", tag).into(),
-			MameCommand::ChangeSlots(changes) => pairs_command_text(&["CHANGE_SLOTS"], changes),
-			MameCommand::StateLoad(filename) => format!("STATE_LOAD {filename}").into(),
-			MameCommand::StateSave(filename) => format!("STATE_SAVE {filename}").into(),
-			MameCommand::SaveSnapshot(screen_number, filename) => {
-				let filename = quote_if_needed(filename);
-				format!("SAVE_SNAPSHOT {screen_number} {filename}").into()
-			}
-			MameCommand::BeginRecording(filename, format) => format!("BEGIN_RECORDING {filename} {format}").into(),
-			MameCommand::EndRecording => "END_RECORDING".into(),
-			MameCommand::Debugger => "DEBUGGER".into(),
-		}
+impl MameCommand {
+	pub fn text(&self) -> &'_ str {
+		self.0.as_ref()
+	}
+
+	pub fn start(machine_name: &str, initial_loads: &[(impl AsRef<str>, impl AsRef<str>)]) -> Self {
+		let initial_loads = initial_loads
+			.iter()
+			.flat_map(|(tag, filename)| [tag.as_ref(), filename.as_ref()]);
+		let args = once(machine_name).chain(initial_loads);
+		build("START", args)
+	}
+
+	pub fn stop() -> Self {
+		Self("STOP".into())
+	}
+
+	pub fn soft_reset() -> Self {
+		Self("SOFT_RESET".into())
+	}
+
+	pub fn hard_reset() -> Self {
+		Self("HARD_RESET".into())
+	}
+
+	pub fn pause() -> Self {
+		Self("PAUSE".into())
+	}
+
+	pub fn resume() -> Self {
+		Self("RESUME".into())
+	}
+
+	pub fn classic_menu() -> Self {
+		Self("CLASSIC_MENU".into())
+	}
+
+	pub fn throttled(throttled: bool) -> Self {
+		build("THROTTLED", [bool_str(throttled)])
+	}
+
+	pub fn throttle_rate(rate: f32) -> Self {
+		let rate = rate.to_string();
+		build("THROTTLE_RATE", [rate.as_str()])
+	}
+
+	pub fn set_system_mute(system_mute: bool) -> Self {
+		build("SET_SYSTEM_MUTE", [bool_str(system_mute)])
+	}
+
+	pub fn set_attenuation(attenuation: i32) -> Self {
+		let attenuation = attenuation.to_string();
+		build("SET_ATTENUATION", [attenuation.as_str()])
+	}
+
+	pub fn load_image(tag: impl AsRef<str>, filename: impl AsRef<str>) -> Self {
+		Self::load_images(&[(tag, filename)])
+	}
+
+	pub fn load_images(loads: &[(impl AsRef<str>, impl AsRef<str>)]) -> Self {
+		let args = loads
+			.iter()
+			.flat_map(|(tag, filename)| [tag.as_ref(), filename.as_ref()]);
+		build("LOAD", args)
+	}
+
+	pub fn unload_image(tag: impl AsRef<str>) -> Self {
+		let tag = tag.as_ref();
+		build("UNLOAD", [tag])
+	}
+
+	pub fn change_slots(changes: &[(impl AsRef<str>, Option<impl AsRef<str>>)]) -> Self {
+		let args = changes
+			.iter()
+			.flat_map(|(tag, filename)| [tag.as_ref(), filename.as_ref().map(|x| x.as_ref()).unwrap_or_default()]);
+		build("CHANGE_SLOTS", args)
+	}
+
+	pub fn state_load(filename: impl AsRef<str>) -> Self {
+		let filename = filename.as_ref();
+		build("STATE_LOAD", [filename])
+	}
+
+	pub fn state_save(filename: impl AsRef<str>) -> Self {
+		let filename = filename.as_ref();
+		build("STATE_SAVE", [filename])
+	}
+
+	pub fn save_snapshot(screen_number: u32, filename: impl AsRef<str>) -> Self {
+		let screen_number = screen_number.to_string();
+		let filename = filename.as_ref();
+		build("SAVE_SNAPSHOT", [screen_number.as_str(), filename])
+	}
+
+	pub fn begin_recording(filename: impl AsRef<str>, format: MovieFormat) -> Self {
+		let filename = filename.as_ref();
+		let format: &'static str = format.into();
+		build("BEGIN_RECORDING", [filename, format])
+	}
+
+	pub fn end_recording() -> Self {
+		Self("END_RECORDING".into())
+	}
+
+	pub fn debugger() -> Self {
+		Self("DEBUGGER".into())
+	}
+
+	pub fn ping() -> Self {
+		Self("PING".into())
+	}
+
+	pub fn exit() -> Self {
+		Self("EXIT".into())
 	}
 }
 
-#[derive(EnumIter, Copy, Clone, Debug, Default, PartialEq, strum::Display)]
+/// Internal method to build a `MameCommand`
+fn build<'a>(command_name: &'a str, args: impl IntoIterator<Item = &'a str>) -> MameCommand {
+	MameCommand(once(command_name).chain(args).map(quote_if_needed).join(" ").into())
+}
+
+#[derive(EnumIter, Copy, Clone, Debug, Default, PartialEq, strum::Display, IntoStaticStr)]
 pub enum MovieFormat {
 	#[default]
 	#[strum(to_string = "avi")]
@@ -90,19 +159,6 @@ fn bool_str(b: bool) -> &'static str {
 	if b { "true" } else { "false" }
 }
 
-fn pairs_command_text(base: &[&str], args: &[(&str, &str)]) -> Cow<'static, str> {
-	base.iter()
-		.copied()
-		.map(Cow::Borrowed)
-		.chain(args.iter().flat_map(|(name, value)| {
-			let name = Cow::Borrowed(*name);
-			let value = quote_if_needed(value);
-			[name, value]
-		}))
-		.join(" ")
-		.into()
-}
-
 fn quote_if_needed(s: &str) -> Cow<'_, str> {
 	if s.is_empty() || s.contains(' ') {
 		Cow::Owned(format!("\"{s}\""))
@@ -117,12 +173,14 @@ mod test {
 
 	use super::MameCommand;
 
-	#[test_case(0, MameCommand::Stop, "STOP")]
-	#[test_case(1, MameCommand::Start { machine_name: "coco2b", initial_loads: &[("-ramsize", "")]}, "START coco2b -ramsize \"\"")]
-	#[test_case(2, MameCommand::Start { machine_name: "coco2b", initial_loads: &[("-ramsize", "64k")]}, "START coco2b -ramsize 64k")]
-	#[test_case(3, MameCommand::Start { machine_name: "coco2b", initial_loads: &[("ext:fdc:wd17xx:0", "foo.dsk")]}, "START coco2b ext:fdc:wd17xx:0 foo.dsk")]
-	#[test_case(4, MameCommand::LoadImage(&[("ext:fdc:wd17xx:0", "foo bar.dsk")]), "LOAD ext:fdc:wd17xx:0 \"foo bar.dsk\"")]
-	fn command_test(_index: usize, command: MameCommand<'_>, expected: &str) {
+	#[rustfmt::skip]
+	#[test_case(0, MameCommand::stop(), "STOP")]
+	#[test_case(1, MameCommand::start("coco2b", &[("-ramsize", "")]), "START coco2b -ramsize \"\"")]
+	#[test_case(2, MameCommand::start("coco2b", &[("-ramsize", "64k")]), "START coco2b -ramsize 64k")]
+	#[test_case(3, MameCommand::start("coco2b", &[("ext:fdc:wd17xx:0", "foo.dsk")]), "START coco2b ext:fdc:wd17xx:0 foo.dsk")]
+	#[test_case(4, MameCommand::load_image("ext:fdc:wd17xx:0", "foo bar.dsk"), "LOAD ext:fdc:wd17xx:0 \"foo bar.dsk\"")]
+	#[test_case(5, MameCommand::load_images(&[("ext:fdc:wd17xx:0", "foo bar.dsk")]), "LOAD ext:fdc:wd17xx:0 \"foo bar.dsk\"")]
+	fn command_test(_index: usize, command: MameCommand, expected: &str) {
 		let actual = command.text();
 		assert_eq!(expected, actual);
 	}


### PR DESCRIPTION
- `MameCommand` is no longer an enum; rather it is the text we pass to MAME
- Methods like `MameCommand::load_images()` now take over the role of the enum members
- Eliminated some of the layer caking of `AppCommand` on top of `MameCommand` (e.g. - `AppCommand::RunMame`) by having `AppCommand::IssueMameCommand` that can wrap arbitrary `MameCommand` objects