### PR TITLE
Changing tracing in `handle_command()` log frequently used `AppCommand` types as `DEBUG` instead of `INFO`

### DIFF
--- a/src/appcommand.rs
+++ b/src/appcommand.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use std::sync::Arc;
 
 use itertools::Itertools;
@@ -58,6 +59,7 @@ pub enum AppCommand {
 
 	// MAME communication
 	MameSessionEnded,
+	#[strum(props(IsFrequent = "true"))]
 	MameStatusUpdate(Update),
 	ErrorMessageBox(String),
 
@@ -142,6 +144,14 @@ impl AppCommand {
 			let json = s.strip_prefix(MENU_PREFIX).expect("not a menu string");
 			serde_json::from_str(json).unwrap()
 		})
+	}
+
+	pub fn is_frequent(&self) -> bool {
+		self.get_str("IsFrequent")
+			.map(bool::from_str)
+			.transpose()
+			.unwrap()
+			.unwrap_or_default()
 	}
 }
 

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -673,7 +673,11 @@ fn menu_item_info(parent_title: Option<&str>, title: &str) -> (Option<AppCommand
 fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 	// tracing
 	let command_str: &'static str = (&command).into();
-	let span = info_span!("handle_command", command = command_str);
+	let span = if command.is_frequent() {
+		debug_span!("handle_command", command = command_str)
+	} else {
+		info_span!("handle_command", command = command_str)
+	};
 	let _guard = span.enter();
 	info!(command=?&command, "handle_command()");
 	let start_instant = Instant::now();


### PR DESCRIPTION
Some `AppCommand` types (like `MameStatusUpdate`) are very noisy