### PR TITLE
Reinstated the technique of using Slint callbacks to keep the child window's position in sync

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -240,7 +240,7 @@ impl AppModel {
 			app_window.set_running_machine_desc(state.running_machine_description().into());
 
 			// child window visibility
-			if let Some(child_window) = self.child_window.borrow().as_deref() {
+			if let Some(child_window) = &*self.child_window.borrow() {
 				child_window.set_active(running.is_some());
 			}
 

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -391,6 +391,18 @@ pub fn create(args: AppArgs) -> AppWindow {
 		}
 	});
 
+	// create a repeating future that will update the child window forever
+	let model_weak = Rc::downgrade(&model);
+	app_window.on_size_changed(move || {
+		if let Some(model) = model_weak.upgrade().as_deref() {
+			if let Some(child_window) = model.child_window.borrow().as_ref() {
+				// set the child window size
+				let top = model.app_window().invoke_menubar_height();
+				child_window.update_bounds(model.app_window().window(), top);
+			}
+		}
+	});
+
 	// set up the collections view model
 	let collections_view_model = CollectionsViewModel::new(app_window.as_weak());
 	let collections_view_model = Rc::new(collections_view_model);

--- a/src/backend/qt.rs
+++ b/src/backend/qt.rs
@@ -42,6 +42,17 @@ impl QtChildWindow {
 		}
 	}
 
+	pub fn set_position_and_size(&self, position: dpi::PhysicalPosition<u32>, size: dpi::PhysicalSize<u32>) {
+		let geometry = (
+			position.x.try_into().unwrap(),
+			position.y.try_into().unwrap(),
+			size.width.try_into().unwrap(),
+			size.width.try_into().unwrap(),
+		);
+		self.geometry.set(geometry);
+		self.internal_update(None);
+	}
+
 	pub fn text(&self) -> String {
 		self.qt_widget.win_id().to_string()
 	}

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -10,7 +10,6 @@ use raw_window_handle::RawWindowHandle;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::Sender;
 use tracing::debug;
-use tracing::info;
 use tracing::info_span;
 use winit::event::WindowEvent;
 use winit::event_loop::ActiveEventLoop;
@@ -145,13 +144,6 @@ impl CustomApplicationHandler for WinitBackendRuntime {
 		self.create_pending_child_windows(event_loop);
 
 		match event {
-			WindowEvent::Resized(physical_size) => {
-				if let FindResult::Parent(child_window) = self.find_child_window(&window_id) {
-					info!(physical_size=?physical_size, child_window=?child_window, "resizing child window");
-					let _ = child_window.window.request_inner_size(*physical_size);
-				}
-			}
-
 			WindowEvent::Focused(true) => match self.find_child_window(&window_id) {
 				FindResult::Parent(child_window) => {
 					if child_window.is_active() {
@@ -207,6 +199,11 @@ impl WinitChildWindow {
 
 	pub fn set_active(&self, active: bool) {
 		self.window.set_visible(active);
+	}
+
+	pub fn set_position_and_size(&self, position: dpi::PhysicalPosition<u32>, size: dpi::PhysicalSize<u32>) {
+		self.window.set_outer_position(position);
+		let _ = self.window.request_inner_size(size);
 	}
 
 	pub fn text(&self) -> String {


### PR DESCRIPTION
The old technique had the benefit of not differing between `winit` and `qt`

Also changed `ChildWindow` to be an `enum` instead of `Box<dyn _>`