### PR TITLE
Added a preflight step to be ran prior to starting an emulation

### DIFF
--- a/src/appcommand.rs
+++ b/src/appcommand.rs
@@ -65,6 +65,11 @@ pub enum AppCommand {
 	ErrorMessageBox(String),
 
 	// Other
+	Start {
+		machine_name: String,
+		ram_size: Option<u64>,
+		initial_loads: Vec<(Arc<str>, Arc<str>)>,
+	},
 	IssueMameCommand(MameCommand),
 	Browse(PrefsCollection),
 	HistoryAdvance(isize),

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -981,6 +981,14 @@ fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 			let fut = dialog_message_box::<OkOnly>(model_clone.modal_stack.clone(), "Error", message);
 			spawn_local(fut).unwrap();
 		}
+		AppCommand::Start {
+			machine_name,
+			ram_size,
+			initial_loads,
+		} => {
+			let command = MameCommand::start(&machine_name, ram_size, &initial_loads).into();
+			handle_command(model, command);
+		}
 		AppCommand::IssueMameCommand(command) => {
 			model.issue_command(command);
 		}

--- a/src/dialogs/configure.rs
+++ b/src/dialogs/configure.rs
@@ -264,8 +264,9 @@ fn context_menu_command(state: &Rc<State>, command: AppCommand) {
 					description: "Image File".to_string(),
 					extensions,
 				}];
-				if let Some(filename) = dialog_load_image(state.modal_stack.clone(), &formats).await {
-					state.set_image_filename(tag, Some(filename));
+				if let Some(image_desc) = dialog_load_image(state.modal_stack.clone(), &formats).await {
+					let new_filename = Some(image_desc.encode().into());
+					state.set_image_filename(tag, new_filename);
 				}
 			};
 			spawn_local(fut).unwrap();
@@ -273,9 +274,9 @@ fn context_menu_command(state: &Rc<State>, command: AppCommand) {
 		AppCommand::ConnectToSocketDialog { tag } => {
 			let state = state.clone();
 			let fut = async move {
-				if let Some((hostname, port)) = dialog_connect_to_socket(state.modal_stack.clone()).await {
-					let filename = format!("socket.{hostname}:{port}");
-					state.set_image_filename(tag, Some(filename));
+				if let Some(image_desc) = dialog_connect_to_socket(state.modal_stack.clone()).await {
+					let new_filename = Some(image_desc.encode().into());
+					state.set_image_filename(tag, new_filename);
 				}
 			};
 			spawn_local(fut).unwrap();

--- a/src/dialogs/image.rs
+++ b/src/dialogs/image.rs
@@ -1,6 +1,7 @@
 use rfd::AsyncFileDialog;
 
 use crate::guiutils::modal::ModalStack;
+use crate::imagedesc::ImageDesc;
 
 #[derive(Clone, Debug)]
 pub struct Format {
@@ -8,7 +9,7 @@ pub struct Format {
 	pub extensions: Vec<String>,
 }
 
-pub async fn dialog_load_image(modal_stack: ModalStack, formats: &[Format]) -> Option<String> {
+pub async fn dialog_load_image(modal_stack: ModalStack, formats: &[Format]) -> Option<ImageDesc<String>> {
 	let all_extensions = formats.iter().flat_map(|f| f.extensions.clone()).collect::<Vec<_>>();
 
 	let parent = modal_stack.top();
@@ -21,5 +22,5 @@ pub async fn dialog_load_image(modal_stack: ModalStack, formats: &[Format]) -> O
 
 	let filename = dialog.pick_file().await?;
 	let filename = filename.file_name();
-	Some(filename)
+	Some(ImageDesc::File(filename))
 }

--- a/src/dialogs/socket.rs
+++ b/src/dialogs/socket.rs
@@ -4,9 +4,10 @@ use tokio::sync::mpsc;
 
 use crate::dialogs::SenderExt;
 use crate::guiutils::modal::ModalStack;
+use crate::imagedesc::ImageDesc;
 use crate::ui::ConnectToSocketDialog;
 
-pub async fn dialog_connect_to_socket(modal_stack: ModalStack) -> Option<(String, u16)> {
+pub async fn dialog_connect_to_socket(modal_stack: ModalStack) -> Option<ImageDesc<String>> {
 	// prepare the dialog
 	let modal = modal_stack.modal(|| ConnectToSocketDialog::new().unwrap());
 	let (tx, mut rx) = mpsc::channel(1);
@@ -53,10 +54,13 @@ fn update_can_accept(dialog: &ConnectToSocketDialog) {
 	dialog.set_can_accept(is_enabled);
 }
 
-fn get_results(dialog: &ConnectToSocketDialog) -> Option<(String, u16)> {
+fn get_results(dialog: &ConnectToSocketDialog) -> Option<ImageDesc<String>> {
 	let host_text = dialog.get_host_text();
 	let port_text = dialog.get_port_text();
 	let port = port_text.parse().ok()?;
 	let is_valid = hostname_validator::is_valid(&host_text);
-	is_valid.then(|| (host_text.into(), port))
+	is_valid.then(|| ImageDesc::Socket {
+		hostname: host_text.into(),
+		port,
+	})
 }

--- a/src/imagedesc.rs
+++ b/src/imagedesc.rs
@@ -1,0 +1,67 @@
+use std::borrow::Cow;
+use std::path::Path;
+use std::str::FromStr;
+
+use anyhow::Error;
+use anyhow::Result;
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub enum ImageDesc<S> {
+	File(S),
+	Software(S),
+	Socket { hostname: S, port: u16 },
+}
+
+impl<S> ImageDesc<S>
+where
+	S: AsRef<str>,
+{
+	pub fn encode(&self) -> Cow<'_, str> {
+		match self {
+			ImageDesc::File(filename) => Cow::Borrowed(filename.as_ref()),
+			ImageDesc::Software(software) => Cow::Borrowed(software.as_ref()),
+			ImageDesc::Socket { hostname, port } => format!("socket.{}:{}", hostname.as_ref(), *port).into(),
+		}
+	}
+
+	pub fn validate(&self) -> Result<()> {
+		if let Self::File(filename) = self {
+			let filename = filename.as_ref();
+			if !Path::new(filename).is_file() {
+				let message = format!("File Not Found: {filename}");
+				return Err(Error::msg(message));
+			}
+		}
+		Ok(())
+	}
+}
+
+impl<'a> ImageDesc<&'a str>
+where
+	Self: 'a,
+{
+	fn internal_parse(s: &'a str) -> Option<Self> {
+		if s.is_empty() {
+			None
+		} else if let Some(other) = s.strip_prefix("socket.") {
+			let (hostname, port) = other.split_once('.')?;
+			let port = u16::from_str(port).ok()?;
+			Some(Self::Socket { hostname, port })
+		} else if s.chars().any(|c| c == '\\' || c == '/' || c == '.' || c == ':') {
+			Some(Self::File(s))
+		} else {
+			Some(Self::Software(s))
+		}
+	}
+}
+
+impl<'a> TryFrom<&'a str> for ImageDesc<&'a str> {
+	type Error = Error;
+
+	fn try_from(value: &'a str) -> Result<Self> {
+		Self::internal_parse(value).ok_or_else(move || {
+			let message = format!("Cannot parse {value}");
+			Error::msg(message)
+		})
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod dialogs;
 mod guiutils;
 mod history;
 mod icon;
+mod imagedesc;
 mod info;
 mod job;
 mod mconfig;


### PR DESCRIPTION
This preflight step currently does nothing more than checking to see if the pertinent images exist, but this is a good start.  In the future we should also run our own ROM audit separate from MAME.