### PR TITLE
Changing how we track "image descriptions" across BletchMAME

### DIFF
--- a/plugins/worker_ui/init.lua
+++ b/plugins/worker_ui/init.lua
@@ -366,20 +366,22 @@ function emit_status(light, out)
 
 	-- abstractions to hide some differences between MAME 0.227 and
 	-- previous versions, similar to get_device_tag
-	local get_item_code, get_image_filename
+	local get_item_code, get_image_filename, get_loaded_through_softlist
 	local get_speed_percent, get_effective_frameskip, get_is_recording
 	if type(machine_video().speed_percent) == "function" then
-		get_item_code			= function(item) return item:code() end
-		get_image_filename		= function(image) return image:filename() end
-		get_speed_percent		= function() return machine_video():speed_percent() end
-		get_effective_frameskip	= function() return machine_video():effective_frameskip() end
-		get_is_recording		= function() return machine_video():is_recording() end
+		get_item_code				= function(item) return item:code() end
+		get_image_filename			= function(image) return image:filename() end
+		get_loaded_through_softlist	= function(image) return image:loaded_through_softlist() end
+		get_speed_percent			= function() return machine_video():speed_percent() end
+		get_effective_frameskip		= function() return machine_video():effective_frameskip() end
+		get_is_recording			= function() return machine_video():is_recording() end
 	else
-		get_item_code			= function(item) return item.code end
-		get_image_filename		= function(image) return image.filename end
-		get_speed_percent		= function() return machine_video().speed_percent end
-		get_effective_frameskip	= function() return machine_video().effective_frameskip end
-		get_is_recording		= function() return machine_video().is_recording end
+		get_item_code				= function(item) return item.code end
+		get_image_filename			= function(image) return image.filename end
+		get_loaded_through_softlist	= function(image) return image.loaded_through_softlist end
+		get_speed_percent			= function() return machine_video().speed_percent end
+		get_effective_frameskip		= function() return machine_video().effective_frameskip end
+		get_is_recording			= function() return machine_video().is_recording end
 	end
 
 	-- we don't always want to send details
@@ -482,6 +484,7 @@ function emit_status(light, out)
 			if filename == nil then
 				filename = ""
 			end
+			local loaded_through_softlist = get_loaded_through_softlist(image)
 
 			-- basic image properties
 			emit(string.format("\t\t<image tag=\"%s\"", xml_encode(get_device_tag(image.device))))
@@ -489,6 +492,9 @@ function emit_status(light, out)
 			-- filename
 			if filename ~= nil and filename ~= "" then
 				emit("\t\t\tfilename=\"" .. xml_encode(filename) .. "\"")
+			end
+			if loaded_through_softlist ~= nil then
+				emit("\t\t\tloaded_through_softlist=\"" .. string_from_bool(loaded_through_softlist) .. "\"")
 			end
 			emit("\t\t>")
 			if emit_details then

--- a/src/appcommand.rs
+++ b/src/appcommand.rs
@@ -14,6 +14,7 @@ use crate::prefs::PrefsCollection;
 use crate::prefs::PrefsItem;
 use crate::prefs::SortOrder;
 use crate::prefs::pathtype::PathType;
+use crate::runtime::MameStartArgs;
 use crate::runtime::command::MameCommand;
 use crate::runtime::command::SeqType;
 use crate::status::InputClass;
@@ -65,11 +66,7 @@ pub enum AppCommand {
 	ErrorMessageBox(String),
 
 	// Other
-	Start {
-		machine_name: String,
-		ram_size: Option<u64>,
-		initial_loads: Vec<(Arc<str>, Arc<str>)>,
-	},
+	Start(MameStartArgs),
 	IssueMameCommand(MameCommand),
 	Browse(PrefsCollection),
 	HistoryAdvance(isize),

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -10,7 +10,6 @@ use std::rc::Rc;
 use std::str::FromStr;
 use std::time::Instant;
 
-use itertools::Itertools;
 use muda::accelerator::Accelerator;
 use slint::CloseRequestResponse;
 use slint::ComponentHandle;
@@ -69,7 +68,6 @@ use crate::guiutils::menuing::MenuItemUpdate;
 use crate::guiutils::menuing::accel;
 use crate::guiutils::modal::ModalStack;
 use crate::history::History;
-use crate::imagedesc::ImageDesc;
 use crate::models::collectionsview::CollectionsViewModel;
 use crate::models::itemstable::EmptyReason;
 use crate::models::itemstable::ItemsTableModel;
@@ -983,31 +981,19 @@ fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 			let fut = dialog_message_box::<OkOnly>(model_clone.modal_stack.clone(), "Error", message);
 			spawn_local(fut).unwrap();
 		}
-		AppCommand::Start {
-			machine_name,
-			ram_size,
-			initial_loads,
-		} => {
-			let validation_errors = initial_loads
-				.iter()
-				.map(|x| {
-					let image_desc = ImageDesc::try_from(x.1.as_ref())?;
-					image_desc.validate()
-				})
-				.filter_map(|x| x.err())
-				.map(|e| e.to_string())
-				.join("\n");
-			if validation_errors.is_empty() {
-				let command = MameCommand::start(&machine_name, ram_size, &initial_loads).into();
+		AppCommand::Start(start_args) => match start_args.preflight() {
+			Ok(_) => {
+				let command = MameCommand::start(&start_args).into();
 				handle_command(model, command);
-			} else {
-				let validation_errors = format!(
-					"The emulation could not be started due to the following problems:\n\n{validation_errors}",
-				);
-				let fut = dialog_message_box::<OkOnly>(model.modal_stack.clone(), "Error", validation_errors);
+			}
+			Err(errors) => {
+				let message = errors.into_iter().map(|e| e.to_string()).collect::<String>();
+				let message =
+					format!("The emulation could not be started due to the following problems:\n\n{message}",);
+				let fut = dialog_message_box::<OkOnly>(model.modal_stack.clone(), "Error", message);
 				spawn_local(fut).unwrap();
 			}
-		}
+		},
 		AppCommand::IssueMameCommand(command) => {
 			model.issue_command(command);
 		}
@@ -1148,8 +1134,7 @@ fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 			let model_clone = model.clone();
 			let fut = async move {
 				if let Some(image_desc) = dialog_load_image(model_clone.modal_stack.clone(), &formats).await {
-					let filename = image_desc.encode();
-					let command = MameCommand::load_image(tag, &filename).into();
+					let command = MameCommand::load_image(tag, &image_desc).into();
 					handle_command(&model_clone, command);
 				}
 			};
@@ -1162,8 +1147,7 @@ fn handle_command(model: &Rc<AppModel>, command: AppCommand) {
 			let model_clone = model.clone();
 			let fut = async move {
 				if let Some(image_desc) = dialog_connect_to_socket(model_clone.modal_stack.clone()).await {
-					let filename = image_desc.encode();
-					let command = MameCommand::load_image(tag, &filename).into();
+					let command = MameCommand::load_image(tag, &image_desc).into();
 					handle_command(&model_clone, command);
 				}
 			};

--- a/src/dialogs/image.rs
+++ b/src/dialogs/image.rs
@@ -9,7 +9,7 @@ pub struct Format {
 	pub extensions: Vec<String>,
 }
 
-pub async fn dialog_load_image(modal_stack: ModalStack, formats: &[Format]) -> Option<ImageDesc<String>> {
+pub async fn dialog_load_image(modal_stack: ModalStack, formats: &[Format]) -> Option<ImageDesc> {
 	let all_extensions = formats.iter().flat_map(|f| f.extensions.clone()).collect::<Vec<_>>();
 
 	let parent = modal_stack.top();

--- a/src/dialogs/socket.rs
+++ b/src/dialogs/socket.rs
@@ -7,7 +7,7 @@ use crate::guiutils::modal::ModalStack;
 use crate::imagedesc::ImageDesc;
 use crate::ui::ConnectToSocketDialog;
 
-pub async fn dialog_connect_to_socket(modal_stack: ModalStack) -> Option<ImageDesc<String>> {
+pub async fn dialog_connect_to_socket(modal_stack: ModalStack) -> Option<ImageDesc> {
 	// prepare the dialog
 	let modal = modal_stack.modal(|| ConnectToSocketDialog::new().unwrap());
 	let (tx, mut rx) = mpsc::channel(1);
@@ -54,10 +54,9 @@ fn update_can_accept(dialog: &ConnectToSocketDialog) {
 	dialog.set_can_accept(is_enabled);
 }
 
-fn get_results(dialog: &ConnectToSocketDialog) -> Option<ImageDesc<String>> {
+fn get_results(dialog: &ConnectToSocketDialog) -> Option<ImageDesc> {
 	let host_text = dialog.get_host_text();
 	let port_text = dialog.get_port_text();
 	let port = port_text.parse().ok()?;
-	let is_valid = hostname_validator::is_valid(&host_text);
-	is_valid.then(|| ImageDesc::socket(host_text.into(), port))
+	ImageDesc::socket(host_text, port).ok()
 }

--- a/src/imagedesc.rs
+++ b/src/imagedesc.rs
@@ -1,50 +1,61 @@
 use std::borrow::Cow;
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::Arc;
 
-use anyhow::Error;
 use anyhow::Result;
+use serde::Deserialize;
+use serde::Serialize;
+use serde::de::Visitor;
+use serde::de::value::MapAccessDeserializer;
 
 use crate::software::is_valid_software_list_name;
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub enum ImageDesc<S> {
-	File(S),
-	Software(S),
-	Socket { hostname: S, port: u16 },
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ImageDesc {
+	File(String),
+	Software(Arc<str>),
+	Socket { hostname: String, port: u16 },
 }
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 enum ThisError {
 	#[error("invalid empty string")]
 	InvalidEmptyString,
-	#[error("cannot parse socket string")]
+	#[error("cannot parse socket string: {0}")]
 	CannotParseSocketString(String),
+	#[error("invalid host name: {0}")]
+	InvalidHostName(String),
 	#[error("cannot parse portnumber")]
 	CannotParsePortNumber,
 	#[error("file not found: {0}")]
 	FileNotFound(String),
+	#[error("invalid software name: {0}")]
+	InvalidSoftwareName(String),
 }
 
-impl<S> ImageDesc<S>
-where
-	S: AsRef<str>,
-{
-	pub fn socket(hostname: S, port: u16) -> Self {
-		Self::Socket { hostname, port }
+impl ImageDesc {
+	pub fn socket(hostname: impl Into<String>, port: u16) -> Result<Self> {
+		Ok(socket(hostname, port)?)
 	}
 
-	pub fn encode(&self) -> Cow<'_, str> {
+	pub fn from_mame_image_desc(
+		desc: impl Into<String> + AsRef<str>,
+		loaded_through_softlist: Option<bool>,
+	) -> Result<Self> {
+		Ok(from_mame_image_desc(desc, loaded_through_softlist)?)
+	}
+
+	pub fn as_mame_image_desc(&self) -> Cow<'_, str> {
 		match self {
-			ImageDesc::File(filename) => Cow::Borrowed(filename.as_ref()),
-			ImageDesc::Software(software) => Cow::Borrowed(software.as_ref()),
-			ImageDesc::Socket { hostname, port } => format!("socket.{}:{}", hostname.as_ref(), *port).into(),
+			Self::File(filename) => Cow::Borrowed(filename.as_ref()),
+			Self::Software(software) => Cow::Borrowed(software.as_ref()),
+			Self::Socket { hostname, port } => format!("socket.{}:{}", hostname, *port).into(),
 		}
 	}
 
 	pub fn validate(&self) -> Result<()> {
 		if let Self::File(filename) = self {
-			let filename = filename.as_ref();
 			if !Path::new(filename).is_file() {
 				let error = ThisError::FileNotFound(filename.to_string());
 				return Err(error.into());
@@ -52,35 +63,123 @@ where
 		}
 		Ok(())
 	}
-}
 
-impl<'a> ImageDesc<&'a str>
-where
-	Self: 'a,
-{
-	fn internal_parse(s: &'a str) -> std::result::Result<Self, ThisError> {
-		if s.is_empty() {
-			Err(ThisError::InvalidEmptyString)
-		} else if let Some(other) = s.strip_prefix("socket.") {
-			let (hostname, port) = other
-				.split_once(':')
-				.ok_or_else(|| ThisError::CannotParseSocketString(s.to_string()))?;
-			let port = u16::from_str(port).map_err(|_| ThisError::CannotParsePortNumber)?;
-			Ok(Self::Socket { hostname, port })
-		} else if is_valid_software_list_name(s) {
-			// not foolproof, but meh
-			Ok(Self::Software(s))
+	pub fn display_name(&self) -> Cow<'_, str> {
+		if let Self::File(filename) = self {
+			Path::new(filename).file_name().unwrap_or_default().to_string_lossy()
 		} else {
-			Ok(Self::File(s))
+			self.as_mame_image_desc()
 		}
 	}
 }
 
-impl<'a> TryFrom<&'a str> for ImageDesc<&'a str> {
-	type Error = Error;
+fn from_mame_image_desc(
+	desc: impl Into<String> + AsRef<str>,
+	loaded_through_softlist: Option<bool>,
+) -> std::result::Result<ImageDesc, ThisError> {
+	// sanity check
+	if desc.as_ref().is_empty() {
+		return Err(ThisError::InvalidEmptyString);
+	}
 
-	fn try_from(value: &'a str) -> Result<Self> {
-		Ok(Self::internal_parse(value)?)
+	// is this a socket identifier?
+	if let Some(other) = desc.as_ref().strip_prefix("socket.") {
+		let (hostname, port) = other
+			.split_once(':')
+			.ok_or_else(|| ThisError::CannotParseSocketString(desc.as_ref().to_string()))?;
+		let port = u16::from_str(port).map_err(|_| ThisError::CannotParsePortNumber)?;
+		socket(hostname, port)
+	} else {
+		// its not a socket... is it a file image or a software image?
+		let is_software = match loaded_through_softlist {
+			None => {
+				// not foolproof, but meh
+				is_valid_software_list_name(desc.as_ref())
+			}
+			Some(false) => false,
+			Some(true) => {
+				if !is_valid_software_list_name(desc.as_ref()) {
+					return Err(ThisError::InvalidSoftwareName(desc.into()));
+				}
+				true
+			}
+		};
+		if is_software {
+			Ok(ImageDesc::Software(desc.as_ref().into()))
+		} else {
+			Ok(ImageDesc::File(desc.into()))
+		}
+	}
+}
+
+fn socket(hostname: impl Into<String>, port: u16) -> Result<ImageDesc, ThisError> {
+	let hostname = hostname.into();
+	if !hostname_validator::is_valid(&hostname) {
+		return Err(ThisError::InvalidHostName(hostname));
+	}
+
+	Ok(ImageDesc::Socket { hostname, port })
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+enum ImageDescAlt {
+	File { filename: String },
+	Software { name: Arc<str> },
+	Socket { hostname: String, port: u16 },
+}
+
+impl Serialize for ImageDesc {
+	fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		let alt = match self.clone() {
+			ImageDesc::File(filename) => ImageDescAlt::File { filename },
+			ImageDesc::Software(name) => ImageDescAlt::Software { name },
+			ImageDesc::Socket { hostname, port } => ImageDescAlt::Socket { hostname, port },
+		};
+		alt.serialize(serializer)
+	}
+}
+
+impl<'de> Deserialize<'de> for ImageDesc {
+	fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		// Try deserializing as a string
+		struct StringOrEnumVisitor;
+
+		impl<'de> Visitor<'de> for StringOrEnumVisitor {
+			type Value = ImageDesc;
+
+			fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+				formatter.write_str("a tagged enum or a string for special case")
+			}
+
+			fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
+			where
+				E: serde::de::Error,
+			{
+				Ok(ImageDesc::from_mame_image_desc(v, None).unwrap())
+			}
+
+			fn visit_map<A>(self, map: A) -> std::result::Result<Self::Value, A::Error>
+			where
+				A: serde::de::MapAccess<'de>,
+			{
+				let result = match ImageDescAlt::deserialize(MapAccessDeserializer::new(map))? {
+					ImageDescAlt::File { filename } => ImageDesc::File(filename),
+					ImageDescAlt::Software { name } => ImageDesc::Software(name),
+					ImageDescAlt::Socket { hostname, port } => ImageDesc::Socket { hostname, port },
+				};
+				Ok(result)
+			}
+		}
+
+		deserializer.deserialize_any(StringOrEnumVisitor)
 	}
 }
 
@@ -91,24 +190,49 @@ mod test {
 	use super::ImageDesc;
 	use super::ThisError;
 
-	#[test_case(0, ImageDesc::File("/foo/bar.img"), "/foo/bar.img")]
-	#[test_case(1, ImageDesc::Software("abcde"), "abcde")]
-	#[test_case(2, ImageDesc::socket("contoso.com", 8888), "socket.contoso.com:8888")]
-	fn encode(_index: usize, image_desc: ImageDesc<&'static str>, expected: &str) {
-		let actual = image_desc.encode();
+	#[test_case(0, ImageDesc::File("/foo/bar.img".into()), "/foo/bar.img")]
+	#[test_case(1, ImageDesc::Software("abcde".into()), "abcde")]
+	#[test_case(2, ImageDesc::socket("contoso.com", 8888).unwrap(), "socket.contoso.com:8888")]
+	fn as_mame_image_desc(_index: usize, image_desc: ImageDesc, expected: &str) {
+		let actual = image_desc.as_mame_image_desc();
 		assert_eq!(expected, actual.as_ref());
 	}
 
-	#[test_case(0, "/foo/bar.img", Ok(ImageDesc::File("/foo/bar.img")))]
-	#[test_case(1, "abcde", Ok(ImageDesc::Software("abcde")))]
-	#[test_case(2, "socket.contoso.com:8888", Ok(ImageDesc::socket("contoso.com", 8888)))]
-	#[test_case(3, "", Err(ThisError::InvalidEmptyString))]
-	#[test_case(4, "socket.INVALID", Err(ThisError::CannotParseSocketString("socket.INVALID".into())))]
-	#[test_case(5, "socket.contoso.com:", Err(ThisError::CannotParsePortNumber))]
-	#[test_case(6, "socket.contoso.com:INVALID", Err(ThisError::CannotParsePortNumber))]
-	#[test_case(7, "socket.contoso.com:888888", Err(ThisError::CannotParsePortNumber))]
-	fn internal_parse(_index: usize, s: &str, expected: Result<ImageDesc<&'static str>, ThisError>) {
-		let actual = ImageDesc::internal_parse(s);
+	#[test_case(0, "/foo/bar.img", None, Ok(ImageDesc::File("/foo/bar.img".into())))]
+	#[test_case(1, "abcde", None, Ok(ImageDesc::Software("abcde".into())))]
+	#[test_case(2, "socket.contoso.com:8888", None, Ok(ImageDesc::socket("contoso.com", 8888).unwrap()))]
+	#[test_case(3, "", None, Err(ThisError::InvalidEmptyString))]
+	#[test_case(4, "socket.INVALID", None, Err(ThisError::CannotParseSocketString("socket.INVALID".into())))]
+	#[test_case(5, "socket.------:8888", None, Err(ThisError::InvalidHostName("------".into())))]
+	#[test_case(6, "socket.contoso.com:", None, Err(ThisError::CannotParsePortNumber))]
+	#[test_case(7, "socket.contoso.com:INVALID", None, Err(ThisError::CannotParsePortNumber))]
+	#[test_case(8, "socket.contoso.com:888888", None, Err(ThisError::CannotParsePortNumber))]
+	fn from_mame_image_desc(
+		_index: usize,
+		s: &str,
+		loaded_through_softlist: Option<bool>,
+		expected: Result<ImageDesc, ThisError>,
+	) {
+		let actual = super::from_mame_image_desc(s, loaded_through_softlist);
 		assert_eq!(expected, actual);
+	}
+
+	#[test_case(0, ImageDesc::File("/foo/bar.img".into()), r#"{"type":"file","filename":"/foo/bar.img"}"#)]
+	#[test_case(1, ImageDesc::Software("abcde".into()), r#"{"type":"software","name":"abcde"}"#)]
+	#[test_case(2, ImageDesc::socket("contoso.com", 8888).unwrap(), r#"{"type":"socket","hostname":"contoso.com","port":8888}"#)]
+	fn serialize(_index: usize, desc: ImageDesc, expected: &str) {
+		let actual = serde_json::to_string(&desc).unwrap();
+		assert_eq!(expected, &actual);
+	}
+
+	#[test_case(0, r#"{"type":"file","filename":"/alpha/bravo.img"}"#, ImageDesc::File("/alpha/bravo.img".into()))]
+	#[test_case(1, r#"{"type":"software","name":"fghijk"}"#, ImageDesc::Software("fghijk".into()))]
+	#[test_case(2, r#"{"type":"socket","hostname":"litware.com","port":7777}"#, ImageDesc::socket("litware.com", 7777).unwrap())]
+	#[test_case(3, "\"/foo/bar.img\"", ImageDesc::File("/foo/bar.img".into()))]
+	#[test_case(4, "\"abcde\"", ImageDesc::Software("abcde".into()))]
+	#[test_case(5, "\"socket.contoso.com:8888\"", ImageDesc::socket("contoso.com", 8888).unwrap())]
+	fn deserialize(_index: usize, json: &str, expected: ImageDesc) {
+		let actual = serde_json::from_str(json).unwrap();
+		assert_eq!(&expected, &actual);
 	}
 }

--- a/src/models/devimages.rs
+++ b/src/models/devimages.rs
@@ -1,7 +1,5 @@
 use std::any::Any;
-use std::borrow::Cow;
 use std::cell::RefCell;
-use std::path::Path;
 
 use slint::Model;
 use slint::ModelNotify;
@@ -12,6 +10,7 @@ use slint::VecModel;
 
 use crate::devimageconfig::DevicesImagesConfig;
 use crate::devimageconfig::EntryDetails;
+use crate::imagedesc::ImageDesc;
 use crate::ui::DeviceAndImageEntry;
 
 pub struct DevicesAndImagesModel {
@@ -111,13 +110,13 @@ impl Model for DevicesAndImagesModel {
 				let current_option_index = current_option_index.try_into().unwrap();
 				(options, current_option_index, "".into())
 			}
-			EntryDetails::Image { filename } => {
-				let filename = filename.map(|x| match Path::new(x).file_name() {
-					Some(x) => x.to_string_lossy(),
-					None => Cow::Borrowed(x),
-				});
-				let filename = filename.unwrap_or_default().as_ref().into();
-				(Vec::default(), -1, filename)
+			EntryDetails::Image { image_desc } => {
+				let display_name = image_desc
+					.map(ImageDesc::display_name)
+					.unwrap_or_default()
+					.as_ref()
+					.into();
+				(Vec::default(), -1, display_name)
 			}
 		};
 

--- a/src/prefs/mod.rs
+++ b/src/prefs/mod.rs
@@ -32,6 +32,7 @@ use tracing::info;
 
 use crate::history::History;
 use crate::icon::Icon;
+use crate::imagedesc::ImageDesc;
 use crate::info::InfoDb;
 use crate::prefs::pathtype::PathType;
 use crate::prefs::pathtype::PickType;
@@ -320,7 +321,7 @@ pub struct PrefsMachineItem {
 	pub slots: Vec<(String, Option<String>)>,
 
 	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
-	pub images: HashMap<String, String>,
+	pub images: HashMap<String, ImageDesc>,
 
 	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
 	pub ram_size: Option<u64>,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3,8 +3,14 @@ pub mod command;
 pub mod session;
 
 use std::rc::Rc;
+use std::sync::Arc;
 
+use anyhow::Error;
+use serde::Deserialize;
+use serde::Serialize;
 use strum::EnumString;
+
+use crate::imagedesc::ImageDesc;
 
 #[derive(Clone, Debug)]
 pub enum MameWindowing {
@@ -21,4 +27,25 @@ pub enum MameStderr {
 	Capture,
 	#[strum(ascii_case_insensitive)]
 	Inherit,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct MameStartArgs {
+	pub machine_name: String,
+	pub ram_size: Option<u64>,
+	pub slots: Vec<(Arc<str>, Arc<str>)>,
+	pub images: Vec<(Arc<str>, ImageDesc)>,
+}
+
+impl MameStartArgs {
+	pub fn preflight(&self) -> Result<(), Vec<Error>> {
+		let errors = self
+			.images
+			.iter()
+			.map(|(_, image_desc)| image_desc.validate())
+			.filter_map(|x| x.err())
+			.collect::<Vec<_>>();
+
+		if errors.is_empty() { Ok(()) } else { Err(errors) }
+	}
 }

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -16,6 +16,7 @@ use strum::EnumString;
 use tracing::debug;
 
 use crate::debugstr::DebugString;
+use crate::imagedesc::ImageDesc;
 use crate::info::InfoDb;
 use crate::status::parse::parse_update;
 use crate::status::validate::validate_status;
@@ -61,7 +62,7 @@ impl Status {
 
 						let new_status_image = Image {
 							tag: update_image.tag,
-							filename: update_image.filename,
+							image_desc: update_image.image_desc,
 							details,
 						};
 						Some(new_status_image)
@@ -131,7 +132,7 @@ pub struct Running {
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct Image {
 	pub tag: String,
-	pub filename: Option<String>,
+	pub image_desc: Option<ImageDesc>,
 	pub details: ImageDetails,
 }
 
@@ -201,7 +202,7 @@ struct RunningUpdate {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]
 struct ImageUpdate {
 	pub tag: String,
-	pub filename: Option<String>,
+	pub image_desc: Option<ImageDesc>,
 	pub details: Option<ImageDetails>,
 }
 


### PR DESCRIPTION
Traditionally, we would reference images using strings behaving the same as descriptors used on the MAME command line.  These could be
- Files (e.g. - `C:\foo\bar.dsk`)
- Software Names (e.g. - `zelda`)
- Sockets (e.g. - `socket.localhost:8888`)

The problem with using these descriptions is that while MAME will do its thing, BletchMAME doesn't really know what these are.  This means that if we have the word `zelda`, it could be either a software name or a file name.  Meaning that if we're going to preflight MAME emulation runs, we need to guess whether it is appropriate to do a file existence check.

With this change, the type of image is now encoded as an `ImageDesc`, which is now used across the codebase.

This was an intrusive change needing many changes (e.g. - encapsulating emulation start up arguments as `MameStartArgs`) affecting much of the codebase.  Therefore there is a high possibility of regressions.