### PR TITLE
Updated to the latest `quick-xml` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,7 @@ dependencies = [
  "num",
  "open",
  "qttypes",
- "quick-xml 0.37.5",
+ "quick-xml 0.38.0",
  "raw-window-handle",
  "rfd",
  "serde",
@@ -4578,6 +4578,15 @@ name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ muda = "=0.17.0"
 raw-window-handle = "0.6.2"
 rfd = "0.15.1"
 serde = { version = "1.0.219", features = ["rc"] }
-quick-xml = "0.37.4"
+quick-xml = "0.38.0"
 itertools = "0.14.0"
 winit = "0.30.3"
 tokio = { version = "1.44.2", features = [


### PR DESCRIPTION
In `0.38.0` a change was introduced to how XML entities were handled