### PR TITLE
Fixing problem where the menu bar would be transluscent in full screen mode

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -333,6 +333,11 @@ pub fn create(args: AppArgs) -> AppWindow {
 	})
 	.unwrap();
 
+	// this is necessary to make the menu bar visible in full screen mode (as per https://github.com/slint-ui/slint/issues/8793)
+	i_slint_backend_winit::WinitWindowAccessor::with_winit_window(app_window.window(), |window| {
+		window.set_transparent(false)
+	});
+
 	// get preferences
 	let prefs_path = args.prefs_path;
 	let preferences = Preferences::load(&prefs_path)


### PR DESCRIPTION
By default, Slint's winit back end specifies `with_transparency(true)`.  This is a workaround that undoes that.