### PR TITLE
Refactoring initialization; `appwindow::create()` ==> `appwindow::setup()`

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -80,6 +80,15 @@ impl BackendRuntime {
 		Ok(backend_runtime)
 	}
 
+	pub async fn wait_for_window_ready(&self, window: &Window) -> Result<()> {
+		match self {
+			Self::Winit(backend) => backend.wait_for_window_ready(window).await,
+
+			#[cfg(feature = "slint-qt-backend")]
+			Self::Qt(backend) => backend.wait_for_window_ready(window).await,
+		}
+	}
+
 	pub async fn create_child_window(&self, parent: &Window) -> Result<ChildWindow> {
 		let child_window = match self {
 			Self::Winit(backend) => ChildWindow::Winit(backend.create_child_window(parent).await?),

--- a/src/backend/qt.rs
+++ b/src/backend/qt.rs
@@ -26,6 +26,10 @@ impl QtBackendRuntime {
 		Box::new(slint_backend) as Box<_>
 	}
 
+	pub async fn wait_for_window_ready(&self, _window: &slint::Window) -> Result<()> {
+		Ok(())
+	}
+
 	pub fn create_child_window(&self, parent: &slint::Window) -> Result<QtChildWindow> {
 		let parent = parent.qt_widget_ptr().ok_or(ThisError::CannotCreateChildWindow)?;
 		let qt_widget = QtWidget::new(parent);

--- a/src/backend/winit.rs
+++ b/src/backend/winit.rs
@@ -93,6 +93,11 @@ impl WinitBackendRuntime {
 		Ok(Box::new(slint_backend) as Box<_>)
 	}
 
+	pub async fn wait_for_window_ready(&self, window: &slint::Window) -> Result<()> {
+		let _ = window.winit_window().await?;
+		Ok(())
+	}
+
 	pub async fn create_child_window(&self, parent: &slint::Window) -> Result<Rc<WinitChildWindow>> {
 		// prepare the window attributes
 		let raw_window_handle = parent.window_handle().window_handle()?.as_raw();


### PR DESCRIPTION
This is taking advantage of the recent addition of `winit_window()` in Slint that lets us await the creation of the winit window

Some gross hacks are now being done to hack in accelerators into Muda; hopefully this won't last that long