### PR TITLE
More modernization of menu command handling

### DIFF
--- a/src/dialogs/input/mod.rs
+++ b/src/dialogs/input/mod.rs
@@ -21,7 +21,7 @@ use crate::status::InputDevice;
 use crate::status::InputDeviceClass;
 use crate::status::InputDeviceClassName;
 use crate::status::InputDeviceItem;
-use crate::ui::InputContextMenuEntry;
+use crate::ui::SimpleMenuEntry;
 
 #[derive(Copy, Clone, Debug)]
 enum InputAxis {
@@ -190,7 +190,7 @@ fn build_context_menu<'a>(
 	specify_command: Option<AppCommand>,
 	add_command: Option<AppCommand>,
 	clear_command: Option<AppCommand>,
-) -> (ModelRc<InputContextMenuEntry>, ModelRc<InputContextMenuEntry>) {
+) -> (ModelRc<SimpleMenuEntry>, ModelRc<SimpleMenuEntry>) {
 	// first pass on processing quick items
 	let quick_items = quick_items
 		.into_iter()
@@ -225,7 +225,7 @@ fn build_context_menu<'a>(
 		let command = AppCommand::InputSelectMultipleDialog { selections };
 		let command = command.encode_for_slint();
 		let title = "Multiple...".into();
-		InputContextMenuEntry { title, command }
+		SimpleMenuEntry { title, command }
 	});
 
 	// now combine
@@ -235,7 +235,7 @@ fn build_context_menu<'a>(
 			let command = MameCommand::seq_set(&seqs);
 			let command = AppCommand::from(command).encode_for_slint();
 			let title = title.as_ref().into();
-			InputContextMenuEntry { title, command }
+			SimpleMenuEntry { title, command }
 		})
 		.chain(multiple_command)
 		.collect::<Vec<_>>();
@@ -251,7 +251,7 @@ fn build_context_menu<'a>(
 			command.map(|command| {
 				let title = title.into();
 				let command = command.encode_for_slint();
-				InputContextMenuEntry { title, command }
+				SimpleMenuEntry { title, command }
 			})
 		})
 		.collect::<Vec<_>>();

--- a/src/dialogs/input/primary.rs
+++ b/src/dialogs/input/primary.rs
@@ -37,9 +37,9 @@ use crate::status::InputClass;
 use crate::status::InputDeviceClass;
 use crate::status::InputDeviceToken;
 use crate::status::Status;
-use crate::ui::InputContextMenuEntry;
 use crate::ui::InputDialog;
 use crate::ui::InputDialogEntry;
+use crate::ui::SimpleMenuEntry;
 
 struct InputDialogModel {
 	dialog_weak: Weak<InputDialog>,
@@ -176,7 +176,7 @@ impl InputDialogModel {
 		}
 	}
 
-	pub fn context_menu(&self, index: usize) -> (ModelRc<InputContextMenuEntry>, ModelRc<InputContextMenuEntry>) {
+	pub fn context_menu(&self, index: usize) -> (ModelRc<SimpleMenuEntry>, ModelRc<SimpleMenuEntry>) {
 		let state = self.state.borrow();
 		let inputs = state.inputs.as_ref();
 

--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -68,6 +68,43 @@ export component AppWindow inherits Window {
     in property <int> menu-entries-throttle-current-index;
     in property <[SimpleMenuEntry]> menu-entries-builtin-collections;
     in property <[bool]> menu-entries-builtin-collections-checked;
+
+    // menu command strings
+    in property <string> menu-command-file-stop;
+    in property <string> menu-command-file-pause;
+    in property <string> menu-command-file-devices-and-images;
+    in property <string> menu-command-file-quick-load-state;
+    in property <string> menu-command-file-quick-save-state;
+    in property <string> menu-command-file-load-state;
+    in property <string> menu-command-file-save-state;
+    in property <string> menu-command-file-save-screenshot;
+    in property <string> menu-command-file-record-movie;
+    in property <string> menu-command-file-debugger;
+    in property <string> menu-command-file-reset-soft;
+    in property <string> menu-command-file-reset-hard;
+    in property <string> menu-command-file-exit;
+    in property <string> menu-command-options-throttle-speed-increase;
+    in property <string> menu-command-options-throttle-speed-decrease;
+    in property <string> menu-command-options-toggle-warp;
+    in property <string> menu-command-options-toggle-fullscreen;
+    in property <string> menu-command-options-toggle-menubar;
+    in property <string> menu-command-options-toggle-sound;
+    in property <string> menu-command-options-cheats;
+    in property <string> menu-command-options-classic;
+    in property <string> menu-command-options-console;
+    in property <string> menu-command-settings-input-controller;
+    in property <string> menu-command-settings-input-keyboard;
+    in property <string> menu-command-settings-input-misc;
+    in property <string> menu-command-settings-input-config;
+    in property <string> menu-command-settings-input-dipswitch;
+    in property <string> menu-command-settings-paths;
+    in property <string> menu-command-settings-reset;
+    in property <string> menu-command-settings-import-mame-ini;
+    in property <string> menu-command-help-refresh-info-db;
+    in property <string> menu-command-help-website;
+    in property <string> menu-command-help-about;
+
+    // height of the menubar
     public function menubar-height() -> length {
         return hbox.absolute-position.y;
     }
@@ -149,7 +186,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Stop");
                 enabled: mode() == "running";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-file-stop);
                 }
             }
 
@@ -157,7 +194,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Pause");
                 enabled: mode() == "running";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-file-pause);
                 }
             }
 
@@ -167,7 +204,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Devices and Images...");
                 enabled: mode() == "running";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-file-devices-and-images);
                 }
             }
 
@@ -176,7 +213,7 @@ export component AppWindow inherits Window {
                 enabled: has-last-save-state;
                 muda-accelerator: "F7";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-file-quick-load-state);
                 }
             }
 
@@ -185,7 +222,7 @@ export component AppWindow inherits Window {
                 enabled: has-last-save-state;
                 muda-accelerator: "Shift+F7";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-file-quick-save-state);
                 }
             }
 
@@ -194,7 +231,7 @@ export component AppWindow inherits Window {
                 enabled: mode() == "running";
                 muda-accelerator: "Ctrl+F7";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-file-load-state);
                 }
             }
 
@@ -203,7 +240,7 @@ export component AppWindow inherits Window {
                 enabled: mode() == "running";
                 muda-accelerator: "Ctrl+Shift+F7";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-file-save-state);
                 }
             }
 
@@ -214,7 +251,7 @@ export component AppWindow inherits Window {
                 enabled: mode() == "running";
                 muda-accelerator: "F12";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-file-save-screenshot);
                 }
             }
 
@@ -223,7 +260,7 @@ export component AppWindow inherits Window {
                 enabled: can-record-movie;
                 muda-accelerator: "Shift+F12";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-file-record-movie);
                 }
             }
 
@@ -233,7 +270,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Debugger...");
                 enabled: mode() == "running";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-file-debugger);
                 }
             }
 
@@ -243,14 +280,14 @@ export component AppWindow inherits Window {
                 MenuItem {
                     title: @tr("MenuBar" => "Soft Reset");
                     activated => {
-                        menu-item-activated(parent.title, self.title);
+                        menu-item-command(root.menu-command-file-reset-soft);
                     }
                 }
 
                 MenuItem {
                     title: @tr("MenuBar" => "Hard Reset");
                     activated => {
-                        menu-item-activated(parent.title, self.title);
+                        menu-item-command(root.menu-command-file-reset-hard);
                     }
                 }
             }
@@ -260,7 +297,7 @@ export component AppWindow inherits Window {
                 enabled: true;
                 muda-accelerator: "Ctrl+Shift+KeyX";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-file-exit);
                 }
             }
         }
@@ -284,7 +321,7 @@ export component AppWindow inherits Window {
                     title: @tr("MenuBar" => "Increase Speed");
                     muda-accelerator: "F9";
                     activated => {
-                        menu-item-activated(parent.title, self.title);
+                        menu-item-command(root.menu-command-options-throttle-speed-increase);
                     }
                 }
 
@@ -292,7 +329,7 @@ export component AppWindow inherits Window {
                     title: @tr("MenuBar" => "Decrease Speed");
                     muda-accelerator: "F8";
                     activated => {
-                        menu-item-activated(parent.title, self.title);
+                        menu-item-command(root.menu-command-options-throttle-speed-decrease);
                     }
                 }
 
@@ -302,7 +339,7 @@ export component AppWindow inherits Window {
                     checked: !is-throttled;
                     muda-accelerator: "F10";
                     activated => {
-                        menu-item-activated(parent.title, self.title);
+                        menu-item-command(root.menu-command-options-toggle-warp);
                     }
                 }
             }
@@ -312,16 +349,10 @@ export component AppWindow inherits Window {
                 enabled: mode() == "running";
                 MenuItem {
                     title: "Auto";
-                    activated => {
-                        menu-item-activated(parent.title, self.title);
-                    }
                 }
 
                 for rate in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]: MenuItem {
                     title: rate;
-                    activated => {
-                        menu-item-activated(parent.title, self.title);
-                    }
                 }
             }
 
@@ -332,7 +363,7 @@ export component AppWindow inherits Window {
                 checked: is-fullscreen;
                 muda-accelerator: "F11";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-options-toggle-fullscreen);
                 }
             }
 
@@ -341,7 +372,7 @@ export component AppWindow inherits Window {
                 enabled: mode() == "running";
                 muda-accelerator: "ScrollLock";
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-options-toggle-menubar);
                 }
             }
 
@@ -351,7 +382,7 @@ export component AppWindow inherits Window {
                 checkable: true;
                 checked: is-sound-enabled;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-options-toggle-sound);
                 }
             }
 
@@ -359,7 +390,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Cheats...");
                 enabled: has-cheats;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-options-cheats);
                 }
             }
 
@@ -369,7 +400,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Classic MAME Menu");
                 enabled: has-classic-mame-menu;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-options-classic);
                 }
             }
 
@@ -377,7 +408,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Console");
                 enabled: true;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-options-console);
                 }
             }
         }
@@ -388,7 +419,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Joysticks and Controllers...");
                 enabled: has-input-class-controller;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-settings-input-controller);
                 }
             }
 
@@ -396,7 +427,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Keyboard...");
                 enabled: has-input-class-keyboard;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-settings-input-keyboard);
                 }
             }
 
@@ -404,7 +435,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Miscellaneous Input...");
                 enabled: has-input-class-misc;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-settings-input-misc);
                 }
             }
 
@@ -412,7 +443,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Configuration...");
                 enabled: has-input-class-config;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-settings-input-config);
                 }
             }
 
@@ -420,7 +451,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "DIP Switches...");
                 enabled: has-input-class-dipswitch;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-settings-input-dipswitch);
                 }
             }
 
@@ -430,7 +461,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Paths...");
                 enabled: true;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-settings-paths);
                 }
             }
 
@@ -451,7 +482,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Reset Settings To Default");
                 enabled: true;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-settings-reset);
                 }
             }
 
@@ -459,7 +490,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Import MAME INI...");
                 enabled: true;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-settings-import-mame-ini);
                 }
             }
         }
@@ -470,7 +501,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "Refresh MAME machine info...");
                 enabled: can-refresh-info-db;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-help-refresh-info-db);
                 }
             }
 
@@ -478,7 +509,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "BletchMAME web site...");
                 enabled: true;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-help-website);
                 }
             }
 
@@ -486,7 +517,7 @@ export component AppWindow inherits Window {
                 title: @tr("MenuBar" => "About...");
                 enabled: true;
                 activated => {
-                    menu-item-activated(parent.title, self.title);
+                    menu-item-command(root.menu-command-help-about);
                 }
             }
         }

--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -66,7 +66,8 @@ export component AppWindow inherits Window {
     callback menu-item-command(string);
     in property <[SimpleMenuEntry]> menu-entries-throttle;
     in property <int> menu-entries-throttle-current-index;
-    in property <[string]> menu-items-builtin-collections;
+    in property <[SimpleMenuEntry]> menu-entries-builtin-collections;
+    in property <[bool]> menu-entries-builtin-collections-checked;
     public function menubar-height() -> length {
         return hbox.absolute-position.y;
     }
@@ -436,10 +437,12 @@ export component AppWindow inherits Window {
             Menu {
                 title: @tr("MenuBar" => "Builtin Collections");
                 enabled: true;
-                for title in menu-items-builtin-collections: MenuItem {
-                    title: title;
+                for entry[index] in menu-entries-builtin-collections: MenuItem {
+                    title: entry.title;
+                    checkable: true;
+                    checked: menu-entries-builtin-collections-checked[index];
                     activated => {
-                        menu-item-activated(parent.title, self.title);
+                        menu-item-command(entry.command);
                     }
                 }
             }

--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -1,6 +1,7 @@
 import { HorizontalBox, VerticalBox, Button, StandardListView, StandardTableView, LineEdit, ListView, ScrollView, GridBox, Spinner } from "std-widgets.slint";
 import { MagicListView, MagicListViewItem } from "@vivi/magic.slint";
 import { FilledIconButton, SearchBar } from "@slint/material.slint";
+import { SimpleMenuEntry } from "common.slint";
 
 struct CollectionContextMenuInfo {
     move-up-command: string,
@@ -51,7 +52,6 @@ export component AppWindow inherits Window {
     in property <bool> is-throttled;
     in property <bool> is-fullscreen;
     in property <bool> is-sound-enabled;
-    in property <int> current-throttle-rate;
     in property <bool> has-last-save-state;
     in property <bool> has-cheats;
     in property <bool> has-classic-mame-menu;
@@ -64,6 +64,8 @@ export component AppWindow inherits Window {
     in property <bool> has-input-class-dipswitch;
     callback menu-item-activated(string, string);
     callback menu-item-command(string);
+    in property <[SimpleMenuEntry]> menu-entries-throttle;
+    in property <int> menu-entries-throttle-current-index;
     in property <[string]> menu-items-builtin-collections;
     public function menubar-height() -> length {
         return hbox.absolute-position.y;
@@ -267,12 +269,12 @@ export component AppWindow inherits Window {
             Menu {
                 title: @tr("MenuBar" => "Throttle");
                 enabled: mode() == "running";
-                for rate in [1000, 500, 200, 100, 50, 20, 10]: MenuItem {
-                    title: rate + "%";
+                for entry[index] in menu-entries-throttle: MenuItem {
+                    title: entry.title;
                     checkable: true;
-                    checked: rate == current-throttle-rate;
+                    checked: index == menu-entries-throttle-current-index;
                     activated => {
-                        menu-item-activated(parent.title, self.title);
+                        menu-item-command(entry.command);
                     }
                 }
                 MenuSeparator { }

--- a/ui/common.slint
+++ b/ui/common.slint
@@ -1,0 +1,4 @@
+export struct SimpleMenuEntry {
+    title: string,
+    command: string}
+    

--- a/ui/input.slint
+++ b/ui/input.slint
@@ -1,14 +1,11 @@
 import { GridBox, VerticalBox, HorizontalBox, Button, StandardButton, ScrollView } from "std-widgets.slint";
+import { SimpleMenuEntry } from "common.slint";
 
 export struct InputDialogEntry {
     name: string,
     text: string,
     primary-command: string}
 
-export struct InputContextMenuEntry {
-    title: string,
-    command: string}
-    
 export component InputDialog inherits Window {
     title: dialog-title;
     icon: @image-url("bletchmame.png");
@@ -26,9 +23,9 @@ export component InputDialog inherits Window {
     callback menu-item-command(string);
 
     // context menu
-    in-out property <[InputContextMenuEntry]> context-menu-entries-1;
-    in-out property <[InputContextMenuEntry]> context-menu-entries-2;
-    public function show-context-menu(entries-1: [InputContextMenuEntry], entries-2: [InputContextMenuEntry], point: Point) {
+    in-out property <[SimpleMenuEntry]> context-menu-entries-1;
+    in-out property <[SimpleMenuEntry]> context-menu-entries-2;
+    public function show-context-menu(entries-1: [SimpleMenuEntry], entries-2: [SimpleMenuEntry], point: Point) {
         self.context-menu-entries-1 = entries-1;
         self.context-menu-entries-2 = entries-2;
         context-menu.show(point);

--- a/ui/input_xy.slint
+++ b/ui/input_xy.slint
@@ -1,5 +1,6 @@
 import { VerticalBox, GridBox, HorizontalBox, Button, StandardButton } from "std-widgets.slint";
-import { InputDialogEntry, InputContextMenuEntry } from "input.slint";
+import { InputDialogEntry } from "input.slint";
+import { SimpleMenuEntry } from "common.slint";
 
 component InputXyPart {
     // properties
@@ -55,9 +56,9 @@ export component InputXyDialog inherits Window {
     callback down-context-button-clicked(Point);
 
     // context menu
-    in-out property <[InputContextMenuEntry]> context-menu-entries-1;
-    in-out property <[InputContextMenuEntry]> context-menu-entries-2;
-    public function show-context-menu(entries-1: [InputContextMenuEntry], entries-2: [InputContextMenuEntry], point: Point) {
+    in-out property <[SimpleMenuEntry]> context-menu-entries-1;
+    in-out property <[SimpleMenuEntry]> context-menu-entries-2;
+    public function show-context-menu(entries-1: [SimpleMenuEntry], entries-2: [SimpleMenuEntry], point: Point) {
         self.context-menu-entries-1 = entries-1;
         self.context-menu-entries-2 = entries-2;
         context-menu.show(point);

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -14,5 +14,6 @@ import { InputXyDialog } from "input_xy.slint";
 import { InputSelectMultipleDialog } from "input_multi.slint";
 import { SeqPollDialog } from "seqpoll.slint";
 import { CheatsDialog, CheatsDialogEntry } from "cheats.slint";
+import { SimpleMenuEntry } from "common.slint";
 
-export { AboutDialog, AppWindow, ConfigureDialog, ConnectToSocketDialog, MessageBoxDialog, NameCollectionDialog, PathsDialog, DevicesAndImagesDialog, DeviceAndImageEntry, ImportMameIniDialog, InputDialog, InputDialogEntry, InputXyDialog, InputSelectMultipleDialog, SeqPollDialog, CheatsDialog, CheatsDialogEntry, Icons }
+export { AboutDialog, AppWindow, ConfigureDialog, ConnectToSocketDialog, MessageBoxDialog, NameCollectionDialog, PathsDialog, DevicesAndImagesDialog, DeviceAndImageEntry, ImportMameIniDialog, InputDialog, InputDialogEntry, InputXyDialog, InputSelectMultipleDialog, SeqPollDialog, CheatsDialog, CheatsDialogEntry, SimpleMenuEntry, Icons }


### PR DESCRIPTION
* "Throttle" and "Builtin Collections" are now implemented with simple models
* `AppCommand` instances for menu commands are now stored in strings instead of matching menu items