### PR TITLE
Creating initial (read only) version of the Configuration and DIP Swtiches dialog

### DIFF
--- a/src/dialogs/mod.rs
+++ b/src/dialogs/mod.rs
@@ -13,6 +13,7 @@ pub mod namecollection;
 pub mod paths;
 pub mod seqpoll;
 pub mod socket;
+pub mod switches;
 
 #[ext(SenderExt)]
 impl<T> Sender<T> {

--- a/src/dialogs/switches.rs
+++ b/src/dialogs/switches.rs
@@ -1,0 +1,212 @@
+use std::any::Any;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use slint::CloseRequestResponse;
+use slint::Model;
+use slint::ModelNotify;
+use slint::ModelRc;
+use slint::ModelTracker;
+use slint::ToSharedString;
+use slint::VecModel;
+use tokio::sync::mpsc;
+
+use crate::appcommand::AppCommand;
+use crate::channel::Channel;
+use crate::dialogs::SenderExt;
+use crate::guiutils::modal::ModalStack;
+use crate::info::InfoDb;
+use crate::info::View;
+use crate::status::Input;
+use crate::status::InputClass;
+use crate::status::Status;
+use crate::ui::SwitchesDialog;
+use crate::ui::SwitchesDialogEntry;
+
+struct SwitchesDialogModel {
+	state: RefCell<SwitchesDialogState>,
+	class: InputClass,
+	info_db: Rc<InfoDb>,
+	notify: ModelNotify,
+}
+
+#[derive(Debug, Default)]
+struct SwitchesDialogState {
+	pub machine_index: Option<usize>,
+	pub inputs: Arc<[Input]>,
+	pub entries: Box<[Entry]>,
+}
+
+#[derive(Debug)]
+struct Entry {
+	pub input_index: usize,
+	pub config_index: Option<usize>,
+}
+
+pub async fn dialog_switches(
+	modal_stack: ModalStack,
+	inputs: Arc<[Input]>,
+	info_db: Rc<InfoDb>,
+	class: InputClass,
+	machine_index: Option<usize>,
+	status_update_channel: Channel<Status>,
+	_invoke_command: impl Fn(AppCommand) + Clone + 'static,
+) {
+	// prepare the dialog
+	let modal = modal_stack.modal(|| SwitchesDialog::new().unwrap());
+	let (tx, mut rx) = mpsc::channel(1);
+
+	// set the title
+	modal.dialog().set_dialog_title(class.title().into());
+
+	// set up the close handler
+	let tx_clone = tx.clone();
+	modal.window().on_close_requested(move || {
+		tx_clone.signal(());
+		CloseRequestResponse::KeepWindowShown
+	});
+
+	// set up the "ok" button
+	let tx_clone = tx.clone();
+	modal.dialog().on_ok_clicked(move || {
+		tx_clone.signal(());
+	});
+
+	// set up the model
+	let model = SwitchesDialogModel::new(class, info_db.clone());
+	let model = Rc::new(model);
+	let model = ModelRc::new(model);
+	modal.dialog().set_entries(model.clone());
+
+	// subscribe to status changes
+	let model_clone = model.clone();
+	let _subscription = status_update_channel.subscribe(move |status| {
+		// update the model
+		let model = SwitchesDialogModel::get_model(&model_clone);
+		let running = status.running.as_ref();
+		let machine_index = running.and_then(|r| info_db.machines().find_index(r.machine_name.as_str()).ok());
+		let inputs = running.map(|r| &r.inputs).cloned().unwrap_or_default();
+		model.update(machine_index, inputs);
+	});
+
+	// update the model
+	SwitchesDialogModel::get_model(&model).update(machine_index, inputs);
+
+	// present the modal dialog
+	modal.run(async { rx.recv().await.unwrap() }).await;
+}
+
+impl SwitchesDialogModel {
+	pub fn new(class: InputClass, info_db: Rc<InfoDb>) -> Self {
+		let state = SwitchesDialogState::default();
+		let state = RefCell::new(state);
+		let notify = ModelNotify::default();
+		Self {
+			state,
+			class,
+			info_db,
+			notify,
+		}
+	}
+
+	pub fn update(&self, machine_index: Option<usize>, inputs: Arc<[Input]>) {
+		let changed = {
+			let mut state = self.state.borrow_mut();
+			let changed = state.machine_index != machine_index || state.inputs != inputs;
+			if changed {
+				state.machine_index = machine_index;
+				state.inputs = inputs;
+				state.entries = build_entries(&self.info_db, self.class, machine_index, &state.inputs);
+			}
+			changed
+		};
+		if changed {
+			self.notify.reset();
+		}
+	}
+
+	pub fn get_model(model: &impl Model) -> &'_ Self {
+		model.as_any().downcast_ref::<Self>().unwrap()
+	}
+}
+
+impl Model for SwitchesDialogModel {
+	type Data = SwitchesDialogEntry;
+
+	fn row_count(&self) -> usize {
+		self.state.borrow().entries.len()
+	}
+
+	fn row_data(&self, row: usize) -> Option<Self::Data> {
+		let state = self.state.borrow();
+		let entry = state.entries.get(row)?;
+		let input = state.inputs.get(entry.input_index).unwrap();
+		let name = input.name.to_shared_string();
+
+		let machine_index = state.machine_index?;
+		let machine = self.info_db.machines().get(machine_index).unwrap();
+
+		// get a view into the current config settings
+		let config_settings = entry.config_index.map(|config_index| {
+			let config = machine.configurations().get(config_index).unwrap();
+			config.settings()
+		});
+
+		// build the options list
+		let options = config_settings
+			.as_ref()
+			.map(|config_settings| {
+				config_settings
+					.iter()
+					.map(|s| s.name().to_shared_string())
+					.collect::<Vec<_>>()
+			})
+			.unwrap_or_default();
+		let options = VecModel::from(options);
+		let options = ModelRc::new(options);
+
+		let current_option_index = config_settings
+			.as_ref()
+			.and_then(|config_settings| config_settings.iter().position(|s| input.value == Some(s.value())));
+		let current_option_index = current_option_index.map(|x| x.try_into().unwrap()).unwrap_or(-1);
+
+		let entry = SwitchesDialogEntry {
+			name,
+			options,
+			current_option_index,
+		};
+		Some(entry)
+	}
+
+	fn model_tracker(&self) -> &dyn ModelTracker {
+		&self.notify
+	}
+
+	fn as_any(&self) -> &dyn Any {
+		self
+	}
+}
+
+fn build_entries(info_db: &InfoDb, class: InputClass, machine_index: Option<usize>, inputs: &[Input]) -> Box<[Entry]> {
+	let Some(machine_index) = machine_index else {
+		return Box::new([]);
+	};
+
+	let configurations = info_db.machines().get(machine_index).unwrap().configurations();
+
+	inputs
+		.iter()
+		.enumerate()
+		.filter(|(_, input)| input.class == Some(class))
+		.map(|(input_index, input)| {
+			let config_index = configurations
+				.iter()
+				.position(|c| c.tag() == input.port_tag && c.mask() == input.mask);
+			Entry {
+				input_index,
+				config_index,
+			}
+		})
+		.collect()
+}

--- a/src/info/binary.rs
+++ b/src/info/binary.rs
@@ -5,6 +5,7 @@ use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 use zerocopy::TryFromBytes;
 use zerocopy::little_endian::U16;
+use zerocopy::little_endian::U32;
 use zerocopy::little_endian::U64;
 
 use crate::info::UsizeDb;
@@ -27,6 +28,9 @@ pub struct Header {
 	pub build_strindex: UsizeDb,
 	pub machine_count: UsizeDb,
 	pub chips_count: UsizeDb,
+	pub config_count: UsizeDb,
+	pub config_setting_count: UsizeDb,
+	pub config_setting_condition_count: UsizeDb,
 	pub device_count: UsizeDb,
 	pub slot_count: UsizeDb,
 	pub slot_option_count: UsizeDb,
@@ -48,6 +52,8 @@ pub struct Machine {
 	pub manufacturer_strindex: UsizeDb,
 	pub chips_start: UsizeDb,
 	pub chips_end: UsizeDb,
+	pub configs_start: UsizeDb,
+	pub configs_end: UsizeDb,
 	pub devices_start: UsizeDb,
 	pub devices_end: UsizeDb,
 	pub slots_start: UsizeDb,
@@ -85,6 +91,53 @@ pub enum ChipType {
 	Cpu,
 	#[strum(serialize = "audio")]
 	Audio,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct Configuration {
+	pub name_strindex: UsizeDb,
+	pub tag_strindex: UsizeDb,
+	pub mask: U32,
+	pub settings_start: UsizeDb,
+	pub settings_end: UsizeDb,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct ConfigurationSetting {
+	pub name_strindex: UsizeDb,
+	pub value: U32,
+	pub conditions_start: UsizeDb,
+	pub conditions_end: UsizeDb,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct ConfigurationSettingCondition {
+	pub tag_strindex: UsizeDb,
+	pub condition_relation: ConditionRelation,
+	pub mask: U32,
+	pub value: U32,
+}
+
+#[repr(u8)]
+#[derive(
+	Clone, Copy, Debug, Deserialize, TryFromBytes, IntoBytes, Immutable, KnownLayout, EnumString, PartialEq, Eq,
+)]
+pub enum ConditionRelation {
+	#[strum(serialize = "eq")]
+	Eq,
+	#[strum(serialize = "ne")]
+	Ne,
+	#[strum(serialize = "gt")]
+	Gt,
+	#[strum(serialize = "le")]
+	Le,
+	#[strum(serialize = "lt")]
+	Lt,
+	#[strum(serialize = "ge")]
+	Ge,
 }
 
 #[repr(C, packed)]

--- a/src/info/binary.rs
+++ b/src/info/binary.rs
@@ -94,7 +94,7 @@ pub enum ChipType {
 }
 
 #[repr(C, packed)]
-#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout, PartialEq)]
 pub struct Configuration {
 	pub name_strindex: UsizeDb,
 	pub tag_strindex: UsizeDb,
@@ -104,7 +104,7 @@ pub struct Configuration {
 }
 
 #[repr(C, packed)]
-#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout, PartialEq)]
 pub struct ConfigurationSetting {
 	pub name_strindex: UsizeDb,
 	pub value: U32,
@@ -113,7 +113,7 @@ pub struct ConfigurationSetting {
 }
 
 #[repr(C, packed)]
-#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout, PartialEq)]
 pub struct ConfigurationSettingCondition {
 	pub tag_strindex: UsizeDb,
 	pub condition_relation: ConditionRelation,

--- a/src/info/entities.rs
+++ b/src/info/entities.rs
@@ -15,6 +15,9 @@ use crate::info::binary;
 pub type Machine<'a> = Object<'a, binary::Machine>;
 pub type MachinesView<'a> = SimpleView<'a, binary::Machine>;
 pub type Chip<'a> = Object<'a, binary::Chip>;
+pub type Configuration<'a> = Object<'a, binary::Configuration>;
+pub type ConfigurationSetting<'a> = Object<'a, binary::ConfigurationSetting>;
+pub type ConfigurationSettingCondition<'a> = Object<'a, binary::ConfigurationSettingCondition>;
 pub type Device<'a> = Object<'a, binary::Device>;
 pub type Slot<'a> = Object<'a, binary::Slot>;
 pub type SlotOption<'a> = Object<'a, binary::SlotOption>;
@@ -61,6 +64,11 @@ impl<'a> Machine<'a> {
 	pub fn chips(&self) -> impl View<'a, Chip<'a>> + use<'a> {
 		let range = self.obj().chips_start.into()..self.obj().chips_end.into();
 		self.db.chips().sub_view(range)
+	}
+
+	pub fn configurations(&self) -> impl View<'a, Configuration<'a>> + use<'a> {
+		let range = self.obj().configs_start.into()..self.obj().configs_end.into();
+		self.db.configurations().sub_view(range)
 	}
 
 	pub fn devices(&self) -> impl View<'a, Device<'a>> + use<'a> {
@@ -118,6 +126,35 @@ impl<'a> Chip<'a> {
 
 	pub fn chip_type(&self) -> ChipType {
 		self.obj().chip_type
+	}
+}
+
+impl<'a> Configuration<'a> {
+	pub fn name(&self) -> &'a str {
+		self.string(|x| x.name_strindex)
+	}
+
+	pub fn tag(&self) -> &'a str {
+		self.string(|x| x.tag_strindex)
+	}
+
+	pub fn mask(&self) -> u32 {
+		self.obj().mask.into()
+	}
+
+	pub fn settings(&self) -> impl View<'a, ConfigurationSetting<'a>> + use<'a> {
+		let range = self.obj().settings_start.into()..self.obj().settings_end.into();
+		self.db.configuration_settings().sub_view(range)
+	}
+}
+
+impl<'a> ConfigurationSetting<'a> {
+	pub fn name(&self) -> &'a str {
+		self.string(|x| x.name_strindex)
+	}
+
+	pub fn value(&self) -> u32 {
+		self.obj().value.into()
 	}
 }
 

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -269,6 +269,7 @@ pub struct Input {
 	pub player: u8,
 	pub is_analog: bool,
 	pub name: SmolStr,
+	pub value: Option<u32>,
 	pub first_keyboard_code: Option<u32>,
 	pub seq_standard_tokens: Option<SmolStr>,
 	pub seq_increment_tokens: Option<SmolStr>,

--- a/src/status/parse.rs
+++ b/src/status/parse.rs
@@ -376,6 +376,7 @@ impl State {
 					player,
 					is_analog,
 					name,
+					value,
 					first_keyboard_code,
 				] = evt.find_attributes([
 					b"port_tag",
@@ -386,6 +387,7 @@ impl State {
 					b"player",
 					b"is_analog",
 					b"name",
+					b"value",
 					b"first_keyboard_code",
 				])?;
 
@@ -400,6 +402,7 @@ impl State {
 				let player = player.ok_or(ThisError::MissingMandatoryAttribute("player"))?.parse()?;
 				let is_analog = parse_mame_bool(is_analog.ok_or(ThisError::MissingMandatoryAttribute("is_analog"))?)?;
 				let name = name.ok_or(ThisError::MissingMandatoryAttribute("name"))?.into();
+				let value = value.map(|value| value.parse::<u32>()).transpose()?;
 				let first_keyboard_code = first_keyboard_code.map(|x| x.parse()).transpose()?;
 
 				let input = Input {
@@ -411,6 +414,7 @@ impl State {
 					player,
 					is_analog,
 					name,
+					value,
 					first_keyboard_code,
 					seq_standard_tokens: None,
 					seq_increment_tokens: None,

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -13,7 +13,8 @@ import { InputDialog, InputDialogEntry } from "input.slint";
 import { InputXyDialog } from "input_xy.slint";
 import { InputSelectMultipleDialog } from "input_multi.slint";
 import { SeqPollDialog } from "seqpoll.slint";
+import { SwitchesDialog, SwitchesDialogEntry } from "switches.slint";
 import { CheatsDialog, CheatsDialogEntry } from "cheats.slint";
 import { SimpleMenuEntry } from "common.slint";
 
-export { AboutDialog, AppWindow, ConfigureDialog, ConnectToSocketDialog, MessageBoxDialog, NameCollectionDialog, PathsDialog, DevicesAndImagesDialog, DeviceAndImageEntry, ImportMameIniDialog, InputDialog, InputDialogEntry, InputXyDialog, InputSelectMultipleDialog, SeqPollDialog, CheatsDialog, CheatsDialogEntry, SimpleMenuEntry, Icons }
+export { AboutDialog, AppWindow, ConfigureDialog, ConnectToSocketDialog, MessageBoxDialog, NameCollectionDialog, PathsDialog, DevicesAndImagesDialog, DeviceAndImageEntry, ImportMameIniDialog, InputDialog, InputDialogEntry, InputXyDialog, InputSelectMultipleDialog, SeqPollDialog, SwitchesDialog, SwitchesDialogEntry, CheatsDialog, CheatsDialogEntry, SimpleMenuEntry, Icons }

--- a/ui/switches.slint
+++ b/ui/switches.slint
@@ -1,0 +1,69 @@
+import { GridBox, VerticalBox, HorizontalBox, Button, StandardButton, ScrollView, ComboBox } from "std-widgets.slint";
+
+export struct SwitchesDialogEntry {
+    name: string,
+    options: [string],
+    current-option-index: int}
+
+export component SwitchesDialog inherits Window {
+    title: dialog-title;
+    icon: @image-url("bletchmame.png");
+    preferred-width: 600px;
+    preferred-height: 500px;
+
+    // properties
+    in property <string> dialog-title;
+    in property <[SwitchesDialogEntry]> entries;
+    in property <string> restore-defaults-command;
+
+    // callbacks
+    callback ok-clicked();
+    callback menu-item-command(string);
+
+    // control hierarchy
+    VerticalBox {
+        ScrollView {
+            VerticalBox {
+                padding: 3px;
+                vertical-stretch: 0;
+                for entry[index] in root.entries: HorizontalLayout {
+                    vertical-stretch: 0;
+                    height: 30px;
+                    VerticalLayout {
+                        width: 300px;
+                        alignment: center;
+                        Text {
+                            text: entry.name;
+                        }
+                    }
+
+                    ComboBox {
+                        model: entry.options;
+                        current-index: entry.current-option-index;
+                        enabled: false;
+                    }
+                }
+            }
+        }
+
+        HorizontalBox {
+            alignment: end;
+            Button {
+                text: @tr("Restore Defaults");
+                horizontal-stretch: 0;
+                enabled: !root.restore-defaults-command.is-empty;
+                clicked => {
+                    menu-item-command(root.restore-defaults-command);
+                }
+            }
+
+            StandardButton {
+                kind: ok;
+                horizontal-stretch: 0;
+                clicked => {
+                    root.ok-clicked();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previously, we were incorrectly treating these dialogs as behaving like the other config dialogs