### PR TITLE
Overhaul to the Paths dialog

### DIFF
--- a/src/dialogs/paths.rs
+++ b/src/dialogs/paths.rs
@@ -11,6 +11,7 @@ use slint::ModelNotify;
 use slint::ModelRc;
 use slint::ModelTracker;
 use slint::SharedString;
+use slint::ToSharedString;
 use slint::VecModel;
 use slint::Weak;
 use slint::spawn_local;
@@ -22,11 +23,10 @@ use tracing::info;
 use crate::dialogs::SenderExt;
 use crate::dialogs::file::choose_path_by_type_dialog;
 use crate::guiutils::modal::ModalStack;
-use crate::icon::Icon;
 use crate::prefs::PrefsPaths;
 use crate::prefs::pathtype::PathType;
-use crate::ui::MagicListViewItem;
 use crate::ui::PathsDialog;
+use crate::ui::PathsListViewItem;
 
 struct State {
 	dialog_weak: Weak<PathsDialog>,
@@ -34,13 +34,10 @@ struct State {
 	original_paths: Rc<PrefsPaths>,
 }
 
-impl Debug for State {
-	fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		fmt.debug_map()
-			.entry(&"paths", &self.paths)
-			.entry(&"original_paths", &self.original_paths)
-			.finish_non_exhaustive()
-	}
+struct PathEntriesModel {
+	state: Rc<State>,
+	data: RefCell<Vec<PathsListViewItem>>,
+	notify: ModelNotify,
 }
 
 pub async fn dialog_paths(
@@ -51,15 +48,12 @@ pub async fn dialog_paths(
 	// prepare the dialog
 	let modal = modal_stack.modal(|| PathsDialog::new().unwrap());
 	let (tx, mut rx) = mpsc::channel(1);
-	let state = State {
-		dialog_weak: modal.dialog().as_weak(),
-		paths: RefCell::new((*paths).clone()),
-		original_paths: paths,
-	};
+	let dialog_weak = modal.dialog().as_weak();
+	let state = State::new(dialog_weak, paths);
 	let state = Rc::new(state);
 
 	// set up the "path labels" combo box
-	let path_labels = PathType::iter().map(|x| x.to_string().into()).collect::<Vec<_>>();
+	let path_labels = PathType::iter().map(|x| x.to_shared_string()).collect::<Vec<_>>();
 	let path_labels = VecModel::from(path_labels);
 	let path_labels = ModelRc::new(path_labels);
 	modal.dialog().set_path_labels(path_labels);
@@ -79,16 +73,31 @@ pub async fn dialog_paths(
 	// set up the "browse" button
 	let state_clone = state.clone();
 	modal.dialog().on_browse_clicked(move || {
-		let fut = browse_clicked(state_clone.clone());
+		let state_clone = state_clone.clone();
+		let fut = async move {
+			state_clone.browse_clicked().await;
+		};
+		spawn_local(fut).unwrap();
+	});
+
+	// set up the "insert" button
+	let state_clone = state.clone();
+	modal.dialog().on_insert_clicked(move || {
+		let state_clone = state_clone.clone();
+		let fut = async move {
+			state_clone.insert_clicked().await;
+		};
 		spawn_local(fut).unwrap();
 	});
 
 	// set up the "delete" button
 	let state_clone = state.clone();
 	modal.dialog().on_delete_clicked(move || {
-		let dialog = state_clone.dialog_weak.unwrap();
-		delete_clicked(&dialog);
-		model_contents_changed(&state_clone);
+		let state_clone = state_clone.clone();
+		let fut = async move {
+			state_clone.delete_clicked().await;
+		};
+		spawn_local(fut).unwrap();
 	});
 
 	// set up the close handler
@@ -98,47 +107,37 @@ pub async fn dialog_paths(
 		CloseRequestResponse::KeepWindowShown
 	});
 
-	// ensure paths entries are updated
-	let state_clone = state.clone();
-	let model: PathEntriesModel = PathEntriesModel::new(modal.dialog().as_weak(), move || {
-		model_contents_changed(&state_clone);
-	});
-	let model = ModelRc::from(Rc::new(model));
+	// set up the paths entries model
+	let model = PathEntriesModel::new(state.clone());
+	let model = Rc::new(model);
+	let model = ModelRc::from(model);
 	modal.dialog().set_path_entries(model);
+
+	// respond to path label index changed events
 	let state_clone = state.clone();
 	modal.dialog().on_path_label_index_changed(move || {
-		let dialog = state_clone.dialog_weak.unwrap();
-		update_paths_entries(&dialog, &state_clone.paths.borrow());
+		state_clone.update_dialog_from_paths();
 	});
 
-	// set the index on the path type dropdown
+	// determine the index on the paths dropdown
 	let path_label_index = path_type
 		.and_then(|path_type| PathType::iter().position(|x| x == path_type))
 		.unwrap_or_default();
-	if path_label_index != 0 {
-		let path_label_index = i32::try_from(path_label_index).unwrap();
-
+	if path_label_index > 0 {
 		// workaround for https://github.com/slint-ui/slint/issues/7632; please remove hack when fixed
-		let dialog_weak = modal.dialog().as_weak();
 		let state_clone = state.clone();
 		let fut = async move {
 			tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-			let dialog = dialog_weak.unwrap();
+			let dialog = state_clone.dialog_weak.unwrap();
+			let path_label_index = path_label_index.try_into().unwrap();
 			dialog.set_path_label_index(path_label_index);
-			update_paths_entries(&dialog, &state_clone.paths.borrow());
+			state_clone.update_dialog_from_paths();
 		};
 		spawn_local(fut).unwrap();
 	} else {
 		// if `path_label_index` is zero, we don't have to do the above buffoonery
-		update_paths_entries(modal.dialog(), &state.paths.borrow());
+		state.update_dialog_from_paths();
 	}
-
-	// update buttons when selected entries changes
-	let dialog_weak = modal.dialog().as_weak();
-	modal.dialog().on_path_entries_index_changed(move || {
-		let dialog = dialog_weak.unwrap();
-		update_buttons(&dialog);
-	});
 
 	// present the modal dialog
 	let accepted = modal.run(async { rx.recv().await.unwrap() }).await;
@@ -147,212 +146,183 @@ pub async fn dialog_paths(
 	accepted.then(|| Rc::try_unwrap(state).unwrap().paths.into_inner())
 }
 
-fn path_type(dialog: &PathsDialog) -> PathType {
-	dialog
-		.get_path_label_index()
-		.try_into()
-		.ok()
-		.and_then(|x: usize| PathType::VARIANTS.get(x))
-		.cloned()
-		.unwrap_or_default()
-}
-
-fn update_paths_entries(dialog: &PathsDialog, paths: &PrefsPaths) {
-	let path_type = path_type(dialog);
-
-	let path_entries = paths.by_type(path_type);
-	let paths_entries = path_entries
-		.iter()
-		.map(|path| {
-			let exists = paths.path_exists(path_type, path);
-			let prefix_icon = if exists { Icon::Blank } else { Icon::Clear };
-			let path = SharedString::from(path);
-			(path, prefix_icon)
-		})
-		.collect::<Vec<_>>();
-
-	let model = dialog.get_path_entries();
-	let model = PathEntriesModel::get_model(&model);
-	model.update(paths_entries, path_type.is_multi());
-}
-
-async fn browse_clicked(state: Rc<State>) {
-	let dialog = state.dialog_weak.unwrap();
-	let path_type = path_type(&dialog);
-	let model = dialog.get_path_entries();
-	let model = PathEntriesModel::get_model(&model);
-
-	// determine the existing path that should serve as the initial path for the dialog
-	let existing_path = usize::try_from(dialog.get_path_entry_index())
-		.ok()
-		.and_then(|index| model.entry(index));
-	let resolved_existing_path = existing_path
-		.as_ref()
-		.and_then(|path| state.paths.borrow().resolve(path));
-	let resolved_existing_path = resolved_existing_path.as_deref();
-	info!(
-		existing_path=?existing_path,
-		resolved_existing_path=?resolved_existing_path,
-		"browse_clicked()"
-	);
-
-	// show the file dialog
-	let parent = dialog.window().window_handle();
-	let Some(path) = choose_path_by_type_dialog(parent, path_type, resolved_existing_path).await else {
-		return;
-	};
-	let Ok(row) = usize::try_from(dialog.get_path_entry_index()) else {
-		return;
-	};
-	model.set_entry(row, &path, Icon::Blank);
-	model_contents_changed(&state);
-}
-
-fn delete_clicked(dialog: &PathsDialog) {
-	let Ok(row) = usize::try_from(dialog.get_path_entry_index()) else {
-		return;
-	};
-	let model = dialog.get_path_entries();
-	let model = PathEntriesModel::get_model(&model);
-	model.remove(row);
-}
-
-fn update_buttons(dialog: &PathsDialog) {
-	let model = dialog.get_path_entries();
-	let model = PathEntriesModel::get_model(&model);
-
-	let row = usize::try_from(dialog.get_path_entry_index()).ok();
-	dialog.set_browse_enabled(row.is_some());
-	dialog.set_delete_enabled(row.is_some_and(|x| x < model.entry_count()));
-}
-
-fn model_contents_changed(state: &State) {
-	let dialog = state.dialog_weak.unwrap();
-	let mut paths = state.paths.borrow_mut();
-	let original_paths = &state.original_paths;
-	let model = dialog.get_path_entries();
-	let model = PathEntriesModel::get_model(&model);
-
-	let path_type = path_type(&dialog);
-	let entries_iter = model.entries().into_iter().map(|x| x.to_string());
-	paths.set_by_type(path_type, entries_iter);
-	dialog.set_ok_enabled(*paths != **original_paths);
-}
-
-fn assign_if_changed<T>(target: &mut T, source: T) -> bool
-where
-	T: PartialEq,
-{
-	let changed = *target != source;
-	if changed {
-		*target = source;
+impl State {
+	pub fn new(dialog_weak: Weak<PathsDialog>, paths: Rc<PrefsPaths>) -> Self {
+		let original_paths = paths;
+		let paths = RefCell::new((*original_paths).clone());
+		Self {
+			dialog_weak,
+			paths,
+			original_paths,
+		}
 	}
-	changed
+
+	pub fn update_dialog_from_paths(&self) {
+		// get the current path type
+		let path_type = self.current_path_type();
+
+		// build the entries from the paths
+		let mut entries = {
+			let paths = self.paths.borrow();
+			paths
+				.by_type(path_type)
+				.iter()
+				.map(|text| {
+					let text = text.to_shared_string();
+					let is_error = !paths.path_exists(path_type, &text);
+					PathsListViewItem { text, is_error }
+				})
+				.collect::<Vec<_>>()
+		};
+
+		// add the final "append" entry if appropriate
+		if path_type.is_multi() {
+			let text = "".into();
+			let is_error = false;
+			entries.push(PathsListViewItem { text, is_error });
+		}
+
+		// update the entries from our paths variable
+		self.with_path_entries_model(|model| model.set_entries(entries));
+
+		// "ok" is enabled if things are different from the original
+		let is_dirty = *self.paths.borrow() != *self.original_paths;
+		self.dialog_weak.unwrap().set_ok_enabled(is_dirty);
+	}
+
+	pub fn update_paths_from_entries(&self) {
+		let dialog = self.dialog_weak.unwrap();
+		let path_type = PathType::VARIANTS[usize::try_from(dialog.get_path_label_index()).unwrap()];
+
+		self.with_path_entries_model(|model| {
+			model.with_entries(|entries| {
+				let paths_iter = entries
+					.iter()
+					.filter(|x| !x.text.is_empty())
+					.map(|x| x.text.to_string());
+				self.paths.borrow_mut().set_by_type(path_type, paths_iter);
+			});
+		});
+		self.update_dialog_from_paths();
+	}
+
+	pub async fn browse_clicked(&self) {
+		let path_type = self.current_path_type();
+		let path_entry_index = self.current_path_entry_index().unwrap();
+
+		// determine the existing path that should serve as the initial path for the dialog
+		let existing_path =
+			self.with_path_entries_model(|model| model.with_entries(|entries| entries[path_entry_index].text.clone()));
+
+		let resolved_existing_path = self.paths.borrow().resolve(&existing_path);
+		let resolved_existing_path = resolved_existing_path.as_deref();
+		info!(
+			existing_path=?existing_path,
+			resolved_existing_path=?resolved_existing_path,
+			"browse_clicked()"
+		);
+
+		// show the file dialog
+		let parent = self.dialog_weak.unwrap().window().window_handle();
+		let Some(path) = choose_path_by_type_dialog(parent, path_type, resolved_existing_path).await else {
+			return;
+		};
+
+		self.with_path_entries_model(|model| model.set_entry(path_entry_index, path));
+	}
+
+	pub async fn insert_clicked(&self) {
+		let row = self.current_path_entry_index().unwrap();
+		self.with_path_entries_model(|model| model.insert(row));
+		self.dialog_weak.unwrap().invoke_begin_editing();
+	}
+
+	pub async fn delete_clicked(&self) {
+		let row = self.current_path_entry_index().unwrap();
+		self.with_path_entries_model(|model| model.remove(row));
+	}
+
+	fn current_path_type(&self) -> PathType {
+		let dialog = self.dialog_weak.unwrap();
+		PathType::VARIANTS[usize::try_from(dialog.get_path_label_index()).unwrap()]
+	}
+
+	fn current_path_entry_index(&self) -> Option<usize> {
+		self.dialog_weak.unwrap().get_path_entry_index().try_into().ok()
+	}
+
+	fn with_path_entries_model<R>(&self, callback: impl FnOnce(&PathEntriesModel) -> R) -> R {
+		let dialog = self.dialog_weak.unwrap();
+		let model = dialog.get_path_entries();
+		let model = PathEntriesModel::get_model(&model);
+		callback(model)
+	}
 }
 
-struct PathEntriesModel {
-	dialog_weak: Weak<PathsDialog>,
-	changed_func: Box<dyn Fn() + 'static>,
-	data: RefCell<(Vec<(SharedString, Icon)>, bool)>,
-	notify: ModelNotify,
+impl Debug for State {
+	fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		fmt.debug_map()
+			.entry(&"paths", &self.paths)
+			.entry(&"original_paths", &self.original_paths)
+			.finish_non_exhaustive()
+	}
 }
 
 impl PathEntriesModel {
-	pub fn new(dialog_weak: Weak<PathsDialog>, changed_func: impl Fn() + 'static) -> Self {
-		let changed_func = Box::new(changed_func) as Box<dyn Fn() + 'static>;
-		let data = RefCell::new((Vec::new(), false));
+	pub fn new(state: Rc<State>) -> Self {
+		let data = RefCell::new(Vec::new());
 		let notify = ModelNotify::default();
-		Self {
-			dialog_weak,
-			changed_func,
-			data,
-			notify,
+		Self { state, data, notify }
+	}
+
+	pub fn with_entries<R>(&self, callback: impl FnOnce(&[PathsListViewItem]) -> R) -> R {
+		let entries = self.data.borrow();
+		callback(&entries)
+	}
+
+	pub fn set_entries(&self, entries: Vec<PathsListViewItem>) {
+		if *self.data.borrow() != entries {
+			self.data.replace(entries);
+			self.notify.reset();
 		}
 	}
 
-	pub fn update(&self, items: Vec<(SharedString, Icon)>, is_multi: bool) {
-		self.data.replace((items, is_multi));
-		self.notify.reset();
+	pub fn set_entry(&self, row: usize, text: impl Into<SharedString>) {
+		self.data.borrow_mut()[row].text = text.into();
+		self.state.update_paths_from_entries();
 	}
 
-	pub fn entry_count(&self) -> usize {
-		self.data.borrow().0.len()
-	}
-
-	pub fn append_row_index(&self) -> Option<usize> {
-		let data = self.data.borrow();
-		let (entries, is_multi) = &*data;
-		(*is_multi || entries.is_empty()).then_some(entries.len())
+	pub fn insert(&self, row: usize) {
+		self.data.borrow_mut().insert(row, Default::default());
+		self.notify.row_added(row, 1);
 	}
 
 	pub fn remove(&self, row: usize) {
-		let mut data = self.data.borrow_mut();
-		data.0.remove(row);
+		self.data.borrow_mut().remove(row);
 		self.notify.row_removed(row, 1);
+		self.state.update_paths_from_entries();
 	}
 
-	pub fn entries(&self) -> Vec<SharedString> {
-		let data = self.data.borrow();
-		data.0.iter().map(|(s, _)| s.clone()).collect()
-	}
-
-	pub fn entry(&self, index: usize) -> Option<SharedString> {
-		self.data.borrow().0.get(index).cloned().map(|x| x.0)
-	}
-
-	pub fn set_entry(&self, row: usize, text: impl Into<SharedString>, prefix_icon: Icon) {
-		let new_value = (text.into(), prefix_icon);
-		let changed = if self.append_row_index() == Some(row) {
-			self.data.borrow_mut().0.push(new_value);
-			self.notify.row_added(row, 1);
-			true
-		} else {
-			let changed = assign_if_changed(&mut self.data.borrow_mut().0[row], new_value);
-			if changed {
-				self.notify.row_changed(row);
-			}
-			changed
-		};
-		if changed {
-			(self.changed_func)();
-		}
-	}
-
-	fn make_entry(&self, text: impl Into<SharedString>, prefix_icon: Icon) -> MagicListViewItem {
-		let prefix_icon = prefix_icon.slint_icon(&self.dialog_weak.unwrap());
-		let text = text.into();
-		MagicListViewItem {
-			prefix_icon,
-			text,
-			supporting_text: Default::default(),
-		}
-	}
-
-	pub fn get_model(model: &ModelRc<MagicListViewItem>) -> &Self {
+	pub fn get_model(model: &ModelRc<PathsListViewItem>) -> &Self {
 		model.as_any().downcast_ref::<Self>().unwrap()
 	}
 }
 
 impl Model for PathEntriesModel {
-	type Data = MagicListViewItem;
+	type Data = PathsListViewItem;
 
 	fn row_count(&self) -> usize {
-		let len = self.data.borrow().0.len();
-		len + if self.append_row_index().is_some() { 1 } else { 0 }
+		self.data.borrow().len()
 	}
 
 	fn row_data(&self, row: usize) -> Option<Self::Data> {
-		let (text, prefix_icon) = if self.append_row_index() == Some(row) {
-			("<          >".into(), Icon::Blank)
-		} else {
-			self.data.borrow().0.get(row)?.clone()
-		};
-		let data = self.make_entry(text, prefix_icon);
-		Some(data)
+		self.data.borrow().get(row).cloned()
 	}
 
 	fn set_row_data(&self, row: usize, data: Self::Data) {
-		self.set_entry(row, data.text, Icon::Blank);
+		self.data.borrow_mut()[row] = data;
+		self.notify.row_changed(row);
+		self.state.update_paths_from_entries();
 	}
 
 	fn model_tracker(&self) -> &dyn ModelTracker {

--- a/ui/paths.slint
+++ b/ui/paths.slint
@@ -1,16 +1,105 @@
-import { AboutSlint, Button, VerticalBox, HorizontalBox, ComboBox, StandardListView, StandardButton } from "std-widgets.slint";
-import { MagicListView, MagicListViewItem } from "@vivi/magic.slint";
+import { AboutSlint, Button, VerticalBox, HorizontalBox, ComboBox, StandardListView, StandardButton, ListView, LineEdit, Palette } from "std-widgets.slint";
+
+struct PathsListViewItem {
+    text: string,
+    is-error: bool,
+}
+
+component PathsListView {
+    // properties
+    in property <[PathsListViewItem]> model;
+    in-out property <int> current-entry-index: -1;
+    in-out property <bool> editing;
+    in property <string> empty-text: "<          >";
+    property <int> to-focus-index: -1;
+
+    // callbacks
+    callback selected-index-changed();
+
+    // functions
+    public function begin-editing() {
+        if (current-entry-index >= 0) {
+            editing = true;
+            to-focus-index = current-entry-index;
+        }
+    }
+
+    // controls
+    ListView {
+        for item[idx] in model: entry-rectangle := Rectangle {
+            TouchArea {
+                HorizontalBox {
+                    alignment: start;
+                    Text {
+                        text: item.text != "" ? item.text : empty-text;
+                        color: item.is-error ? #FF0000 : idx == current-entry-index ? Palette.selection-foreground : Palette.foreground;
+                    }
+                }
+
+                visible: current-entry-index != idx || !editing;
+                clicked => {
+                    if (current-entry-index != idx) {
+                        current-entry-index = idx;
+                        editing = false;
+                        selected-index-changed();
+                    }
+                }
+                double-clicked => {
+                    editing = true;
+                    line-edit.focus();
+                    line-edit.select-all();
+                }
+            }
+
+            line-edit := LineEdit {
+                text: item.text;
+                horizontal-stretch: 1;
+                width: 100%;
+                visible: current-entry-index == idx && editing;
+                accepted(text) => {
+                    item.text = text;
+                    editing = false;
+                }
+
+                // crude focus trick
+                property <bool> should-get-focus: to-focus-index == idx;
+                changed should-get-focus => {
+                    if (should-get-focus) {
+                        self.focus();
+                        to-focus-index = -1;
+                    }
+                }
+
+                // the ESC key should break out
+                key-pressed(event) => {
+                    if (event.text == Key.Escape) {
+                        // Abort editing: reset to original text and remove focus
+                        self.text = item.text;
+                        self.clear-focus();
+                        editing = false;
+                        return EventResult.accept;
+                    }
+                    return EventResult.reject;
+                }
+            }
+
+            background: idx == current-entry-index ? Palette.selection-background : Colors.transparent;
+        }
+    }
+}
 
 export component PathsDialog inherits Window {
     title: "Paths";
     icon: @image-url("bletchmame.png");
+
+    // properties
     in property <[string]> path-labels;
-    in property <[MagicListViewItem]> path-entries;
+    in property <[PathsListViewItem]> path-entries;
     in property <bool> ok-enabled;
-    in property <bool> browse-enabled;
-    in property <bool> delete-enabled;
     in-out property <int> path-label-index;
-    out property <int> path-entry-index <=> entries-view.current-index;
+    out property <int> path-entry-index <=> entries-view.current-entry-index;
+
+    // callbacks
     callback ok-clicked();
     callback cancel-clicked();
     callback browse-clicked();
@@ -18,6 +107,13 @@ export component PathsDialog inherits Window {
     callback delete-clicked();
     callback path-label-index-changed();
     callback path-entries-index-changed();
+
+    // functions
+    public function begin-editing() {
+        entries-view.begin-editing();
+    }
+
+    // controls
     HorizontalBox {
         VerticalBox {
             preferred-width: 300px;
@@ -38,9 +134,9 @@ export component PathsDialog inherits Window {
                 text: "Paths:";
             }
 
-            entries-view := MagicListView {
+            entries-view := PathsListView {
                 model: path-entries;
-                selected => {
+                selected-index-changed => {
                     path-entries-index-changed();
                 }
             }
@@ -67,7 +163,7 @@ export component PathsDialog inherits Window {
 
             Button {
                 text: "Browse";
-                enabled: browse-enabled;
+                enabled: entries-view.current-entry-index >= 0;
                 clicked => {
                     root.browse-clicked();
                 }
@@ -75,7 +171,7 @@ export component PathsDialog inherits Window {
 
             Button {
                 text: "Insert";
-                enabled: false;
+                enabled: entries-view.current-entry-index >= 0 && entries-view.current-entry-index < path-entries.length - 1 && path-entries[path-entries.length - 1].text == "";
                 clicked => {
                     root.insert-clicked();
                 }
@@ -83,7 +179,7 @@ export component PathsDialog inherits Window {
 
             Button {
                 text: "Delete";
-                enabled: delete-enabled;
+                enabled: entries-view.current-entry-index >= 0 && path-entries[entries-view.current-entry-index].text != "";
                 clicked => {
                     root.delete-clicked();
                 }


### PR DESCRIPTION
This was a general overhaul to the Paths dialog, including the following:

Parity with old BletchMAME/MAMEUI
- Implemented the "Insert" button
- Entries can be edited inline

Other changes:
- No longer using `vivi`