### PR TITLE
Removing usage of the `vivi` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,6 @@ dependencies = [
  "tracing-subscriber",
  "unicase",
  "uuid",
- "vivi_ui",
  "win32job",
  "windows 0.62.0",
  "winit",
@@ -5831,11 +5830,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vivi_ui"
-version = "0.2.0"
-source = "git+https://seed.radicle.garden/z3oxAZSLcyXgpa7fcvgtueF49jHpH.git?rev=92a0987cf92647290353826bf05113a65fca25a9#92a0987cf92647290353826bf05113a65fca25a9"
 
 [[package]]
 name = "vtable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,6 @@ tempdir = "0.3.7"
 cpp_build = "0.5.10"
 ico = "0.4.0"
 slint-build = { git = "https://github.com/npwoods/slint.git", rev = "d18eaa5f07da1c7160b781c01e833ef4e957d6c4" }
-vivi_ui = { git = "https://seed.radicle.garden/z3oxAZSLcyXgpa7fcvgtueF49jHpH.git", rev = "92a0987cf92647290353826bf05113a65fca25a9" }
 slint-material-components = { git = "https://github.com/slint-ui/material-components.git", rev = "09988fb4f60a845a9b85e5b25cb744593abaacec" }
 winresource = "0.1.20"
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::env;
 use std::error::Error;
 use std::fs::File;
@@ -24,7 +25,7 @@ fn main() -> std::io::Result<()> {
 		.get("slint")
 		.unwrap()
 		.join("..");
-	let mut library_paths = vivi_ui::import_paths();
+	let mut library_paths = HashMap::new();
 	library_paths.insert("slint".into(), slint_material_components_dir);
 
 	// build Slint stuff

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -3,11 +3,8 @@ use slint::Image;
 
 use crate::ui::Icons;
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Icon {
-	#[default]
-	Blank,
-	Clear,
 	Folder,
 	Search,
 }
@@ -19,8 +16,6 @@ impl Icon {
 	{
 		let icons = Icons::get(component);
 		match self {
-			Icon::Blank => Image::default(),
-			Icon::Clear => icons.get_clear(),
 			Icon::Folder => icons.get_folder(),
 			Icon::Search => icons.get_search(),
 		}

--- a/ui/about.slint
+++ b/ui/about.slint
@@ -1,13 +1,14 @@
 import { AboutSlint, Button, VerticalBox, HorizontalBox } from "std-widgets.slint";
+import { Icons } from "icons.slint";
 
 export component AboutDialog inherits Window {
     title: "About BletchMAME";
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     HorizontalBox {
         Image {
             width: 192px;
             height: 192px;
-            source: @image-url("bletchmame.png");
+            source: Icons.bletchmame;
         }
 
         VerticalBox {

--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -1,6 +1,7 @@
 import { HorizontalBox, VerticalBox, Button, StandardListView, StandardTableView, LineEdit, ListView, ScrollView, GridBox, Spinner } from "std-widgets.slint";
 import { NavigationDrawer, NavigationItem, FilledIconButton, SearchBar } from "@slint/material.slint";
 import { SimpleMenuEntry } from "common.slint";
+import { Icons } from "icons.slint";
 
 struct CollectionContextMenuInfo {
     move-up-command: string,
@@ -29,7 +30,7 @@ export component AppWindow inherits Window {
     min-height: 100px;
     max-width: 10000px;
     max-height: 10000px;
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     title: @tr("BletchMAME 3.0 prototype") + (running-machine-desc != "" ? ": " + running-machine-desc : "");
 
     // width and height
@@ -682,7 +683,7 @@ export component AppWindow inherits Window {
                 preferred-width: 100%;
                 FilledIconButton {
                     horizontal-stretch: 0;
-                    icon: @image-url("icons/arrow-back.svg");
+                    icon: Icons.arrow-back;
                     enabled: history-can-go-back;
                     clicked => {
                         history-advance-clicked(-1)
@@ -691,7 +692,7 @@ export component AppWindow inherits Window {
 
                 FilledIconButton {
                     horizontal-stretch: 0;
-                    icon: @image-url("icons/book.svg");
+                    icon: Icons.book;
                     enabled: bookmark-collection-enabled;
                     clicked => {
                         bookmark-collection-clicked();
@@ -700,7 +701,7 @@ export component AppWindow inherits Window {
 
                 FilledIconButton {
                     horizontal-stretch: 0;
-                    icon: @image-url("icons/arrow-forward.svg");
+                    icon: Icons.arrow-forward;
                     enabled: history-can-go-forward;
                     clicked => {
                         history-advance-clicked(+1)

--- a/ui/cheats.slint
+++ b/ui/cheats.slint
@@ -1,4 +1,5 @@
 import { GridBox, VerticalBox, HorizontalBox, Button, StandardButton, ScrollView, CheckBox, Slider, ComboBox } from "std-widgets.slint";
+import { Icons } from "icons.slint";
 
 export struct CheatsDialogEntry {
     cheat-type: string,
@@ -15,7 +16,7 @@ export struct CheatsDialogEntry {
 
 export component CheatsDialog inherits Window {
     title: "Cheats";
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     preferred-width: 600px;
     preferred-height: 500px;
 

--- a/ui/configure.slint
+++ b/ui/configure.slint
@@ -1,5 +1,6 @@
 import { Button, HorizontalBox, VerticalBox, TabWidget, ComboBox, GridBox, StandardButton, ListView, CheckBox  } from "std-widgets.slint";
 import { DevicesAndImagesList, DevicesAndImagesState, DevicesAndImagesContextMenuInfo } from "devimageslist.slint";
+import { Icons } from "icons.slint";
 
 struct SoftwareMachine {
     machine-index: int,
@@ -8,7 +9,7 @@ struct SoftwareMachine {
 
 export component ConfigureDialog inherits Window {
     title: dialog-title;
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     preferred-width: 600px;
     preferred-height: 500px;
 

--- a/ui/devimages.slint
+++ b/ui/devimages.slint
@@ -1,10 +1,10 @@
 import { Button, VerticalBox, HorizontalBox, ComboBox, ListView, LineEdit, StandardButton } from "std-widgets.slint";
 import { DevicesAndImagesList, DeviceAndImageEntry, DevicesAndImagesState, DevicesAndImagesContextMenuInfo } from "devimageslist.slint";
-
+import { Icons } from "icons.slint";
 
 export component DevicesAndImagesDialog inherits Window {
     title: "Devices And Images";
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     callback ok-clicked();
     callback apply-changes-clicked();
     preferred-width: 600px;

--- a/ui/icons.slint
+++ b/ui/icons.slint
@@ -1,0 +1,10 @@
+import { Icons as ViviIcons } from "@vivi/magic.slint";
+
+export global Icons {
+    out property <image> bletchmame: @image_url("bletchmame.png");
+    out property <image> arrow-back: @image_url("icons/arrow-back.svg");
+    out property <image> arrow-forward: @image_url("icons/arrow-forward.svg");
+    out property <image> book: @image_url("icons/book.svg");
+    out property <image> folder: ViviIcons.folder;
+    out property <image> search: ViviIcons.search;
+}

--- a/ui/icons.slint
+++ b/ui/icons.slint
@@ -1,10 +1,8 @@
-import { Icons as ViviIcons } from "@vivi/magic.slint";
-
 export global Icons {
     out property <image> bletchmame: @image_url("bletchmame.png");
     out property <image> arrow-back: @image_url("icons/arrow-back.svg");
     out property <image> arrow-forward: @image_url("icons/arrow-forward.svg");
     out property <image> book: @image_url("icons/book.svg");
-    out property <image> folder: ViviIcons.folder;
-    out property <image> search: ViviIcons.search;
+    out property <image> folder: @image_url("icons/folder.svg");
+    out property <image> search: @image_url("icons/search.svg");
 }

--- a/ui/icons/folder.svg
+++ b/ui/icons/folder.svg
@@ -1,0 +1,5 @@
+<!--
+    SPDX-FileCopyrightText: Google Inc. <https://fonts.google.com/icons?selected=Material+Icons>
+    SPDX-License-Identifier: Apache-2.0
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="m9.17 6 2 2H20v10H4V6h5.17M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/></svg>

--- a/ui/icons/search.svg
+++ b/ui/icons/search.svg
@@ -1,0 +1,5 @@
+<!--
+    SPDX-FileCopyrightText: Google Inc. <https://fonts.google.com/icons?selected=Material+Icons>
+    SPDX-License-Identifier: Apache-2.0
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>

--- a/ui/importmameini.slint
+++ b/ui/importmameini.slint
@@ -1,4 +1,5 @@
 import { VerticalBox, GridBox, HorizontalBox, StandardButton, ComboBox, ListView } from "std-widgets.slint";
+import { Icons } from "icons.slint";
 
 export struct ImportMameIniDialogEntry {
     path-type: string,
@@ -9,7 +10,7 @@ export struct ImportMameIniDialogEntry {
 
 export component ImportMameIniDialog inherits Window {
     title: "Import MAME INI";
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     preferred-width: 600px;
     preferred-height: 500px;
 

--- a/ui/input.slint
+++ b/ui/input.slint
@@ -1,5 +1,6 @@
 import { GridBox, VerticalBox, HorizontalBox, Button, StandardButton, ScrollView } from "std-widgets.slint";
 import { SimpleMenuEntry } from "common.slint";
+import { Icons } from "icons.slint";
 
 export struct InputDialogEntry {
     name: string,
@@ -8,7 +9,7 @@ export struct InputDialogEntry {
 
 export component InputDialog inherits Window {
     title: dialog-title;
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     preferred-width: 600px;
     preferred-height: 500px;
 

--- a/ui/input_multi.slint
+++ b/ui/input_multi.slint
@@ -1,4 +1,5 @@
 import { StandardListView, HorizontalBox, VerticalBox, StandardButton, CheckBox } from "std-widgets.slint";
+import { Icons } from "icons.slint";
 
 export component InputSelectMultipleDialog inherits Window {
     // properties
@@ -11,7 +12,7 @@ export component InputSelectMultipleDialog inherits Window {
 
     // control hierarchy
     title: "Multiple";
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     VerticalBox {
         for text[i] in entries: CheckBox {
             text: text;

--- a/ui/input_xy.slint
+++ b/ui/input_xy.slint
@@ -1,6 +1,7 @@
 import { VerticalBox, GridBox, HorizontalBox, Button, StandardButton } from "std-widgets.slint";
 import { InputDialogEntry } from "input.slint";
 import { SimpleMenuEntry } from "common.slint";
+import { Icons } from "icons.slint";
 
 component InputXyPart {
     // properties
@@ -87,7 +88,7 @@ export component InputXyDialog inherits Window {
 
     // control hierarchy
     title: dialog-title;
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     VerticalBox {
         GridBox {
             InputXyPart {

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -1,4 +1,4 @@
-export { Icons } from "@vivi/magic.slint";
+export { Icons } from "icons.slint";
 export { AboutDialog } from "about.slint";
 export { PathsDialog } from "paths.slint";
 export { MessageBoxDialog } from "messagebox.slint";

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -1,20 +1,18 @@
-import { Icons } from "@vivi/magic.slint";
-import { AboutDialog } from "about.slint";
-import { PathsDialog } from "paths.slint";
-import { MessageBoxDialog } from "messagebox.slint";
-import { NameCollectionDialog } from "namecollection.slint";
-import { ConnectToSocketDialog } from "socket.slint";
-import { DevicesAndImagesDialog } from "devimages.slint";
-import { DeviceAndImageEntry } from "devimageslist.slint";
-import { AppWindow } from "appwindow.slint";
-import { ConfigureDialog } from "configure.slint";
-import { ImportMameIniDialog } from "importmameini.slint";
-import { InputDialog, InputDialogEntry } from "input.slint";
-import { InputXyDialog } from "input_xy.slint";
-import { InputSelectMultipleDialog } from "input_multi.slint";
-import { SeqPollDialog } from "seqpoll.slint";
-import { SwitchesDialog, SwitchesDialogEntry } from "switches.slint";
-import { CheatsDialog, CheatsDialogEntry } from "cheats.slint";
-import { SimpleMenuEntry } from "common.slint";
-
-export { AboutDialog, AppWindow, ConfigureDialog, ConnectToSocketDialog, MessageBoxDialog, NameCollectionDialog, PathsDialog, DevicesAndImagesDialog, DeviceAndImageEntry, ImportMameIniDialog, InputDialog, InputDialogEntry, InputXyDialog, InputSelectMultipleDialog, SeqPollDialog, SwitchesDialog, SwitchesDialogEntry, CheatsDialog, CheatsDialogEntry, SimpleMenuEntry, Icons }
+export { Icons } from "@vivi/magic.slint";
+export { AboutDialog } from "about.slint";
+export { PathsDialog } from "paths.slint";
+export { MessageBoxDialog } from "messagebox.slint";
+export { NameCollectionDialog } from "namecollection.slint";
+export { ConnectToSocketDialog } from "socket.slint";
+export { DevicesAndImagesDialog } from "devimages.slint";
+export { DeviceAndImageEntry } from "devimageslist.slint";
+export { AppWindow } from "appwindow.slint";
+export { ConfigureDialog } from "configure.slint";
+export { ImportMameIniDialog } from "importmameini.slint";
+export { InputDialog, InputDialogEntry } from "input.slint";
+export { InputXyDialog } from "input_xy.slint";
+export { InputSelectMultipleDialog } from "input_multi.slint";
+export { SeqPollDialog } from "seqpoll.slint";
+export { SwitchesDialog, SwitchesDialogEntry } from "switches.slint";
+export { CheatsDialog, CheatsDialogEntry } from "cheats.slint";
+export { SimpleMenuEntry } from "common.slint";

--- a/ui/messagebox.slint
+++ b/ui/messagebox.slint
@@ -1,4 +1,5 @@
 import { Button, VerticalBox, HorizontalBox } from "std-widgets.slint";
+import { Icons } from "icons.slint";
 
 export component MessageBoxDialog inherits Window {
     in property <string> title-text;
@@ -6,7 +7,7 @@ export component MessageBoxDialog inherits Window {
     in property <[string]> button-texts;
     callback button-clicked(int);
     title: title-text;
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     VerticalBox {
         Text {
             text: message-text;

--- a/ui/namecollection.slint
+++ b/ui/namecollection.slint
@@ -1,8 +1,10 @@
 import { AboutSlint, Button, VerticalBox, HorizontalBox, LineEdit, StandardButton } from "std-widgets.slint";
+import { Icons } from "icons.slint";
+import { Icons } from "icons.slint";
 
 export component NameCollectionDialog inherits Window {
     title: title-text;
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     width: 400px;
     height: 100px;
     callback ok-clicked();

--- a/ui/paths.slint
+++ b/ui/paths.slint
@@ -1,4 +1,5 @@
 import { AboutSlint, Button, VerticalBox, HorizontalBox, ComboBox, StandardListView, StandardButton, ListView, LineEdit, Palette } from "std-widgets.slint";
+import { Icons } from "icons.slint";
 
 struct PathsListViewItem {
     text: string,
@@ -90,7 +91,7 @@ component PathsListView {
 
 export component PathsDialog inherits Window {
     title: "Paths";
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
 
     // properties
     in property <[string]> path-labels;

--- a/ui/seqpoll.slint
+++ b/ui/seqpoll.slint
@@ -1,9 +1,10 @@
 
 import { VerticalBox, HorizontalBox, Button } from "std-widgets.slint";
+import { Icons } from "icons.slint";
 
 export component SeqPollDialog inherits Window {
     title: dialog-title;
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
 
     // properties
     in property <string> dialog-title;

--- a/ui/socket.slint
+++ b/ui/socket.slint
@@ -1,8 +1,9 @@
 import { Button, VerticalBox, HorizontalBox, LineEdit, StandardButton } from "std-widgets.slint";
+import { Icons } from "icons.slint";
 
 export component ConnectToSocketDialog inherits Window {
     title: "Connect To Socket";
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     height: 150px;
     width: 350px;
     callback accepted();

--- a/ui/switches.slint
+++ b/ui/switches.slint
@@ -1,4 +1,5 @@
 import { GridBox, VerticalBox, HorizontalBox, Button, StandardButton, ScrollView, ComboBox } from "std-widgets.slint";
+import { Icons } from "icons.slint";
 
 export struct SwitchesDialogEntry {
     name: string,
@@ -7,7 +8,7 @@ export struct SwitchesDialogEntry {
 
 export component SwitchesDialog inherits Window {
     title: dialog-title;
-    icon: @image-url("bletchmame.png");
+    icon: Icons.bletchmame;
     preferred-width: 600px;
     preferred-height: 500px;
 


### PR DESCRIPTION
`vivi` doesn't seem to be under active development, and `material-components` gives us more