### PR TITLE
Fixing bug in Paths Dialog that prevented user from setting a single path option if none was there

### DIFF
--- a/src/dialogs/paths.rs
+++ b/src/dialogs/paths.rs
@@ -176,7 +176,7 @@ impl State {
 		};
 
 		// add the final "append" entry if appropriate
-		if path_type.is_multi() {
+		if path_type.is_multi() || entries.is_empty() {
 			let text = "".into();
 			let is_error = false;
 			entries.push(PathsListViewItem { text, is_error });


### PR DESCRIPTION
The only single path type was "MAME Executable"