### PR TITLE
Fixing an issue that could cause a panic if some folders have more items than others

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -1266,13 +1266,13 @@ fn handle_action(model: &Rc<AppModel>, command: Action) {
 				.enumerate()
 				.filter_map(|(folder_index, collection)| {
 					if let PrefsCollection::Folder { name, items } = collection.as_ref() {
-						(name == &folder_name).then_some((folder_index, items[index].clone()))
+						(name == &folder_name).then(|| (folder_index, items[index].clone()))
 					} else {
 						None
 					}
 				})
 				.next()
-				.unwrap();
+				.expect("could not find folder");
 
 			let fut = async move {
 				let paths = model_clone.preferences.borrow().paths.clone();


### PR DESCRIPTION
The issue was that when we were responding to `Action::Configure`, we have to search for the folder.  But the code that looked up the item in the folder always executed even if the target folder was not found.  This would panic if the index of the configured item exceeded the size of the other folder.