### PR TITLE
Updated to a newer version of our hacked fork of Slint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,8 +1168,8 @@ dependencies = [
 
 [[package]]
 name = "const-field-offset"
-version = "0.1.5"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+version = "0.2.0"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "const-field-offset-macro",
  "field-offset",
@@ -1177,8 +1177,8 @@ dependencies = [
 
 [[package]]
 name = "const-field-offset-macro"
-version = "0.1.5"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+version = "0.2.0"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2429,7 +2429,7 @@ checksum = "48ce8546b993eaf241d69ded33b1be6d205dd9857ec879d9d18bd05d3676e144"
 [[package]]
 name = "i-slint-backend-linuxkms"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "bytemuck",
  "calloop 0.14.4",
@@ -2450,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-qt"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "const-field-offset",
  "cpp",
@@ -2468,7 +2468,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-selector"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "cfg-if",
  "i-slint-backend-linuxkms",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-winit"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2528,19 +2528,19 @@ dependencies = [
 [[package]]
 name = "i-slint-common"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
+ "derive_more",
  "fontique",
  "htmlparser",
  "pulldown-cmark",
  "skrifa",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "i-slint-compiler"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "annotate-snippets",
  "by_address",
@@ -2572,7 +2572,7 @@ dependencies = [
 [[package]]
 name = "i-slint-core"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "auto_enums",
  "bitflags 2.11.0",
@@ -2619,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "i-slint-core-macros"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "quote",
  "serde_json",
@@ -2629,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-femtovg"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "cfg-if",
  "const-field-offset",
@@ -2650,7 +2650,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-skia"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2686,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-software"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "bytemuck",
  "clru",
@@ -5586,7 +5586,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slint"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "const-field-offset",
  "i-slint-backend-selector",
@@ -5607,7 +5607,7 @@ dependencies = [
 [[package]]
 name = "slint-build"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "derive_more",
  "fontique",
@@ -5619,7 +5619,7 @@ dependencies = [
 [[package]]
 name = "slint-macros"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "i-slint-compiler",
  "proc-macro2",
@@ -5630,7 +5630,7 @@ dependencies = [
 [[package]]
 name = "slint-material-components"
 version = "1.16.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 
 [[package]]
 name = "slotmap"
@@ -6605,8 +6605,8 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vtable"
-version = "0.3.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+version = "0.4.0"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "const-field-offset",
  "portable-atomic",
@@ -6616,8 +6616,8 @@ dependencies = [
 
 [[package]]
 name = "vtable-macro"
-version = "0.3.0"
-source = "git+https://github.com/npwoods/slint.git?rev=2a8b1d0732939e1ea0f670912505a6fd1e087304#2a8b1d0732939e1ea0f670912505a6fd1e087304"
+version = "0.4.0"
+source = "git+https://github.com/npwoods/slint.git?rev=bd1503fffbaad88534a6aead879b7ef221f2c20a#bd1503fffbaad88534a6aead879b7ef221f2c20a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,11 +67,11 @@ zerocopy = { version = "0.8.48", features = ["derive"] }
 zip = "7.2.0"
 
 # Slint dependencies
-i-slint-backend-qt = { git = "https://github.com/npwoods/slint.git", rev = "2a8b1d0732939e1ea0f670912505a6fd1e087304", optional = true }
-i-slint-backend-winit = { git = "https://github.com/npwoods/slint.git", rev = "2a8b1d0732939e1ea0f670912505a6fd1e087304" }
-i-slint-common = { git = "https://github.com/npwoods/slint.git", rev = "2a8b1d0732939e1ea0f670912505a6fd1e087304" }
-i-slint-core = { git = "https://github.com/npwoods/slint.git", rev = "2a8b1d0732939e1ea0f670912505a6fd1e087304" }
-slint = { git = "https://github.com/npwoods/slint.git", rev = "2a8b1d0732939e1ea0f670912505a6fd1e087304", features = [
+i-slint-backend-qt = { git = "https://github.com/npwoods/slint.git", rev = "bd1503fffbaad88534a6aead879b7ef221f2c20a", optional = true }
+i-slint-backend-winit = { git = "https://github.com/npwoods/slint.git", rev = "bd1503fffbaad88534a6aead879b7ef221f2c20a" }
+i-slint-common = { git = "https://github.com/npwoods/slint.git", rev = "bd1503fffbaad88534a6aead879b7ef221f2c20a" }
+i-slint-core = { git = "https://github.com/npwoods/slint.git", rev = "bd1503fffbaad88534a6aead879b7ef221f2c20a" }
+slint = { git = "https://github.com/npwoods/slint.git", rev = "bd1503fffbaad88534a6aead879b7ef221f2c20a", features = [
     "raw-window-handle-06",
 ] }
 
@@ -103,8 +103,8 @@ test-case = "3.3.1"
 [build-dependencies]
 cpp_build = "0.5.10"
 ico = "0.5.0"
-slint-build = { git = "https://github.com/npwoods/slint.git", rev = "2a8b1d0732939e1ea0f670912505a6fd1e087304" }
-slint-material-components = { git = "https://github.com/npwoods/slint.git", rev = "2a8b1d0732939e1ea0f670912505a6fd1e087304" }
+slint-build = { git = "https://github.com/npwoods/slint.git", rev = "bd1503fffbaad88534a6aead879b7ef221f2c20a" }
+slint-material-components = { git = "https://github.com/npwoods/slint.git", rev = "bd1503fffbaad88534a6aead879b7ef221f2c20a" }
 winresource = "0.1.31"
 
 [profile.dev]


### PR DESCRIPTION
This includes a fix that will allow menu shortcuts to work when the menu bar is disabled