### PR TITLE
Fixing an issue that could cause hanging on initial run or when window size is default

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -22,6 +22,7 @@ use slint::LogicalPosition;
 use slint::LogicalSize;
 use slint::Model;
 use slint::ModelRc;
+use slint::PhysicalSize;
 use slint::SharedString;
 use slint::TableColumn;
 use slint::ToSharedString;
@@ -509,6 +510,17 @@ pub async fn start(app_window: &AppWindow, args: AppArgs) {
 	let (child_window, mame_windowing) = match args.mame_windowing {
 		AppWindowing::Integrated => {
 			let parent = app_window.window();
+
+			// the following is a stupid hack only needed for winit where we need to force some `WindowEvent`'s to
+			// fire so that the child window can be properly created
+			let size = app_window.window().size();
+			parent.set_size(PhysicalSize {
+				width: size.width + 1,
+				..size
+			});
+			parent.set_size(size);
+
+			// finally create the child window
 			let child_window = args.backend_runtime.create_child_window(parent).await.unwrap();
 			let child_window_text = child_window.text();
 			(Some(child_window), MameWindowing::Attached(child_window_text.into()))


### PR DESCRIPTION
The issue is that the `winit` code relies on `WindowEvent`s being pumped so that `create_pending_child_windows()` can be called.  But if the window size is not specified (or it is specified but unchanged), no `WindowEVent`s will fire.

This is a stupid hack to get around this problem.