### PR TITLE
Changed representation of history items to reference collections and items instead of identifying them by value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,7 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "assert_matches",
+ "base64",
  "binary-search",
  "byte-unit",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ i-slint-core = { git = "https://github.com/npwoods/slint.git", rev = "495f2eca43
 slint = { git = "https://github.com/npwoods/slint.git", rev = "495f2eca43ff1617bb10e572946b6e4f551ef812", features = [
     "raw-window-handle-06",
 ] }
+base64 = "0.22.1"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 features = [

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsStr;
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -79,10 +80,10 @@ pub enum Action {
 	SearchText(String),
 	ItemsSort(usize, SortOrder),
 	ItemsSelectedChanged,
-	AddToExistingFolder(usize, Vec<PrefsItem>),
-	AddToNewFolder(String, Vec<PrefsItem>),
-	AddToNewFolderDialog(Vec<PrefsItem>),
-	RemoveFromFolder(String, Vec<PrefsItem>),
+	AddToExistingFolder(usize, Arc<[PrefsItem]>),
+	AddToNewFolder(String, Arc<[PrefsItem]>),
+	AddToNewFolderDialog(Arc<[PrefsItem]>),
+	RemoveFromFolder(String, Box<[SmolStr]>),
 	MoveCollection {
 		old_index: usize,
 		new_index: Option<usize>,

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -1315,12 +1315,12 @@ fn handle_action(model: &Rc<AppModel>, action: Action) {
 		}
 		Action::AddToExistingFolder(folder_index, new_items) => {
 			model.modify_prefs(|prefs| {
-				add_items_to_existing_folder_collection(&mut prefs.collections, folder_index, new_items);
+				add_items_to_existing_folder_collection(&mut prefs.collections, folder_index, &new_items);
 			});
 		}
 		Action::AddToNewFolder(name, items) => {
 			model.modify_prefs(|prefs| {
-				add_items_to_new_folder_collection(&mut prefs.collections, name, items);
+				add_items_to_new_folder_collection(&mut prefs.collections, name, items.iter().cloned().collect());
 			});
 		}
 		Action::AddToNewFolderDialog(items) => {
@@ -1689,7 +1689,7 @@ fn update_ui_for_current_history_item(model: &AppModel) {
 	app_window.set_collections_view_selected_index(collection_index);
 
 	// update the snap view
-	let current_snap_view = snap_view_string(prefs.current_history_entry().selection.first());
+	let current_snap_view = snap_view_string(&collection, prefs.current_history_entry().selection.first());
 	app_window.set_current_snap_view(current_snap_view);
 
 	// and finish tracing

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -37,14 +37,18 @@ pub fn add_items_to_new_folder_collection(
 pub fn add_items_to_existing_folder_collection(
 	collections: &mut [Rc<PrefsCollection>],
 	folder_index: usize,
-	mut new_items: Vec<PrefsItem>,
+	new_items: &[PrefsItem],
 ) {
 	let mut col = Rc::unwrap_or_clone(collections[folder_index].clone());
 	let PrefsCollection::Folder { items, .. } = &mut col else {
 		panic!("Expected PrefsCollection::Folder");
 	};
 
-	new_items.retain(|x| !items.contains(x));
+	let new_items = new_items
+		.iter()
+		.filter(|x| !items.contains(x))
+		.cloned()
+		.collect::<Vec<_>>();
 	items.extend(new_items);
 
 	collections[folder_index] = Rc::new(col);
@@ -53,7 +57,7 @@ pub fn add_items_to_existing_folder_collection(
 pub fn remove_items_from_folder_collection(
 	collections: &mut [Rc<PrefsCollection>],
 	folder_name: String,
-	items: &[PrefsItem],
+	ids: &[impl AsRef<str>],
 ) {
 	let (index, old_items) = collections
 		.iter()
@@ -70,7 +74,10 @@ pub fn remove_items_from_folder_collection(
 
 	let new_items = old_items
 		.iter()
-		.filter(|x| !items.contains(x))
+		.filter(|x| {
+			let id = x.id.get_opt();
+			!ids.iter().any(|y| Some(y.as_ref()) == id.as_deref())
+		})
 		.cloned()
 		.collect::<Vec<_>>();
 

--- a/src/dialogs/configure.rs
+++ b/src/dialogs/configure.rs
@@ -619,7 +619,8 @@ impl State {
 		let video = (!dialog.get_video_use_default_settings())
 			.then(|| PrefsVideo::try_from(&dialog.get_video_settings()).unwrap());
 
-		PrefsItem { details, video }
+		let id = Default::default();
+		PrefsItem { id, details, video }
 	}
 
 	pub fn set_slot_entry_option(&self, entry_index: usize, new_option_name: Option<&str>) {

--- a/src/history.rs
+++ b/src/history.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 use crate::prefs::HistoryEntry;
 use crate::prefs::Preferences;
 use crate::prefs::PrefsCollection;
+use crate::prefs::PrefsCollectionRef;
 
 const MAX_HISTORY_LEN: usize = 10;
 
@@ -35,7 +36,7 @@ where
 		let (history, position) = self.entries_mut();
 
 		let history_entry: HistoryEntry = HistoryEntry {
-			collection: sanitize_collection(collection),
+			collection: reference_collection(collection),
 			search: "".into(),
 			sort_suppressed: false,
 			selection: Vec::default(),
@@ -61,16 +62,27 @@ where
 
 	fn current_collection(&self) -> (Rc<PrefsCollection>, Option<usize>) {
 		let collections = self.collections();
-		let target_collection = &self.current_history_entry().collection;
+		let target_collection_ref = &self.current_history_entry().collection;
 
 		let (collection, collection_index) = if let Some((index, collection)) = collections
 			.iter()
 			.enumerate()
-			.find(|(_, collection)| &sanitize_collection((*collection).clone()) == target_collection)
+			.find(|(_, collection)| &reference_collection(collection) == target_collection_ref)
 		{
+			let collection = collection.clone();
 			(collection, Some(index))
 		} else {
-			(target_collection, None)
+			let collection = match target_collection_ref {
+				PrefsCollectionRef::Builtin(name) => PrefsCollection::Builtin(*name),
+				PrefsCollectionRef::MachineSoftware { machine_name } => PrefsCollection::MachineSoftware {
+					machine_name: machine_name.clone(),
+				},
+				PrefsCollectionRef::Folder { name } => {
+					panic!("History entry references folder {name} which does not exist in collections")
+				}
+			};
+			let collection = Rc::new(collection);
+			(collection, None)
 		};
 		(collection.clone(), collection_index)
 	}
@@ -103,8 +115,8 @@ where
 
 		let (entries, _) = self.entries_mut();
 		for entry in entries.iter_mut() {
-			if matches!(entry.collection.as_ref(), PrefsCollection::Folder { name, .. } if name == &old_name) {
-				entry.collection = sanitize_collection(new_collection.clone());
+			if matches!(&entry.collection, PrefsCollectionRef::Folder { name, .. } if name == &old_name) {
+				entry.collection = reference_collection(&new_collection);
 			}
 		}
 	}
@@ -124,7 +136,7 @@ where
 		// and retain everything - except folders that are no longer named
 		let history_entries = take(history);
 		let (new_history, new_position) = retain_with_position(history_entries, *position, |entry| {
-			collection_folder_name(&entry.collection).is_none_or(|x| folder_names.contains(x))
+			collection_ref_folder_name(&entry.collection).is_none_or(|x| folder_names.contains(x))
 		});
 
 		// override the old history
@@ -139,21 +151,26 @@ fn advance_position(position: usize, length: usize, delta: isize) -> Option<usiz
 	(position < length).then_some(position)
 }
 
-fn sanitize_collection(collection: Rc<PrefsCollection>) -> Rc<PrefsCollection> {
-	if let PrefsCollection::Folder { name, items: _ } = collection.as_ref() {
-		let name = name.clone();
-		let collection = PrefsCollection::Folder {
-			name,
-			items: Vec::default(),
-		};
-		Rc::new(collection)
-	} else {
-		collection
+fn reference_collection(collection: impl AsRef<PrefsCollection>) -> PrefsCollectionRef {
+	match collection.as_ref() {
+		PrefsCollection::Builtin(col) => PrefsCollectionRef::Builtin(*col),
+		PrefsCollection::MachineSoftware { machine_name } => PrefsCollectionRef::MachineSoftware {
+			machine_name: machine_name.clone(),
+		},
+		PrefsCollection::Folder { name, items: _ } => PrefsCollectionRef::Folder { name: name.clone() },
 	}
 }
 
 fn collection_folder_name(collection: &PrefsCollection) -> Option<&str> {
 	if let PrefsCollection::Folder { name, items: _ } = collection {
+		Some(name)
+	} else {
+		None
+	}
+}
+
+fn collection_ref_folder_name(collection_ref: &PrefsCollectionRef) -> Option<&str> {
+	if let PrefsCollectionRef::Folder { name, .. } = collection_ref {
 		Some(name)
 	} else {
 		None

--- a/src/models/itemstable.rs
+++ b/src/models/itemstable.rs
@@ -109,7 +109,16 @@ impl ItemsTableModel {
 		// tracing
 		let span = debug_span!("ItemsTableModel::update");
 		let _guard = span.enter();
-		debug!(info_db=?info_db, software_list_paths=?software_list_paths, collection=?collection, column_types=?column_types, search=?search, sorting=?sorting, selection=?selection, "ItemsTableModel::update()");
+		debug!(
+			?info_db,
+			?software_list_paths,
+			?collection,
+			?column_types,
+			?search,
+			?sorting,
+			?selection,
+			"ItemsTableModel::update()"
+		);
 
 		// update the state that forces items refreshes
 		let mut must_refresh_items = false;
@@ -532,7 +541,7 @@ impl ItemsTableModel {
 	}
 
 	fn set_current_selection(&self, selection: &[PrefsItem]) {
-		debug!(selection=?selection, "ItemsTableModel::set_current_selection()");
+		debug!(?selection, "ItemsTableModel::set_current_selection()");
 
 		// we only support single selection now
 		let selection = selection.iter().next();
@@ -661,7 +670,7 @@ struct Item {
 #[derive(Clone)]
 enum ItemDetails {
 	Machine {
-		// Commentary:  `MachineConfig` has its own `InfoDb`; maybe we need a lighter `MachineConfigPartial`?
+		// commentary:  `MachineConfig` has its own `InfoDb`; maybe we need a lighter `MachineConfigPartial`?
 		machine_config: MachineConfig,
 		images: HashMap<String, ImageDesc>,
 		ram_size: Option<u64>,

--- a/src/models/itemstable.rs
+++ b/src/models/itemstable.rs
@@ -39,9 +39,9 @@ use crate::prefs::ColumnType;
 use crate::prefs::PrefsCollection;
 use crate::prefs::PrefsItem;
 use crate::prefs::PrefsItemDetails;
+use crate::prefs::PrefsItemRef;
 use crate::prefs::PrefsMachineItem;
 use crate::prefs::PrefsSoftwareItem;
-use crate::prefs::PrefsVideo;
 use crate::prefs::SortOrder;
 use crate::runtime::MameStartArgs;
 use crate::selection::SelectionManager;
@@ -104,7 +104,7 @@ impl ItemsTableModel {
 		column_types: Option<Rc<[ColumnType]>>,
 		search: Option<&str>,
 		sorting: Option<Option<(ColumnType, SortOrder)>>,
-		selection: Option<&[PrefsItem]>,
+		selection: Option<&[PrefsItemRef]>,
 	) {
 		// tracing
 		let span = debug_span!("ItemsTableModel::update");
@@ -234,7 +234,6 @@ impl ItemsTableModel {
 								software_list,
 								software,
 								machine_indexes,
-								preferred_machines: None,
 							};
 							details.into()
 						})
@@ -253,11 +252,11 @@ impl ItemsTableModel {
 										.map(move |index| (list.clone(), list.software[index].clone()))
 								})
 								.map(|(software_list, software)| {
+									let machine_indexes = Default::default();
 									let details = ItemDetails::Software {
 										software_list,
 										software,
-										machine_indexes: [machine_index].into_iter().collect(),
-										preferred_machines: None,
+										machine_indexes,
 									};
 									details.into()
 								})
@@ -270,16 +269,15 @@ impl ItemsTableModel {
 						.iter()
 						.map(|item| {
 							folder_item(info_db, &mut dispenser, item).unwrap_or_else(|error| {
-								let video = item.video.clone();
+								let id = Some(item.id.get());
 								let details = ItemDetails::Unrecognized {
 									details: item.details.clone(),
 									error: Rc::new(error),
 								};
-								Item { video, details }
+								Item { id, details }
 							})
 						})
 						.collect::<Rc<[_]>>(),
-
 					None => Rc::new([]),
 				};
 				(items, dispenser.is_empty())
@@ -328,7 +326,20 @@ impl ItemsTableModel {
 		let index = *self.items_map.borrow().get(index).unwrap();
 		let index = usize::try_from(index).unwrap();
 		let item = items.get(index)?;
-		let items = vec![make_prefs_item(item)];
+
+		// find the prefs item referenced by the Id, if appropriate
+		let current_collection = self.current_collection.borrow().clone();
+		let prefs_item = item.id.as_ref().and_then(|id| {
+			current_collection
+				.as_ref()
+				.and_then(|collection| match collection.as_ref() {
+					PrefsCollection::Folder { name: _, items } => {
+						items.iter().find(|x| x.id.get_opt().as_ref() == Some(id))
+					}
+					_ => None,
+				})
+		});
+		let video = prefs_item.and_then(|item| item.video.clone());
 
 		// get the critical information - the description and where (if anyplace) "Browse" would go to
 		let (run_title, run_descs, browse_target, can_configure) = match &item.details {
@@ -355,7 +366,6 @@ impl ItemsTableModel {
 					.iter()
 					.map(|(tag, image_desc)| (tag.as_str().into(), image_desc.clone()))
 					.collect::<Vec<_>>();
-				let video = item.video.clone();
 
 				let start_args = MameStartArgs {
 					machine_name,
@@ -365,11 +375,11 @@ impl ItemsTableModel {
 					images,
 					video,
 				};
-				let action = has_mame_initialized.then_some(Action::Start(start_args));
+				let action = Action::Start(start_args);
 				let run_title = run_item_text(machine.description()).into();
 				let run_descs = vec![MenuDesc {
 					title: "".into(),
-					action,
+					action: Some(action),
 				}];
 				let browse_target =
 					(!machine.machine_software_lists().is_empty()).then(|| PrefsCollection::MachineSoftware {
@@ -411,7 +421,7 @@ impl ItemsTableModel {
 								bios: None,
 								slots: [].into(),
 								images,
-								video: item.video.clone(),
+								video: video.clone(),
 							};
 							let action = Some(Action::Start(start_args));
 							let title = machine.description().into();
@@ -428,6 +438,41 @@ impl ItemsTableModel {
 				(run_title, run_descs, None, false)
 			}
 		};
+
+		// figure out the PrefsItem we would create if we were to add this to a folder
+		let prefs_item = prefs_item.cloned().unwrap_or_else(|| {
+			let details = match &item.details {
+				ItemDetails::Machine { machine_config, .. } => PrefsItemDetails::Machine(PrefsMachineItem {
+					machine_name: machine_config.machine().name().to_string(),
+					slots: [].into(),
+					images: [].into(),
+					ram_size: None,
+					bios: None,
+				}),
+				ItemDetails::Software {
+					software_list,
+					software,
+					..
+				} => {
+					let software_list = software_list.name.as_str().into();
+					let software = software.name.as_str().into();
+					PrefsItemDetails::Software(PrefsSoftwareItem {
+						software_list,
+						software,
+						preferred_machines: None,
+					})
+				}
+				ItemDetails::Unrecognized { .. } => {
+					unreachable!("Cannot create PrefsItemDetails for unrecognized item");
+				}
+			};
+			PrefsItem {
+				id: Default::default(),
+				video: None,
+				details,
+			}
+		});
+		let prefs_items = Arc::<[_]>::from([prefs_item]);
 
 		// now actually build the context menu
 		let configure_action = can_configure
@@ -449,21 +494,26 @@ impl ItemsTableModel {
 					panic!("Expected PrefsCollection::Folder");
 				};
 
-				let folder_contains_all_items = items.iter().all(|x| folder_items.contains(x));
-				let action = (!folder_contains_all_items).then(|| Action::AddToExistingFolder(*index, items.clone()));
+				let folder_contains_all_items = prefs_items.iter().all(|x| folder_items.contains(x));
+				let action =
+					(!folder_contains_all_items).then(|| Action::AddToExistingFolder(*index, prefs_items.clone()));
 
 				let title = name.into();
 				MenuDesc { action, title }
 			})
 			.collect::<Vec<_>>();
-		let new_folder_action = Action::AddToNewFolderDialog(items.clone());
+		let new_folder_action = Action::AddToNewFolderDialog(prefs_items.clone());
 
 		// remove from this folder
 		let remove_from_folder_desc = folder_name.map(|folder_name| {
 			let title = format!("Remove From \"{folder_name}\"").into();
-			let action = Some(Action::RemoveFromFolder(folder_name, items.clone()));
+			let ids = prefs_items.iter().filter_map(|item| item.id.get_opt()).collect::<_>();
+			let action = Some(Action::RemoveFromFolder(folder_name, ids));
 			MenuDesc { action, title }
 		});
+
+		// can't run if MAME is not initialized!
+		let run_descs = if has_mame_initialized { run_descs } else { [].into() };
 
 		// and return!
 		let result = LocalItemContextMenuInfo {
@@ -497,11 +547,11 @@ impl ItemsTableModel {
 		self.items_map.replace(new_items_map);
 	}
 
-	pub fn current_selection(&self) -> Vec<PrefsItem> {
+	pub fn current_selection(&self) -> Vec<PrefsItemRef> {
 		let result = self.current_selected_index().map(|index| {
 			let items = self.items.borrow();
 			let index = usize::try_from(index).unwrap();
-			make_prefs_item(&items[index])
+			make_prefs_item_ref(&items[index])
 		});
 
 		result.into_iter().collect()
@@ -540,7 +590,7 @@ impl ItemsTableModel {
 		Some(text)
 	}
 
-	fn set_current_selection(&self, selection: &[PrefsItem]) {
+	fn set_current_selection(&self, selection: &[PrefsItemRef]) {
 		debug!(?selection, "ItemsTableModel::set_current_selection()");
 
 		// we only support single selection now
@@ -592,60 +642,58 @@ impl Model for ItemsTableModel {
 	}
 }
 
-fn folder_item(info_db: &Rc<InfoDb>, dispenser: &mut SoftwareListDispenser<'_>, item: &PrefsItem) -> Result<Item> {
-	let video = item.video.clone();
-	match &item.details {
+fn folder_item(
+	info_db: &Rc<InfoDb>,
+	dispenser: &mut SoftwareListDispenser<'_>,
+	prefs_item: &PrefsItem,
+) -> Result<Item> {
+	let details = match &prefs_item.details {
 		PrefsItemDetails::Machine(item) => {
 			let machine_config =
 				MachineConfig::from_machine_name_and_slots(info_db.clone(), &item.machine_name, &item.slots)?;
 			let images = item.images.clone();
 			let ram_size = item.ram_size;
 			let bios: Option<String> = item.bios.clone();
-			let details = ItemDetails::Machine {
+			ItemDetails::Machine {
 				machine_config,
 				images,
 				ram_size,
 				bios,
-			};
-			Ok(Item { video, details })
+			}
 		}
-		PrefsItemDetails::Software(software_item) => software_folder_item(dispenser, software_item),
-	}
-}
+		PrefsItemDetails::Software(item) => {
+			let (info, software_list) = dispenser.get(&item.software_list)?;
+			let software = software_list
+				.software
+				.iter()
+				.find(|x| x.name.as_str() == item.software)
+				.ok_or_else(|| ThisError::UnknownSoftware(item.software.clone()))?
+				.clone();
 
-fn software_folder_item(dispenser: &mut SoftwareListDispenser, item: &PrefsSoftwareItem) -> Result<Item> {
-	let (info, software_list) = dispenser.get(&item.software_list)?;
-	let software = software_list
-		.software
-		.iter()
-		.find(|x| x.name.as_str() == item.software)
-		.ok_or_else(|| ThisError::UnknownSoftware(item.software.clone()))?
-		.clone();
+			let machine_indexes = if let Some(preferred_machines) = item.preferred_machines.as_deref() {
+				preferred_machines
+					.iter()
+					.flat_map(|machine_name| dispenser.info_db.machines().find(machine_name).ok())
+					.map(|machine| machine.index())
+					.collect()
+			} else {
+				Iterator::chain(
+					info.original_for_machines().iter(),
+					info.compatible_for_machines().iter(),
+				)
+				.map(|x| x.index())
+				.collect()
+			};
 
-	let machine_indexes = if let Some(preferred_machines) = item.preferred_machines.as_deref() {
-		preferred_machines
-			.iter()
-			.flat_map(|machine_name| dispenser.info_db.machines().find(machine_name).ok())
-			.map(|machine| machine.index())
-			.collect()
-	} else {
-		Iterator::chain(
-			info.original_for_machines().iter(),
-			info.compatible_for_machines().iter(),
-		)
-		.map(|x| x.index())
-		.collect()
+			ItemDetails::Software {
+				software_list,
+				software,
+				machine_indexes,
+			}
+		}
 	};
-
-	let preferred_machines = item.preferred_machines.as_ref().map(|x| x.iter().join("\0").into());
-
-	let details = ItemDetails::Software {
-		software_list,
-		software,
-		machine_indexes,
-		preferred_machines,
-	};
-	Ok(details.into())
+	let id = Some(prefs_item.id.get());
+	Ok(Item { id, details })
 }
 
 /// Sometimes, the items view is empty - we can (try to) report why
@@ -661,13 +709,13 @@ pub enum EmptyReason {
 	Unknown,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct Item {
-	pub video: Option<PrefsVideo>,
+	pub id: Option<SmolStr>,
 	pub details: ItemDetails,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum ItemDetails {
 	Machine {
 		// commentary:  `MachineConfig` has its own `InfoDb`; maybe we need a lighter `MachineConfigPartial`?
@@ -680,7 +728,6 @@ enum ItemDetails {
 		software_list: Arc<SoftwareList>,
 		software: Arc<Software>,
 		machine_indexes: SmallVec<[usize; 2]>,
-		preferred_machines: Option<Box<str>>, // NUL delimited
 	},
 	Unrecognized {
 		details: PrefsItemDetails,
@@ -690,56 +737,36 @@ enum ItemDetails {
 
 impl From<ItemDetails> for Item {
 	fn from(details: ItemDetails) -> Self {
-		Self { video: None, details }
+		Self { id: None, details }
 	}
 }
 
-fn make_prefs_item(item: &Item) -> PrefsItem {
-	let video = item.video.clone();
-	let details = match &item.details {
-		ItemDetails::Machine {
-			machine_config,
-			images,
-			ram_size,
-			bios,
-		} => {
-			let machine_name = machine_config.machine().name().to_string();
-			let slots = machine_config.changed_slots(None);
-			let slots = slots
-				.into_iter()
-				.map(|(slot, option_name)| (slot.to_string(), option_name.map(str::to_string)))
-				.collect::<Vec<_>>();
-			let images = images.clone();
-			let ram_size = *ram_size;
-			let bios = bios.clone();
-			let item = PrefsMachineItem {
-				machine_name,
-				slots,
-				images,
-				ram_size,
-				bios,
-			};
-			PrefsItemDetails::Machine(item)
+fn make_prefs_item_ref(item: &Item) -> PrefsItemRef {
+	if let Some(id) = &item.id {
+		PrefsItemRef::Id(id.clone())
+	} else {
+		match &item.details {
+			ItemDetails::Machine { machine_config, .. } => {
+				let machine_name = machine_config.machine().name().into();
+				PrefsItemRef::Machine { machine_name }
+			}
+			ItemDetails::Software {
+				software_list,
+				software,
+				..
+			} => {
+				let software_list = software_list.name.clone();
+				let software = software.name.clone();
+				PrefsItemRef::Software {
+					software_list,
+					software,
+				}
+			}
+			ItemDetails::Unrecognized { .. } => {
+				panic!("unrecognized item details without an id - cannot make PrefsItemRef");
+			}
 		}
-		ItemDetails::Software {
-			software_list,
-			software,
-			preferred_machines,
-			..
-		} => {
-			let preferred_machines = preferred_machines
-				.as_ref()
-				.map(|x| x.split('\0').map(str::to_string).collect::<Vec<_>>());
-			let item = PrefsSoftwareItem {
-				software_list: software_list.name.to_string(),
-				software: software.name.to_string(),
-				preferred_machines,
-			};
-			PrefsItemDetails::Software(item)
-		}
-		ItemDetails::Unrecognized { details, .. } => details.clone(),
-	};
-	PrefsItem { video, details }
+	}
 }
 
 struct RowModel {
@@ -883,8 +910,8 @@ fn column_text<'a>(_info_db: &'a InfoDb, item: &'a Item, column: ColumnType) -> 
 	}
 }
 
-fn is_item_match(prefs_item: &PrefsItem, item: &Item) -> bool {
-	make_prefs_item(item) == *prefs_item
+fn is_item_match(prefs_item_ref: &PrefsItemRef, item: &Item) -> bool {
+	make_prefs_item_ref(item) == *prefs_item_ref
 }
 
 fn run_item_text(text: &str) -> String {
@@ -974,7 +1001,6 @@ mod test {
 	use crate::selection::SelectionManager;
 
 	use super::ItemsTableModel;
-	use super::make_prefs_item;
 
 	#[test_case(0, include_str!("../info/test_data/listxml_coco.xml"), include_str!("../prefs/test_data/prefs01.json"), "Favorites")]
 	pub fn update_with_folder_count(_index: usize, info_xml: &str, prefs_xml: &str, folder_name: &str) {
@@ -1013,7 +1039,7 @@ mod test {
 		let PrefsCollection::Folder { items, .. } = collection.as_ref() else {
 			unreachable!()
 		};
-		let new_items = model.items.borrow().iter().map(make_prefs_item).collect::<Vec<_>>();
-		assert_eq!(items.as_slice(), new_items.as_slice());
+		let items_in_model = model.items.borrow().clone();
+		assert_eq!(items.len(), items_in_model.len());
 	}
 }

--- a/src/prefs/mod.rs
+++ b/src/prefs/mod.rs
@@ -17,9 +17,12 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::str::FromStr;
+use std::sync::Mutex;
 
 use anyhow::Error;
 use anyhow::Result;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD_NO_PAD;
 use itertools::Itertools;
 use num::clamp;
 use serde::Deserialize;
@@ -32,6 +35,7 @@ use strum::EnumProperty;
 use strum::EnumString;
 use tracing::error;
 use tracing::info;
+use uuid::Uuid;
 
 use crate::history::History;
 use crate::icon::Icon;
@@ -395,23 +399,10 @@ pub enum BuiltinCollection {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct HistoryEntry {
-	#[serde(flatten)]
-	pub collection: Rc<PrefsCollection>,
-
-	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
-	pub search: String,
-
-	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
-	pub sort_suppressed: bool,
-
-	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
-	pub selection: Vec<PrefsItem>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
 pub struct PrefsItem {
+	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
+	pub id: PrefsIdentifier,
+
 	#[serde(default, flatten, skip_serializing_if = "default_ext::DefaultExt::is_default")]
 	pub video: Option<PrefsVideo>,
 
@@ -419,11 +410,55 @@ pub struct PrefsItem {
 	pub details: PrefsItemDetails,
 }
 
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct PrefsIdentifier(Mutex<Option<SmolStr>>);
+
+impl PrefsIdentifier {
+	pub fn get(&self) -> SmolStr {
+		let mut lock = self.0.lock().unwrap();
+		lock.as_ref().cloned().unwrap_or_else(|| {
+			let uuid = Uuid::new_v4();
+			let bytes = uuid.as_bytes();
+			let id = SmolStr::from(STANDARD_NO_PAD.encode(bytes));
+			*lock = Some(id.clone());
+			id
+		})
+	}
+
+	pub fn get_opt(&self) -> Option<SmolStr> {
+		self.0.lock().unwrap().clone()
+	}
+}
+
+impl Clone for PrefsIdentifier {
+	fn clone(&self) -> Self {
+		Self(Mutex::new(self.0.lock().unwrap().clone()))
+	}
+}
+
+impl PartialEq for PrefsIdentifier {
+	fn eq(&self, other: &Self) -> bool {
+		std::ptr::eq(self, other) || self.0.lock().unwrap().as_ref() == other.0.lock().unwrap().as_ref()
+	}
+}
+
+impl Eq for PrefsIdentifier {}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum PrefsItemDetails {
 	Machine(PrefsMachineItem),
 	Software(PrefsSoftwareItem),
+}
+
+impl From<PrefsItemDetails> for PrefsItem {
+	fn from(details: PrefsItemDetails) -> Self {
+		Self {
+			id: Default::default(),
+			video: None,
+			details,
+		}
+	}
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -509,6 +544,129 @@ impl Preferences {
 		result_paths.inis = prefs_path.iter().cloned().collect();
 		result_paths.nvram = prefs_path;
 		result
+	}
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryEntry {
+	#[serde(flatten)]
+	pub collection: PrefsCollectionRef,
+
+	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
+	pub search: String,
+
+	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
+	pub sort_suppressed: bool,
+
+	#[serde(default, skip_serializing_if = "default_ext::DefaultExt::is_default")]
+	pub selection: Vec<PrefsItemRef>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum PrefsCollectionRef {
+	Builtin(BuiltinCollection),
+	MachineSoftware {
+		#[serde(rename = "machine")]
+		machine_name: String,
+	},
+	Folder {
+		name: String,
+	},
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PrefsItemRef {
+	Id(SmolStr),
+	Machine { machine_name: SmolStr },
+	Software { software_list: SmolStr, software: SmolStr },
+}
+
+impl Serialize for PrefsItemRef {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		use serde::ser::SerializeMap;
+
+		let mut map = serializer.serialize_map(Some(1))?;
+		match self {
+			PrefsItemRef::Id(id) => {
+				map.serialize_entry("id", id)?;
+			}
+			PrefsItemRef::Machine { machine_name } => {
+				map.serialize_entry("machine", machine_name)?;
+			}
+			PrefsItemRef::Software {
+				software_list,
+				software,
+			} => {
+				map.serialize_entry("softwareList", software_list)?;
+				map.serialize_entry("software", software)?;
+			}
+		}
+		map.end()
+	}
+}
+
+impl<'de> serde::Deserialize<'de> for PrefsItemRef {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		struct HistoryItemVisitor;
+
+		impl<'de> serde::de::Visitor<'de> for HistoryItemVisitor {
+			type Value = PrefsItemRef;
+
+			fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+				write!(f, "an object with either an 'id' field or PrefsItemDetails fields")
+			}
+
+			fn visit_map<A>(self, mut map: A) -> Result<PrefsItemRef, A::Error>
+			where
+				A: serde::de::MapAccess<'de>,
+			{
+				use serde_json::Value;
+
+				// Collect into a temporary map so we can inspect it
+				let mut temp = serde_json::Map::new();
+
+				while let Some((key, value)) = map.next_entry::<String, Value>()? {
+					temp.insert(key, value);
+				}
+
+				let id = temp.remove("id");
+				let machine = temp.get("machine");
+				let software_list = temp.get("softwareList");
+				let software = temp.get("software");
+				match (id, machine, software_list, software) {
+					(Some(id), None, None, None) => {
+						let id = serde_json::from_value(id).map_err(serde::de::Error::custom)?;
+						Ok(PrefsItemRef::Id(id))
+					}
+					(None, Some(machine), None, None) => {
+						let machine_name = serde_json::from_value(machine.clone()).map_err(serde::de::Error::custom)?;
+						Ok(PrefsItemRef::Machine { machine_name })
+					}
+					(None, None, Some(software_list), Some(software)) => {
+						let software_list =
+							serde_json::from_value(software_list.clone()).map_err(serde::de::Error::custom)?;
+						let software = serde_json::from_value(software.clone()).map_err(serde::de::Error::custom)?;
+						Ok(PrefsItemRef::Software {
+							software_list,
+							software,
+						})
+					}
+					_ => Err(serde::de::Error::custom(
+						"Expected either an 'id' field or 'machine' field or both 'softwareList' and 'software' fields, but got an invalid combination",
+					)),
+				}
+			}
+		}
+
+		deserializer.deserialize_map(HistoryItemVisitor)
 	}
 }
 
@@ -603,6 +761,7 @@ mod test {
 	use test_case::test_case;
 
 	use super::Preferences;
+	use super::PrefsIdentifier;
 	use super::load_prefs_from_reader;
 	use super::save_prefs_to_string;
 
@@ -647,5 +806,11 @@ mod test {
 		// try to create a file in that dir
 		let result = File::create(path.join("file_in_ensured_dir.txt")).map(|_| ());
 		assert_matches!(result, Ok(_));
+	}
+
+	#[test]
+	pub fn identifier_identify_compare() {
+		let id = PrefsIdentifier::default();
+		assert_eq!(id, id);
 	}
 }

--- a/src/snapview.rs
+++ b/src/snapview.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fs::File;
 use std::fs::metadata;
@@ -17,16 +18,15 @@ use slint::Image;
 use slint::Rgba8Pixel;
 use slint::SharedPixelBuffer;
 use slint::SharedString;
+use slint::ToSharedString;
 use tracing::debug;
 use tracing::warn;
 use zip::ZipArchive;
 use zip::result::ZipError;
 
 use crate::history_xml::HistoryXml;
-use crate::prefs::PrefsItem;
-use crate::prefs::PrefsItemDetails;
-use crate::prefs::PrefsMachineItem;
-use crate::prefs::PrefsSoftwareItem;
+use crate::prefs::PrefsCollection;
+use crate::prefs::PrefsItemRef;
 
 #[derive(Debug)]
 pub enum MultiPath {
@@ -36,15 +36,38 @@ pub enum MultiPath {
 
 pub struct HistoryLoader(CancelableWorker<PathBuf, Result<HistoryXml>>);
 
-pub fn snap_view_string(item: Option<&PrefsItem>) -> SharedString {
-	match item.map(|x| &x.details) {
+pub fn snap_view_string(collection: &PrefsCollection, item: Option<&PrefsItemRef>) -> SharedString {
+	let item = if let Some(PrefsItemRef::Id(id)) = item {
+		let items = if let PrefsCollection::Folder { items, .. } = collection {
+			items.as_slice()
+		} else {
+			&[]
+		};
+		let item = items.iter().find(|x| Some(id) == x.id.get_opt().as_ref());
+		let item = match item.map(|x| &x.details) {
+			None => None,
+			Some(crate::prefs::PrefsItemDetails::Machine(details)) => Some(PrefsItemRef::Machine {
+				machine_name: details.machine_name.as_str().into(),
+			}),
+			Some(crate::prefs::PrefsItemDetails::Software(details)) => Some(PrefsItemRef::Software {
+				software_list: details.software_list.as_str().into(),
+				software: details.software.as_str().into(),
+			}),
+		};
+		item.map(Cow::Owned)
+	} else {
+		item.map(Cow::Borrowed)
+	};
+
+	match item.as_deref() {
 		None => "".into(),
-		Some(PrefsItemDetails::Machine(PrefsMachineItem { machine_name, .. })) => machine_name.into(),
-		Some(PrefsItemDetails::Software(PrefsSoftwareItem {
+		Some(PrefsItemRef::Id(_)) => unreachable!(),
+		Some(PrefsItemRef::Machine { machine_name, .. }) => machine_name.to_shared_string(),
+		Some(PrefsItemRef::Software {
 			software_list,
 			software,
 			..
-		})) => format!("{software_list}/{software}").into(),
+		}) => format!("{software_list}/{software}").into(),
 	}
 }
 


### PR DESCRIPTION
This is a very intrusive change because it involves creating a separation between the data structures that represent collections (`PrefsCollection`) and items (`PrefsItem`) and the new ones that reference them (`PrefsCollectionRef` and `PrefsItemRef`).  This also involves creating `id` values for items inside of folders.
    
Miscellaneous notes:
* `id` values are created on demand as Base64 encoded UUIDs
* `Item` and `ItemDetail` structs in `crate::models::itemtable` are no longer burdened with carrying all data to represent the item, as they can now reference the richer structure in folder collections
* `sanitize_collection` is now `reference_collection`; so-called "sanitization" was just removing excess data irrelevant to the now separate purposes of referencing collections