### PR TITLE
When showing a mode prefix on the window title, indicate "[busy]" when appropriate

### DIFF
--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -53,7 +53,11 @@ export component AppWindow inherits Window {
     max-width: 10000px;
     max-height: 10000px;
     icon: Icons.bletchmame;
-    title: (prefix-title-with-mode ? "[" + mode() + "] " : "") + root.apptitle + (running-machine-desc != "" ? ": " + running-machine-desc : "");
+    title: (prefix-title-with-mode ? display-mode() + " " : "") + root.apptitle + (running-machine-desc != "" ? ": " + running-machine-desc : "");
+
+    function display-mode() -> string {
+        return "[" + mode() + "]" + (mode() == "report" && report-spinning ? "[busy]" : "");
+    }
 
     // properties that influence the title
     in property <bool> prefix-title-with-mode: false;


### PR DESCRIPTION
This is needed to signal whether we are busy when we are running automated application level tests