### PR TITLE
Minor cleanup to the Paths dialog

### DIFF
--- a/src/dialogs/paths.rs
+++ b/src/dialogs/paths.rs
@@ -111,7 +111,7 @@ pub async fn dialog_paths(
 	let model = PathEntriesModel::new(state.clone());
 	let model = Rc::new(model);
 	let model = ModelRc::from(model);
-	modal.dialog().set_path_entries(model);
+	modal.dialog().set_path_entries(model.clone());
 
 	// respond to path label index changed events
 	let state_clone = state.clone();
@@ -137,6 +137,11 @@ pub async fn dialog_paths(
 	} else {
 		// if `path_label_index` is zero, we don't have to do the above buffoonery
 		state.update_dialog_from_paths();
+	}
+
+	// select the first entry if appropriate
+	if PathEntriesModel::get_model(&model).row_count() > 0 {
+		modal.dialog().set_path_entry_index(0);
 	}
 
 	// present the modal dialog

--- a/ui/dialogs/paths.slint
+++ b/ui/dialogs/paths.slint
@@ -116,7 +116,7 @@ export component PathsDialog inherits Window {
     in property <[PathsListViewItem]> path-entries;
     in property <bool> ok-enabled;
     in-out property <int> path-label-index;
-    out property <int> path-entry-index <=> entries-view.current-entry-index;
+    in-out property <int> path-entry-index <=> entries-view.current-entry-index;
 
     // callbacks
     callback ok-clicked();


### PR DESCRIPTION
Specifically if we start up and we can select something (whether it be a path or the "append placeholder"), select it