### PR TITLE
Updated to a newer version of our hacked fork of Slint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,7 +1190,7 @@ dependencies = [
 [[package]]
 name = "const-field-offset"
 version = "0.2.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "const-field-offset-macro",
  "field-offset",
@@ -1199,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "const-field-offset-macro"
 version = "0.2.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2487,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-linuxkms"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "bytemuck",
  "calloop 0.14.4",
@@ -2509,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-qt"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "const-field-offset",
  "cpp",
@@ -2527,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-selector"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "cfg-if",
  "i-slint-backend-linuxkms",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "i-slint-backend-winit"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "i-slint-common"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "derive_more",
  "fontique",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "i-slint-compiler"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "annotate-snippets",
  "by_address",
@@ -2631,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "i-slint-core"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "auto_enums",
  "bitflags 2.11.1",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "i-slint-core-macros"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "quote",
  "serde_json",
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-femtovg"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "cfg-if",
  "const-field-offset",
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-skia"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2745,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "i-slint-renderer-software"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "bytemuck",
  "clru",
@@ -5721,7 +5721,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slint"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "const-field-offset",
  "i-slint-backend-selector",
@@ -5742,7 +5742,7 @@ dependencies = [
 [[package]]
 name = "slint-build"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "derive_more",
  "fontique",
@@ -5754,7 +5754,7 @@ dependencies = [
 [[package]]
 name = "slint-macros"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "i-slint-compiler",
  "proc-macro2",
@@ -5765,7 +5765,7 @@ dependencies = [
 [[package]]
 name = "slint-material-components"
 version = "1.17.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 
 [[package]]
 name = "slotmap"
@@ -6714,7 +6714,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vtable"
 version = "0.4.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "const-field-offset",
  "portable-atomic",
@@ -6725,7 +6725,7 @@ dependencies = [
 [[package]]
 name = "vtable-macro"
 version = "0.4.0"
-source = "git+https://github.com/npwoods/slint.git?rev=88474566efee5d4f619d9503e51d34499cebcd6a#88474566efee5d4f619d9503e51d34499cebcd6a"
+source = "git+https://github.com/npwoods/slint.git?rev=0f2087c14eeab5bf99a254e51419caeeeb5fa9b2#0f2087c14eeab5bf99a254e51419caeeeb5fa9b2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,11 +68,11 @@ zerocopy = { version = "0.8.48", features = ["derive"] }
 zip = "8.6.0"
 
 # Slint dependencies
-i-slint-backend-qt = { git = "https://github.com/npwoods/slint.git", rev = "88474566efee5d4f619d9503e51d34499cebcd6a", optional = true }
-i-slint-backend-winit = { git = "https://github.com/npwoods/slint.git", rev = "88474566efee5d4f619d9503e51d34499cebcd6a" }
-i-slint-common = { git = "https://github.com/npwoods/slint.git", rev = "88474566efee5d4f619d9503e51d34499cebcd6a" }
-i-slint-core = { git = "https://github.com/npwoods/slint.git", rev = "88474566efee5d4f619d9503e51d34499cebcd6a" }
-slint = { git = "https://github.com/npwoods/slint.git", rev = "88474566efee5d4f619d9503e51d34499cebcd6a", features = [
+i-slint-backend-qt = { git = "https://github.com/npwoods/slint.git", rev = "0f2087c14eeab5bf99a254e51419caeeeb5fa9b2", optional = true }
+i-slint-backend-winit = { git = "https://github.com/npwoods/slint.git", rev = "0f2087c14eeab5bf99a254e51419caeeeb5fa9b2" }
+i-slint-common = { git = "https://github.com/npwoods/slint.git", rev = "0f2087c14eeab5bf99a254e51419caeeeb5fa9b2" }
+i-slint-core = { git = "https://github.com/npwoods/slint.git", rev = "0f2087c14eeab5bf99a254e51419caeeeb5fa9b2" }
+slint = { git = "https://github.com/npwoods/slint.git", rev = "0f2087c14eeab5bf99a254e51419caeeeb5fa9b2", features = [
     "raw-window-handle-06",
 ] }
 
@@ -104,8 +104,8 @@ test-case = "3.3.1"
 [build-dependencies]
 cpp_build = "0.5.11"
 ico = "0.5.0"
-slint-build = { git = "https://github.com/npwoods/slint.git", rev = "88474566efee5d4f619d9503e51d34499cebcd6a" }
-slint-material-components = { git = "https://github.com/npwoods/slint.git", rev = "88474566efee5d4f619d9503e51d34499cebcd6a" }
+slint-build = { git = "https://github.com/npwoods/slint.git", rev = "0f2087c14eeab5bf99a254e51419caeeeb5fa9b2" }
+slint-material-components = { git = "https://github.com/npwoods/slint.git", rev = "0f2087c14eeab5bf99a254e51419caeeeb5fa9b2" }
 winresource = "0.1.31"
 
 [profile.dev]

--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -275,8 +275,9 @@ export component AppWindow inherits Window {
         }
     }
 
-    // Slint's crude menu bar
-    if menubar-visible: MenuBar {
+    // Slint's menu bar
+    MenuBar {
+        visible: menubar-visible;
         Menu {
             title: @tr("MenuBar" => "&File");
             MenuItem {
@@ -663,6 +664,7 @@ export component AppWindow inherits Window {
             }
         }
     }
+
     collection-context-menu := ContextMenuArea {
         enabled: false;
         Menu {


### PR DESCRIPTION
This includes a manually applied version of the `menubar_visible_property` so we can do menu bar toggling the way Slint will work.  The Slint tip has a scalability problem with `StandardTableView` right now so that cannot be merged