### PR TITLE
Changing History display to use Slint's new `StyledText` feature

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -253,7 +253,6 @@ impl AppModel {
 					})
 					.unwrap_or_default()
 			});
-			app_window.set_snap_image_salt(app_window.get_snap_image_salt() + 1);
 		}
 
 		if old_prefs.is_none_or(|old_prefs| prefs.paths.history_file != old_prefs.paths.history_file) {
@@ -1873,7 +1872,6 @@ fn set_history_xml(model: &AppModel, history: Option<HistoryXml>, is_loading: bo
 	let app_window = model.app_window();
 	app_window.on_get_history_styled_text(move |name| get_history_styled_text(history.as_ref(), &name));
 	app_window.set_history_xml_is_loading(is_loading);
-	app_window.set_history_styled_text_salt(app_window.get_history_styled_text_salt() + 1);
 }
 
 fn searchbar_items(model: &AppModel, text: &str) -> Vec<SearchBarItem> {

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -98,7 +98,7 @@ use crate::runtime::command::MameCommand;
 use crate::runtime::command::MovieFormat;
 use crate::selection::SelectionManager;
 use crate::snapview::HistoryLoader;
-use crate::snapview::get_history_text;
+use crate::snapview::get_history_styled_text;
 use crate::snapview::load_image_from_paths;
 use crate::snapview::make_multi_paths;
 use crate::snapview::snap_view_string;
@@ -1871,9 +1871,9 @@ fn start_load_history_xml(model: &AppModel, path: Option<&str>) {
 
 fn set_history_xml(model: &AppModel, history: Option<HistoryXml>, is_loading: bool) {
 	let app_window = model.app_window();
-	app_window.on_get_history_text(move |name| get_history_text(history.as_ref(), &name));
+	app_window.on_get_history_styled_text(move |name| get_history_styled_text(history.as_ref(), &name));
 	app_window.set_history_xml_is_loading(is_loading);
-	app_window.set_history_text_salt(app_window.get_history_text_salt() + 1);
+	app_window.set_history_styled_text_salt(app_window.get_history_styled_text_salt() + 1);
 }
 
 fn searchbar_items(model: &AppModel, text: &str) -> Vec<SearchBarItem> {

--- a/src/history_xml/mod.rs
+++ b/src/history_xml/mod.rs
@@ -6,15 +6,15 @@ use std::io::BufReader;
 use std::path::Path;
 
 use anyhow::Result;
-use slint::SharedString;
+use slint::StyledText;
 use smol_str::SmolStr;
 
 use crate::history_xml::parse::parse_from_reader;
 
 #[derive(Debug, Default)]
 pub struct HistoryXml {
-	systems: HashMap<SmolStr, SharedString>,
-	software: HashMap<(SmolStr, SmolStr), SharedString>,
+	systems: HashMap<SmolStr, StyledText>,
+	software: HashMap<(SmolStr, SmolStr), StyledText>,
 }
 
 impl HistoryXml {
@@ -24,17 +24,18 @@ impl HistoryXml {
 		parse_from_reader(reader, callback)
 	}
 
-	pub fn by_system(&self, system: impl AsRef<str>) -> Option<SharedString> {
+	pub fn by_system(&self, system: impl AsRef<str>) -> Option<StyledText> {
 		self.systems.get(system.as_ref()).cloned()
 	}
 
-	pub fn by_software(&self, list: impl Into<SmolStr>, name: impl Into<SmolStr>) -> Option<SharedString> {
+	pub fn by_software(&self, list: impl Into<SmolStr>, name: impl Into<SmolStr>) -> Option<StyledText> {
 		self.software.get(&(list.into(), name.into())).cloned()
 	}
 }
 
 #[cfg(test)]
 mod tests {
+	use slint::StyledText;
 	use test_case::test_case;
 
 	use super::parse_from_reader;
@@ -45,7 +46,8 @@ mod tests {
 	fn by_system(_index: usize, xml: &str, system: &str, expected: Option<&str>) {
 		let history = parse_from_reader(xml.as_bytes(), || false).unwrap().unwrap();
 		let actual = history.by_system(system);
-		let actual = actual.as_deref();
+
+		let expected = expected.map(StyledText::from_markdown).transpose().unwrap();
 		assert_eq!(expected, actual);
 	}
 
@@ -55,7 +57,8 @@ mod tests {
 	fn by_software(_index: usize, xml: &str, list: &str, name: &str, expected: Option<&str>) {
 		let history = parse_from_reader(xml.as_bytes(), || false).unwrap().unwrap();
 		let actual = history.by_software(list, name);
-		let actual = actual.as_deref();
+
+		let expected = expected.map(StyledText::from_markdown).transpose().unwrap();
 		assert_eq!(expected, actual);
 	}
 }

--- a/src/history_xml/parse.rs
+++ b/src/history_xml/parse.rs
@@ -1,7 +1,9 @@
+use std::borrow::Cow;
 use std::io::BufRead;
 
 use anyhow::Result;
-use slint::ToSharedString;
+use itertools::Itertools;
+use slint::StyledText;
 use smol_str::SmolStr;
 use tracing::info_span;
 
@@ -80,14 +82,17 @@ impl State {
 	pub fn handle_end(&mut self, text: Option<String>) -> Result<()> {
 		match self.phase_stack.last().unwrap() {
 			Phase::Entry => {
-				let text = self.text.take().unwrap().trim().to_shared_string();
+				let text = self.text.take().unwrap();
+				let markdown = markdown_from_history_text(&text);
+				let styled_text = StyledText::from_markdown(&markdown)
+					.expect("markdown_from_history_text() should always produce valid markdown");
 				for ei in self.entry_infos.drain(..) {
 					match ei {
 						EntryInfo::System { name } => {
-							self.history.systems.insert(name, text.clone());
+							self.history.systems.insert(name, styled_text.clone());
 						}
 						EntryInfo::Software { list, name } => {
-							self.history.software.insert((list, name), text.clone());
+							self.history.software.insert((list, name), styled_text.clone());
 						}
 					}
 				}
@@ -141,4 +146,99 @@ pub fn parse_from_reader(reader: impl BufRead, callback: impl Fn() -> bool) -> R
 		}
 	}
 	Ok(Some(state.history))
+}
+
+fn markdown_from_history_text(text: &str) -> String {
+	text.trim()
+		.lines()
+		.map(|line| {
+			let line = if let Some(line) = line.strip_prefix("- ")
+				&& let Some(line) = line.strip_suffix(" -")
+			{
+				Cow::Owned(format!("**{line}**"))
+			} else {
+				Cow::Borrowed(line)
+			};
+			markdown_urls(line)
+		})
+		.join("\n")
+}
+
+fn markdown_urls<'a>(text: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
+	let text = text.into();
+	let mut result = None;
+	let mut current = text.as_ref();
+
+	while !current.is_empty() {
+		let h = current.find("http://");
+		let hs = current.find("https://");
+
+		let start = match (h, hs) {
+			(Some(i), Some(j)) => i.min(j),
+			(Some(i), None) => i,
+			(None, Some(j)) => j,
+			(None, None) => break,
+		};
+
+		let result = result.get_or_insert_with(|| String::with_capacity(text.len() + 128));
+		result.push_str(&current[..start]);
+		let remainder = &current[start..];
+
+		let end = remainder.find(|c: char| c.is_whitespace()).unwrap_or(remainder.len());
+		let mut url_end = end;
+
+		// backtrack trailing punctuation
+		while url_end > 0 {
+			let last_char = remainder.as_bytes()[url_end - 1];
+			if matches!(
+				last_char,
+				b'.' | b',' | b';' | b':' | b'!' | b'?' | b')' | b']' | b'}' | b'\'' | b'"'
+			) {
+				url_end -= 1;
+			} else {
+				break;
+			}
+		}
+
+		if url_end > 0 {
+			let url = &remainder[..url_end];
+			result.push('[');
+			result.push_str(url);
+			result.push_str("](");
+			result.push_str(url);
+			result.push(')');
+			current = &remainder[url_end..];
+		} else {
+			// this should be impossible because we found http:// or https://, but let's be safe
+			result.push_str(&remainder[..1]);
+			current = &remainder[1..];
+		}
+	}
+
+	if let Some(mut result) = result {
+		result.push_str(current);
+		Cow::Owned(result)
+	} else {
+		text
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use test_case::test_case;
+
+	#[test_case(0, "no url", "no url")]
+	#[test_case(1, "http://google.com", "[http://google.com](http://google.com)")]
+	#[test_case(2, "https://google.com", "[https://google.com](https://google.com)")]
+	#[test_case(3, "Visit http://google.com for info.", "Visit [http://google.com](http://google.com) for info.")]
+	#[test_case(4, "Check (https://www.mamedev.org)", "Check ([https://www.mamedev.org](https://www.mamedev.org))")]
+	#[test_case(
+		5,
+		"Multiple: http://one.com and https://two.com!",
+		"Multiple: [http://one.com](http://one.com) and [https://two.com](https://two.com)!"
+	)]
+	fn markdown_urls(_index: usize, input: &str, expected: &str) {
+		let actual = super::markdown_urls(input);
+		assert_eq!(&actual, expected);
+	}
 }

--- a/src/snapview.rs
+++ b/src/snapview.rs
@@ -18,6 +18,7 @@ use slint::Image;
 use slint::Rgba8Pixel;
 use slint::SharedPixelBuffer;
 use slint::SharedString;
+use slint::StyledText;
 use slint::ToSharedString;
 use tracing::debug;
 use tracing::warn;
@@ -162,7 +163,7 @@ pub fn load_image_from_paths(paths: &[MultiPath], name: &str) -> Result<Option<I
 	Ok(Some(slint::Image::from_rgba8(buffer)))
 }
 
-pub fn get_history_text(history: Option<&HistoryXml>, name: &str) -> SharedString {
+pub fn get_history_styled_text(history: Option<&HistoryXml>, name: &str) -> StyledText {
 	history
 		.and_then(|history| {
 			if name.is_empty() {

--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -234,14 +234,10 @@ export component AppWindow inherits Window {
     in-out property <bool> is-picture-area-visible: true;
     pure callback get-snap-image(string) -> image;
     pure callback get-history-styled-text(string) -> styled-text;
-    in-out property <int> snap-image-salt;
-    in-out property <int> history-styled-text-salt;
     function get-snap-image-func() -> image {
-        let _ = snap-image-salt; // force re-evaluation when salt changes
         return get-snap-image(current-snap-view);
     }
     function get-history-styled-text-func() -> styled-text {
-        let _ = history-styled-text-salt; // force re-evaluation when salt changes
         return get-history-styled-text(current-snap-view);
     }
 

--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -233,16 +233,16 @@ export component AppWindow inherits Window {
     in property <bool> history-xml-is-loading;
     in-out property <bool> is-picture-area-visible: true;
     pure callback get-snap-image(string) -> image;
-    pure callback get-history-text(string) -> string;
+    pure callback get-history-styled-text(string) -> styled-text;
     in-out property <int> snap-image-salt;
-    in-out property <int> history-text-salt;
+    in-out property <int> history-styled-text-salt;
     function get-snap-image-func() -> image {
         let _ = snap-image-salt; // force re-evaluation when salt changes
         return get-snap-image(current-snap-view);
     }
-    function get-history-text-func() -> string {
-        let _ = history-text-salt; // force re-evaluation when salt changes
-        return get-history-text(current-snap-view);
+    function get-history-styled-text-func() -> styled-text {
+        let _ = history-styled-text-salt; // force re-evaluation when salt changes
+        return get-history-styled-text(current-snap-view);
     }
 
     // status bar
@@ -940,23 +940,28 @@ export component AppWindow inherits Window {
                 }
                 if root.is-picture-area-visible: VerticalLayout {
                     width: root.column-right-width;
-                    alignment: center;
+                    height: 100%;
                     Image {
                         source: get-snap-image-func();
                         min-height: 0px;
                         preferred-height: 300px;
                     }
 
-                    Rectangle {
+                    if get-history-styled-text-func() != @markdown("") || root.history-xml-is-loading: Rectangle {
                         vertical-stretch: 1;
                         min-height: 0px;
                         preferred-height: 300px;
-                        TextEdit {
+                        ScrollView {
                             width: 100%;
                             height: 100%;
-                            text: get-history-text-func();
-                            visible: get-history-text(current-snap-view) != "";
-                            read-only: true;
+                            viewport-width: self.width;
+                            VerticalLayout {
+                                alignment: start;
+                                StyledText {
+                                    text: get-history-styled-text-func();
+                                    visible: self.text != @markdown("");
+                                }
+                            }
                         }
 
                         Spinner {


### PR DESCRIPTION
Not using `TextEdit`, we lose some built in functionality (e.g. - Text Selection, Copy & Paste) but this is a step in the correct direction.