### PR TITLE
GUI Tests:  Restoring stricter timeouts

### DIFF
--- a/scripts/guitests/002_setup_mame.py
+++ b/scripts/guitests/002_setup_mame.py
@@ -91,8 +91,7 @@ def test_setup_mame(exe_path, exe_log, mame_dir):
         time.sleep(3.0)
 
         # Since we configured MAME, the window should be ready
-        # NOTE - TIMEOUT TEMPORARILY INCREASED TO 90s TO ACCOUNT FOR LIKELY SLINT REGRESSION - reset to 40s after regression is fixed
-        window = wait_for_window(["[ready] BletchMameAuto"], timeout=90)
+        window = wait_for_window(["[ready] BletchMameAuto"], timeout=40)
 
         # Attempt to close app via Alt+F then X (as in other tests)
         print("[INFO] Exiting application via Alt+F, x")

--- a/scripts/guitests/003_import_mame_ini.py
+++ b/scripts/guitests/003_import_mame_ini.py
@@ -103,9 +103,6 @@ def test_import_mame_ini(exe_path, exe_log, mame_dir):
                 try:
                     _ = wait_for_window(["[ready] BletchMameAuto", "[report] BletchMameAuto"], timeout=1)
                     print("[INFO] Import dialog closed and main window ready")
-
-                    # NOTE - INTRODUCING SLEEP - remove after regression is fixed
-                    time.sleep(12)
                     break
                 except TimeoutError:
                     pass

--- a/scripts/guitests/common.py
+++ b/scripts/guitests/common.py
@@ -246,8 +246,7 @@ def click_center(window):
     except Exception as e:
         print(f"[WARN] Failed clicking center: {e}")
 
-# NOTE - TIMEOUT TEMPORARILY INCREASED TO 90s TO ACCOUNT FOR LIKELY SLINT REGRESSION - reset to 30s after regression is fixed
-def wait_for_process_termination(process, timeout=90):
+def wait_for_process_termination(process, timeout=30):
     """Wait for a process to terminate, with fallback to terminate/kill.
     
     Returns the return code if the process exited, or None if it could not be confirmed.


### PR DESCRIPTION
With the Slint bug addressed, no need for these looser timeouts anymore