### PR TITLE
Fixed a few issues stemming from unrobust conversion of History XML text to markdown

### DIFF
--- a/src/history_xml/markdown.rs
+++ b/src/history_xml/markdown.rs
@@ -1,0 +1,169 @@
+use std::borrow::Cow;
+
+use itertools::Itertools;
+
+pub fn markdown_from_history_text(text: &str) -> String {
+	text.trim()
+		.lines()
+		.map(|line| {
+			let (prefix, middle, suffix) = if let Some(line) = line.strip_prefix("- ")
+				&& let Some(line) = line.strip_suffix(" -")
+			{
+				("**", line, "**")
+			} else {
+				let prefixes_needing_escaping = ['-', '=', '#', '>'];
+				if prefixes_needing_escaping.iter().any(|&c| line.starts_with(c)) {
+					("\\", line, "")
+				} else {
+					("", line, "")
+				}
+			};
+
+			let middle = markdown_urls(middle);
+
+			if prefix.is_empty() && suffix.is_empty() {
+				middle
+			} else {
+				Cow::Owned(format!("{}{}{}", prefix, middle, suffix))
+			}
+		})
+		.join("\n")
+}
+
+fn markdown_urls<'a>(text: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
+	let text = text.into();
+	let mut result = None;
+	let mut current = text.as_ref();
+
+	while !current.is_empty() {
+		let h = current.find("http://").map(|i| (i, false));
+		let hs = current.find("https://").map(|i| (i, false));
+		let a = current.find("<a href=\"").map(|i| (i, true));
+
+		let next = [h, hs, a].into_iter().flatten().min_by_key(|&(i, _)| i);
+
+		let (start, is_a) = match next {
+			Some(n) => n,
+			None => break,
+		};
+
+		let result = result.get_or_insert_with(|| String::with_capacity(text.len() + 128));
+		result.push_str(&current[..start]);
+		let remainder = &current[start..];
+
+		if is_a {
+			let mut consumed = false;
+			if let Some(url_end_quote) = remainder[9..].find('"') {
+				let url_end_quote = url_end_quote + 9;
+				let url = &remainder[9..url_end_quote];
+				let rest = &remainder[url_end_quote..];
+				if let Some(tag_end) = rest.find('>') {
+					let tag_end_abs = url_end_quote + tag_end;
+					let rest = &remainder[tag_end_abs + 1..];
+					if let Some(closing_tag_start) = rest.find("</a>") {
+						let closing_tag_start_abs = tag_end_abs + 1 + closing_tag_start;
+						let text = &remainder[tag_end_abs + 1..closing_tag_start_abs];
+
+						result.push('[');
+						result.push_str(text);
+						result.push_str("](");
+						result.push_str(url);
+						result.push(')');
+
+						current = &remainder[closing_tag_start_abs + 4..];
+						consumed = true;
+					}
+				}
+			}
+
+			if !consumed {
+				result.push_str(&remainder[..1]);
+				current = &remainder[1..];
+			}
+		} else {
+			let end = remainder.find(|c: char| c.is_whitespace()).unwrap_or(remainder.len());
+			let mut url_end = end;
+
+			// backtrack trailing punctuation
+			while url_end > 0 {
+				let last_char = remainder.as_bytes()[url_end - 1];
+				if matches!(
+					last_char,
+					b'.' | b',' | b';' | b':' | b'!' | b'?' | b')' | b']' | b'}' | b'\'' | b'"'
+				) {
+					url_end -= 1;
+				} else {
+					break;
+				}
+			}
+
+			if url_end > 0 {
+				let url = &remainder[..url_end];
+				result.push('[');
+				result.push_str(url);
+				result.push_str("](");
+				result.push_str(url);
+				result.push(')');
+				current = &remainder[url_end..];
+			} else {
+				// this should be impossible because we found http:// or https://, but let's be safe
+				result.push_str(&remainder[..1]);
+				current = &remainder[1..];
+			}
+		}
+	}
+
+	if let Some(mut result) = result {
+		result.push_str(current);
+		Cow::Owned(result)
+	} else {
+		text
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use slint::StyledText;
+	use test_case::test_case;
+
+	#[allow(clippy::zero_prefixed_literal)]
+	#[test_case(00, "", "")]
+	#[test_case(01, "no formatting", "no formatting")]
+	#[test_case(02, "- HEADER -", "**HEADER**")]
+	#[test_case(03, "---", "\\---")]
+	#[test_case(04, "-----", "\\-----")]
+	#[test_case(05, "# Stuff after hash", "\\# Stuff after hash")]
+	#[test_case(06, "#### Stuff after hashes", "\\#### Stuff after hashes")]
+	#[test_case(07, "> Stuff after block quote", "\\> Stuff after block quote")]
+	#[test_case(08, ">>> Stuff after block quotes", "\\>>> Stuff after block quotes")]
+	#[test_case(09, "=======================", "\\=======================")]
+	#[test_case(10, "<a href=\"https://www.mamedev.org\">MAME</a>", "[MAME](https://www.mamedev.org)")]
+	fn markdown_from_history_text(_index: usize, input: &str, expected: &str) {
+		let actual = super::markdown_from_history_text(input);
+		let _ = StyledText::from_markdown(&actual).expect("markdown_from_history_text() should produce valid markdown");
+		assert_eq!(&actual, expected);
+	}
+
+	#[allow(clippy::zero_prefixed_literal)]
+	#[test_case(00, "no url", "no url")]
+	#[test_case(01, "http://google.com", "[http://google.com](http://google.com)")]
+	#[test_case(02, "https://google.com", "[https://google.com](https://google.com)")]
+	#[test_case(03, "Visit http://google.com for info.", "Visit [http://google.com](http://google.com) for info.")]
+	#[test_case(04, "Check (https://www.mamedev.org)", "Check ([https://www.mamedev.org](https://www.mamedev.org))")]
+	#[test_case(05, "<a href=\"https://www.mamedev.org\">MAME</a>", "[MAME](https://www.mamedev.org)")]
+	#[test_case(06, "Link: <a href=\"http://info.com\">Info</a>.", "Link: [Info](http://info.com).")]
+	#[test_case(
+		07,
+		"Multiple: http://one.com and https://two.com!",
+		"Multiple: [http://one.com](http://one.com) and [https://two.com](https://two.com)!"
+	)]
+	#[test_case(
+		08,
+		"Mixed: <a href=\"http://google.com\">Google</a> and http://bing.com",
+		"Mixed: [Google](http://google.com) and [http://bing.com](http://bing.com)"
+	)]
+	fn markdown_urls(_index: usize, input: &str, expected: &str) {
+		let actual = super::markdown_urls(input);
+		assert_eq!(&actual, expected);
+	}
+}

--- a/src/history_xml/mod.rs
+++ b/src/history_xml/mod.rs
@@ -1,3 +1,4 @@
+mod markdown;
 mod parse;
 
 use std::collections::HashMap;

--- a/src/history_xml/parse.rs
+++ b/src/history_xml/parse.rs
@@ -1,13 +1,12 @@
-use std::borrow::Cow;
 use std::io::BufRead;
 
 use anyhow::Result;
-use itertools::Itertools;
 use slint::StyledText;
 use smol_str::SmolStr;
 use tracing::info_span;
 
 use crate::history_xml::HistoryXml;
+use crate::history_xml::markdown::markdown_from_history_text;
 use crate::xml::XmlElement;
 use crate::xml::XmlEvent;
 use crate::xml::XmlReader;
@@ -146,99 +145,4 @@ pub fn parse_from_reader(reader: impl BufRead, callback: impl Fn() -> bool) -> R
 		}
 	}
 	Ok(Some(state.history))
-}
-
-fn markdown_from_history_text(text: &str) -> String {
-	text.trim()
-		.lines()
-		.map(|line| {
-			let line = if let Some(line) = line.strip_prefix("- ")
-				&& let Some(line) = line.strip_suffix(" -")
-			{
-				Cow::Owned(format!("**{line}**"))
-			} else {
-				Cow::Borrowed(line)
-			};
-			markdown_urls(line)
-		})
-		.join("\n")
-}
-
-fn markdown_urls<'a>(text: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
-	let text = text.into();
-	let mut result = None;
-	let mut current = text.as_ref();
-
-	while !current.is_empty() {
-		let h = current.find("http://");
-		let hs = current.find("https://");
-
-		let start = match (h, hs) {
-			(Some(i), Some(j)) => i.min(j),
-			(Some(i), None) => i,
-			(None, Some(j)) => j,
-			(None, None) => break,
-		};
-
-		let result = result.get_or_insert_with(|| String::with_capacity(text.len() + 128));
-		result.push_str(&current[..start]);
-		let remainder = &current[start..];
-
-		let end = remainder.find(|c: char| c.is_whitespace()).unwrap_or(remainder.len());
-		let mut url_end = end;
-
-		// backtrack trailing punctuation
-		while url_end > 0 {
-			let last_char = remainder.as_bytes()[url_end - 1];
-			if matches!(
-				last_char,
-				b'.' | b',' | b';' | b':' | b'!' | b'?' | b')' | b']' | b'}' | b'\'' | b'"'
-			) {
-				url_end -= 1;
-			} else {
-				break;
-			}
-		}
-
-		if url_end > 0 {
-			let url = &remainder[..url_end];
-			result.push('[');
-			result.push_str(url);
-			result.push_str("](");
-			result.push_str(url);
-			result.push(')');
-			current = &remainder[url_end..];
-		} else {
-			// this should be impossible because we found http:// or https://, but let's be safe
-			result.push_str(&remainder[..1]);
-			current = &remainder[1..];
-		}
-	}
-
-	if let Some(mut result) = result {
-		result.push_str(current);
-		Cow::Owned(result)
-	} else {
-		text
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use test_case::test_case;
-
-	#[test_case(0, "no url", "no url")]
-	#[test_case(1, "http://google.com", "[http://google.com](http://google.com)")]
-	#[test_case(2, "https://google.com", "[https://google.com](https://google.com)")]
-	#[test_case(3, "Visit http://google.com for info.", "Visit [http://google.com](http://google.com) for info.")]
-	#[test_case(4, "Check (https://www.mamedev.org)", "Check ([https://www.mamedev.org](https://www.mamedev.org))")]
-	#[test_case(
-		5,
-		"Multiple: http://one.com and https://two.com!",
-		"Multiple: [http://one.com](http://one.com) and [https://two.com](https://two.com)!"
-	)]
-	fn markdown_urls(_index: usize, input: &str, expected: &str) {
-		let actual = super::markdown_urls(input);
-		assert_eq!(&actual, expected);
-	}
 }

--- a/src/history_xml/test_data/history.xml
+++ b/src/history_xml/test_data/history.xml
@@ -19,4 +19,39 @@
       Contoso&apos;s alpha invaders never existed either
     </text>
   </entry>
+  <entry>
+		<software>
+			<item list="contoso_cart" name="contoso_beta01" />
+		</software>
+		<text>
+Contoso&apos;s beta invaders never existed either
+			
+- HEADER1 -
+			
+Bacon ipsum dolor amet bacon beef ribs pig ham swine, leberkas boudin tri-tip alcatra. Filet mignon andouille strip steak leberkas. Cupim rump polony prosciutto, chuck meatloaf drumstick alcatra pork spare ribs turducken strip steak. Drumstick filet mignon doner tongue spare ribs prosciutto pork loin kielbasa pig turducken.
+
+- HEADER2 - 
+
+Ham polony jowl salami venison. Pork belly pig pork loin ribeye turducken, short ribs rump shank bacon pancetta. Prosciutto pork salami pancetta pork belly. Short ribs swine capicola beef meatloaf chislic kevin burgdoggen jerky porchetta ribeye. Chuck tail venison salami. Pastrami leberkas ground round sausage, short ribs capicola beef ball tip chicken kevin ham hock swine.
+
+Salami
+------
+Salami andouille cupim cow pancetta pork loin ball tip tongue beef capicola shankle bresaola frankfurter kevin.
+
+Sirloin
+-------
+Sirloin cow tail venison pig pork
+
+Invalid Underline
+------------------------------
+Invalid! Invalid! Invalid! Invalid!
+
+Another Underline
+=======================
+
+- CONTRIBUTE -
+
+Edit this entry: https://www.contoso.com/dummylink
+		</text>
+	  </entry>
 </history>      


### PR DESCRIPTION
We convert history text to markdown before passing it to Slint, and we expect the conversion to succeed.