### PR TITLE
Removing nasty Slint hacks for setting `current-index` on `ComboBox` widgets

### DIFF
--- a/src/dialogs/configure.rs
+++ b/src/dialogs/configure.rs
@@ -156,14 +156,8 @@ pub async fn dialog_configure(
 		let ram_option_texts = ModelRc::new(ram_option_texts);
 		modal.dialog().set_ram_sizes_model(ram_option_texts);
 
-		// workaround for https://github.com/slint-ui/slint/issues/7632; please remove hack when fixed
-		let dialog_weak = modal.dialog().as_weak();
-		let fut = async move {
-			tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-			let current_index = current_index.try_into().unwrap();
-			dialog_weak.unwrap().set_ram_sizes_index(current_index);
-		};
-		spawn_local(fut).unwrap();
+		let current_index = current_index.try_into().unwrap();
+		modal.dialog().set_ram_sizes_index(current_index);
 	}
 
 	// BIOS options
@@ -172,14 +166,8 @@ pub async fn dialog_configure(
 		let bios_option_texts = ModelRc::new(bios_option_texts);
 		modal.dialog().set_bios_selection_model(bios_option_texts);
 
-		// workaround for https://github.com/slint-ui/slint/issues/7632; please remove hack when fixed
-		let dialog_weak = modal.dialog().as_weak();
-		let fut = async move {
-			tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-			let current_index = current_index.try_into().unwrap();
-			dialog_weak.unwrap().set_bios_selection_index(current_index);
-		};
-		spawn_local(fut).unwrap();
+		let current_index = current_index.try_into().unwrap();
+		modal.dialog().set_bios_selection_index(current_index);
 	}
 
 	// asset audit button

--- a/src/dialogs/paths.rs
+++ b/src/dialogs/paths.rs
@@ -123,22 +123,11 @@ pub async fn dialog_paths(
 	// determine the index on the paths dropdown
 	let path_label_index = path_type
 		.and_then(|path_type| PathType::iter().position(|x| x == path_type))
-		.unwrap_or_default();
-	if path_label_index > 0 {
-		// workaround for https://github.com/slint-ui/slint/issues/7632; please remove hack when fixed
-		let state_clone = state.clone();
-		let fut = async move {
-			tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-			let dialog = state_clone.dialog_weak.unwrap();
-			let path_label_index = path_label_index.try_into().unwrap();
-			dialog.set_path_label_index(path_label_index);
-			state_clone.update_dialog_from_paths();
-		};
-		spawn_local(fut).unwrap();
-	} else {
-		// if `path_label_index` is zero, we don't have to do the above buffoonery
-		state.update_dialog_from_paths();
-	}
+		.unwrap_or_default()
+		.try_into()
+		.unwrap();
+	modal.dialog().set_path_label_index(path_label_index);
+	state.update_dialog_from_paths();
 
 	// select the first entry if appropriate
 	if PathEntriesModel::get_model(&model).row_count() > 0 {


### PR DESCRIPTION
According to https://github.com/slint-ui/slint/issues/7632#issuecomment-4624301153 this problem has since been fixed.  This has been confirmed, and this hack can now be removed.