### PR TITLE
Created a "watchdog" will kill MAME if it goes unresponsive after a timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,7 @@ dependencies = [
  "splitty",
  "strum",
  "strum_macros",
+ "sysinfo",
  "tempdir",
  "test-case",
  "thiserror 2.0.18",
@@ -3768,6 +3769,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4169,6 +4179,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4211,6 +4231,17 @@ checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.13.0",
  "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
  "objc2-foundation 0.3.2",
 ]
 
@@ -6100,6 +6131,21 @@ dependencies = [
  "libc",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.39.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ i-slint-core = { git = "https://github.com/npwoods/slint.git", rev = "12b8c4cba4
 slint = { git = "https://github.com/npwoods/slint.git", rev = "12b8c4cba45f34d601e0df81c70b24dd01094844", features = [
     "raw-window-handle-06",
 ] }
+sysinfo = "0.39.3"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 features = [

--- a/src/appstate.rs
+++ b/src/appstate.rs
@@ -214,9 +214,11 @@ impl AppState {
 	}
 
 	fn start_session(&self, mame_args: MameArguments) -> Session {
+		let watchdog_timeout = Duration::from_secs(30);
 		let (job, command_sender) = spawn_mame_session_thread(
 			mame_args,
 			self.fixed.mame_stderr,
+			watchdog_timeout,
 			self.fixed.interaction_monitor.clone(),
 			self.fixed.callback.clone(),
 		);

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -264,12 +264,13 @@ fn exercise_mame(mame_child: &mut Child, script: &Script) -> Result<()> {
 			.next()
 			.map_or(MameCommand::exit(), |s| MameCommand::from_text(s.as_ref()))
 	};
+	let watchdog_timeout = Duration::from_secs(30);
 	let emit_console = |emit_type: EmitType, s: &str| {
 		let style = emit_type.style();
 		println!("{}", style.apply_to(s));
 	};
 	let event_callback = |_event| {};
-	interact_with_mame(mame_child, &receiver, &emit_console, &event_callback)?;
+	interact_with_mame(mame_child, &receiver, watchdog_timeout, &emit_console, &event_callback)?;
 
 	// wait for stderr to complete
 	stderr_thread.join().unwrap();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,6 +1,7 @@
 pub mod args;
 pub mod command;
 pub mod session;
+mod watchdog;
 
 use anyhow::Error;
 use serde::Deserialize;

--- a/src/runtime/session.rs
+++ b/src/runtime/session.rs
@@ -34,6 +34,7 @@ use crate::platform::CommandExt;
 use crate::runtime::MameStderr;
 use crate::runtime::args::MameArguments;
 use crate::runtime::command::MameCommand;
+use crate::runtime::watchdog::Watchdog;
 use crate::status::Update;
 use crate::threadlocalbubble::ThreadLocalBubble;
 
@@ -62,6 +63,8 @@ enum ThisError {
 	ReadingFromMame(anyhow::Error),
 	#[error("Error writing to MAME: {0:?}")]
 	WritingToMame(anyhow::Error),
+	#[error("MAME has stopped responding to events")]
+	TimeoutFromMame,
 }
 
 #[derive(Debug)]
@@ -73,6 +76,7 @@ pub enum MameEvent {
 pub fn spawn_mame_session_thread(
 	mame_args: MameArguments,
 	mame_stderr: MameStderr,
+	watchdog_timeout: Duration,
 	interaction_monitor: Arc<Mutex<Option<InteractionMonitor>>>,
 	callback: Rc<dyn Fn(Action) + 'static>,
 ) -> (Job<Result<()>>, Sender<MameCommand>) {
@@ -94,6 +98,7 @@ pub fn spawn_mame_session_thread(
 		execute_mame(
 			&mame_args,
 			&receiver,
+			watchdog_timeout,
 			&event_callback,
 			mame_stderr,
 			interaction_monitor.as_ref(),
@@ -105,6 +110,7 @@ pub fn spawn_mame_session_thread(
 fn execute_mame(
 	mame_args: &MameArguments,
 	receiver: &Receiver<MameCommand>,
+	watchdog_timeout: Duration,
 	event_callback: &impl Fn(MameEvent),
 	mame_stderr: MameStderr,
 	interaction_monitor: &Mutex<Option<InteractionMonitor>>,
@@ -138,6 +144,7 @@ fn execute_mame(
 	let mame_result = interact_with_mame(
 		&mut child,
 		&receiver,
+		watchdog_timeout,
 		&|emit_type, s| emit_interaction_monitor(interaction_monitor, emit_type, s),
 		&event_callback,
 	);
@@ -180,6 +187,7 @@ fn execute_mame(
 pub fn interact_with_mame(
 	child: &mut Child,
 	receiver: &dyn Fn(Duration) -> MameCommand,
+	watchdog_timeout: Duration,
 	emit_interaction_monitor: &dyn for<'a> Fn(EmitType, &'a str),
 	event_callback: &dyn Fn(MameEvent),
 ) -> anyhow::Result<()> {
@@ -190,9 +198,13 @@ pub fn interact_with_mame(
 	let mut is_exiting = false;
 	let mut is_running = false;
 
+	// this is to guard against MAME messups
+	let watchdog = Watchdog::new(child.id(), watchdog_timeout);
+
 	loop {
 		info!("Calling read_response_from_mame()");
-		let (update, is_signal) = read_response_from_mame(&mut mame_stdout, &emit_interaction_monitor, &mut line)?;
+		let (update, is_signal) =
+			read_response_from_mame(&mut mame_stdout, &watchdog, &emit_interaction_monitor, &mut line)?;
 
 		if let Some(update) = update {
 			is_running = update.is_running();
@@ -211,6 +223,7 @@ pub fn interact_with_mame(
 
 fn read_response_from_mame(
 	mame_stdout: &mut impl BufRead,
+	watchdog: &Watchdog,
 	emit_interaction_monitor: &dyn for<'a> Fn(EmitType, &'a str),
 	line: &mut String,
 ) -> anyhow::Result<(Option<Update>, bool)> {
@@ -222,7 +235,7 @@ fn read_response_from_mame(
 		Cruft,
 	}
 
-	let (resp, comment) = match read_line_from_mame(mame_stdout, line) {
+	let (resp, comment) = match read_line_from_mame(mame_stdout, watchdog, line) {
 		Ok(()) => {
 			let line_without_eolns = line.trim_end_matches(&['\r', '\n'][..]);
 			if let Some(status_line) = line.strip_prefix("@") {
@@ -260,7 +273,7 @@ fn read_response_from_mame(
 		info!("update" = ?update.as_ref().map(|_| ()), "Parsed update");
 
 		// read until end of line
-		let result = read_line_from_mame(mame_stdout, line);
+		let result = read_line_from_mame(mame_stdout, watchdog, line);
 		info!(?line, ?result, "Poststatus eoln");
 		result?;
 		if !line.trim().is_empty() {
@@ -282,12 +295,14 @@ fn read_response_from_mame(
 	Ok((update, is_signal))
 }
 
-fn read_line_from_mame(mame_stdout: &mut impl BufRead, line: &mut String) -> anyhow::Result<()> {
+fn read_line_from_mame(mame_stdout: &mut impl BufRead, watchdog: &Watchdog, line: &mut String) -> anyhow::Result<()> {
 	line.clear();
-	match mame_stdout.read_line(line) {
-		Ok(0) => Err(ThisError::EofFromMame.into()),
-		Ok(_) => Ok(()),
-		Err(e) => Err(ThisError::ReadingFromMame(e.into()).into()),
+
+	match watchdog.with_timeout(|| mame_stdout.read_line(line)) {
+		(Ok(0), false) => Err(ThisError::EofFromMame.into()),
+		(Ok(_), false) => Ok(()),
+		(Err(e), false) => Err(ThisError::ReadingFromMame(e.into()).into()),
+		(_, true) => Err(ThisError::TimeoutFromMame.into()),
 	}
 }
 

--- a/src/runtime/watchdog.rs
+++ b/src/runtime/watchdog.rs
@@ -1,0 +1,94 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::RecvTimeoutError;
+use std::sync::mpsc::Sender;
+use std::sync::mpsc::channel;
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use sysinfo::Pid;
+use sysinfo::ProcessesToUpdate;
+use sysinfo::System;
+use tracing::error;
+use tracing::warn;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum WatchdogState {
+	Idle,
+	Wait,
+}
+
+pub struct Watchdog {
+	sender: Sender<Option<WatchdogState>>,
+	thread: Option<JoinHandle<()>>,
+	timed_out: Arc<AtomicBool>,
+}
+
+impl Watchdog {
+	pub fn new(pid: u32, timeout: Duration) -> Self {
+		let (sender, receiver) = channel();
+		let timed_out = Arc::new(AtomicBool::new(false));
+		let timed_out_clone = Arc::clone(&timed_out);
+		let thread = thread::spawn(move || thread_proc(receiver, pid, timeout, timed_out_clone));
+		let thread = Some(thread);
+		Self {
+			sender,
+			thread,
+			timed_out,
+		}
+	}
+
+	pub fn with_timeout<T>(&self, f: impl FnOnce() -> T) -> (T, bool) {
+		self.send_state(Some(WatchdogState::Wait));
+		let result = f();
+		self.send_state(Some(WatchdogState::Idle));
+		let timed_out = self.timed_out.load(Ordering::SeqCst);
+		(result, timed_out)
+	}
+
+	fn send_state(&self, state: Option<WatchdogState>) {
+		let _ = self.sender.send(state);
+	}
+}
+
+impl Drop for Watchdog {
+	fn drop(&mut self) {
+		self.send_state(None);
+		self.thread
+			.take()
+			.unwrap()
+			.join()
+			.expect("Failed to join watchdog thread");
+	}
+}
+
+fn thread_proc(receiver: Receiver<Option<WatchdogState>>, pid: u32, timeout: Duration, timed_out: Arc<AtomicBool>) {
+	let mut sys = System::new_all();
+	sys.refresh_processes(ProcessesToUpdate::All, true);
+	let Some(process) = sys.process(Pid::from_u32(pid)) else {
+		warn!("Process with PID {} not found; watchdog will not be functional", pid);
+		return;
+	};
+
+	let mut state = Some(WatchdogState::Idle);
+	while let Some(current_state) = state {
+		let result = match current_state {
+			WatchdogState::Wait => receiver.recv_timeout(timeout),
+			WatchdogState::Idle => receiver.recv().map_err(|_| RecvTimeoutError::Disconnected),
+		};
+
+		state = match result {
+			Ok(new_state) => new_state,
+			Err(RecvTimeoutError::Timeout) => {
+				error!("Watchdog timeout for MAME process with PID {}", pid);
+				timed_out.store(true, Ordering::SeqCst);
+				process.kill();
+				None
+			}
+			Err(RecvTimeoutError::Disconnected) => None,
+		};
+	}
+}


### PR DESCRIPTION
This timeout is currently hardcoded to 30 seconds.  In the future we probably want to expose this configuration.