### PR TITLE
Before starting an emulation, we will now audit ROMs and samples

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -138,6 +138,9 @@ pub enum Action {
 	HistoryLoadCompleted,
 	Launch(Box<OsStr>),
 	ShowFile(Box<Path>),
+	AuditProgress(SmolStr),
+	AuditCancel,
+	AuditComplete,
 }
 
 const MENU_PREFIX: &str = "MENU_";

--- a/src/appstate.rs
+++ b/src/appstate.rs
@@ -17,7 +17,6 @@ use smol_str::ToSmolStr;
 use smol_str::format_smolstr;
 use strum::EnumProperty;
 use throttle::Throttle;
-use tracing::debug;
 use tracing::info;
 
 use crate::action::Action;
@@ -50,7 +49,6 @@ pub struct AppState {
 	live: Option<Live>,
 	failure: Option<Failure>,
 	last_save_state: Option<Box<str>>,
-	video_override: Option<PrefsVideo>,
 	fixed: Fixed,
 }
 
@@ -69,17 +67,30 @@ struct Live {
 /// Represents a session and associated communication
 struct Session {
 	job: Job<SessionResult<()>>,
-	command_sender: Option<Sender<MameCommand>>,
+	video: Option<PrefsVideo>,
 	status: Option<Rc<Status>>,
 	pending_status: Option<Rc<Status>>,
-	expecting: Option<Expecting>,
-	post_session_end: Option<PostSessionEnd>,
+	session_state: SessionState,
 }
 
 #[derive(Debug)]
-enum PostSessionEnd {
-	Shutdown,
-	Restart { command: Option<MameCommand> },
+enum SessionState {
+	ShuttingDown,
+	Stopping,
+	Restarting {
+		start_args: Option<MameStartArgs>,
+	},
+	Active {
+		command_sender: Sender<MameCommand>,
+		active_state: SessionActiveState,
+	},
+}
+
+#[derive(Debug)]
+enum SessionActiveState {
+	Normal,
+	EmuStarting,
+	EmuStopping,
 }
 
 #[derive(Debug, EnumProperty)]
@@ -104,12 +115,6 @@ enum Failure {
 
 	#[strum(props(Message = "Processing machine information from MAME was cancelled"))]
 	InfoDbBuildCancelled,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum Expecting {
-	Start,
-	Stop,
 }
 
 struct Fixed {
@@ -171,7 +176,6 @@ impl AppState {
 			live: None,
 			failure: None,
 			last_save_state: None,
-			video_override: None,
 			fixed,
 		}
 	}
@@ -186,17 +190,12 @@ impl AppState {
 		)
 	}
 
-	fn make_mame_args(&mut self) -> std::result::Result<MameArguments, ()> {
+	fn make_mame_args(&mut self, video: Option<&PrefsVideo>) -> std::result::Result<MameArguments, ()> {
 		// clear out any failures
 		self.failure = None;
 
 		// create MAME arguments
-		let mame_args_result = MameArguments::new(
-			&self.preferences,
-			self.video_override.as_ref(),
-			&self.fixed.mame_windowing,
-			false,
-		);
+		let mame_args_result = MameArguments::new(&self.preferences, video, &self.fixed.mame_windowing, false);
 
 		// if we failed, report it
 		mame_args_result.map_err(|e| {
@@ -215,7 +214,7 @@ impl AppState {
 		}
 
 		// get or load the InfoDb
-		let mame_args_result = self.make_mame_args();
+		let mame_args_result = self.make_mame_args(None);
 		let info_db = self.info_db().cloned().or_else(|| {
 			let mame_executable_path = mame_args_result.as_ref().as_ref().ok()?.program.as_str();
 			let info_db = InfoDb::load(&self.fixed.prefs_path, mame_executable_path).ok()?;
@@ -223,7 +222,9 @@ impl AppState {
 		});
 
 		if let Some(info_db) = info_db {
-			let session = mame_args_result.map(|mame_args| self.start_session(mame_args)).ok();
+			let session = mame_args_result
+				.map(|mame_args| self.start_session(mame_args, None))
+				.ok();
 			self.live = Some(Live { info_db, session });
 			true
 		} else {
@@ -232,7 +233,8 @@ impl AppState {
 		}
 	}
 
-	fn start_session(&self, mame_args: MameArguments) -> Session {
+	fn start_session(&self, mame_args: MameArguments, start_args: Option<MameStartArgs>) -> Session {
+		// start the session thread
 		let watchdog_timeout = Duration::from_secs(30);
 		let (job, command_sender) = spawn_mame_session_thread(
 			mame_args,
@@ -241,14 +243,32 @@ impl AppState {
 			self.fixed.interaction_monitor.clone(),
 			self.fixed.callback.clone(),
 		);
-		let command_sender = Some(command_sender);
+
+		// if we're starting, set the active state accordingly
+		let active_state = if start_args.is_some() {
+			SessionActiveState::EmuStarting
+		} else {
+			SessionActiveState::Normal
+		};
+
+		// are we starting with a command?
+		if let Some(start_args) = start_args.as_ref() {
+			let command = MameCommand::start(start_args);
+			command_sender.send(command).unwrap();
+		}
+
+		// finally return all the state
+		let video = start_args.and_then(|x| x.video);
+		let session_state = SessionState::Active {
+			command_sender,
+			active_state,
+		};
 		Session {
 			job,
-			command_sender,
+			video,
 			status: None,
-			expecting: None,
 			pending_status: None,
-			post_session_end: None,
+			session_state,
 		}
 	}
 
@@ -258,7 +278,7 @@ impl AppState {
 		}
 
 		// access the MAME executable path (or preflight errors if we don't have them)
-		if let Ok(mame_args) = self.make_mame_args() {
+		if let Ok(mame_args) = self.make_mame_args(None) {
 			let mame_executable_path = mame_args.program.as_str();
 			let prefs_path = &self.fixed.prefs_path;
 			let callback = self.fixed.callback.clone();
@@ -276,8 +296,7 @@ impl AppState {
 		// if a session is live, set it to stop and restart
 		if let Some(session) = self.live.as_mut().and_then(|live| live.session.as_mut()) {
 			session.job.cancel();
-			session.command_sender = None;
-			session.post_session_end = Some(PostSessionEnd::Restart { command: None });
+			session.session_state = SessionState::Restarting { start_args: None };
 		}
 
 		// attempt to reactivate and return
@@ -286,28 +305,32 @@ impl AppState {
 	}
 
 	pub fn start(&mut self, start_args: MameStartArgs) -> bool {
-		// build the command that will ultimately be issued to MAME/worker_ui
-		let command = MameCommand::start(&start_args);
-
 		// access the live session (which had better be present)
 		let session = self.live.as_mut().unwrap().session.as_mut().unwrap();
 
-		// we're expecting to run
-		session.expecting = Some(Expecting::Start);
-
-		// is the session live and ready?
-		if let Some(command_sender) = &session.command_sender
-			&& self.video_override == start_args.video
+		// do we have an active session that with the expected video state?
+		if let SessionState::Active {
+			command_sender,
+			active_state,
+		} = &mut session.session_state
+			&& session.video == start_args.video
 		{
-			// if so, issue the command to start
+			// there is indeed - use this session; build the command that will ultimately be issued to MAME/worker_ui
+			let command = MameCommand::start(&start_args);
+
+			// dispatch the command
 			command_sender.send(command).unwrap();
+
+			// and set the state to "starting"
+			*active_state = SessionActiveState::EmuStarting;
 		} else {
-			// if not, set us up to restart with the new command
-			let command = Some(command);
-			self.video_override = start_args.video;
-			session.command_sender = None;
-			session.post_session_end = Some(PostSessionEnd::Restart { command });
-		}
+			// the session is unusable either because it is shutting down and/or the video is wrong; we need to restart
+			let start_args = Some(start_args);
+			session.session_state = SessionState::Restarting { start_args };
+
+			// cancel the current session
+			session.job.cancel();
+		};
 		true
 	}
 
@@ -315,16 +338,34 @@ impl AppState {
 		// access the live session (which had better be present)
 		let session = self.live.as_mut().unwrap().session.as_mut().unwrap();
 
-		let changed = session.expecting != Some(Expecting::Stop);
-		session.expecting = Some(Expecting::Stop);
-		self.issue_command(MameCommand::stop());
-		changed
+		// get the active session (if we don't have one, we're already stopping)
+		let SessionState::Active {
+			command_sender,
+			active_state,
+		} = &mut session.session_state
+		else {
+			return false;
+		};
+
+		// are we already stopping?
+		if matches!(*active_state, SessionActiveState::EmuStopping) {
+			return false;
+		}
+
+		// send the stop command
+		command_sender.send(MameCommand::stop()).unwrap();
+
+		// we're now stopping
+		*active_state = SessionActiveState::EmuStopping;
+
+		// and we're done!
+		true
 	}
 
 	/// Issues a command to MAME
 	pub fn issue_command(&self, command: MameCommand) {
 		let session = self.live.as_ref().unwrap().session.as_ref().unwrap();
-		if let Some(command_sender) = session.command_sender.as_ref() {
+		if let SessionState::Active { command_sender, .. } = &session.session_state {
 			command_sender.send(command).unwrap();
 		}
 	}
@@ -384,7 +425,7 @@ impl AppState {
 					);
 
 					self.failure = if let Err(error) = result {
-						session.command_sender = None;
+						session.session_state = SessionState::Stopping;
 						Some(error.into())
 					} else {
 						None
@@ -394,8 +435,8 @@ impl AppState {
 					session.pending_status = pending_status;
 				} else {
 					// no session; create a new one
-					if let Ok(mame_args) = self.make_mame_args() {
-						let session = self.start_session(mame_args);
+					if let Ok(mame_args) = self.make_mame_args(None) {
+						let session = self.start_session(mame_args, None);
 						self.live.as_mut().unwrap().session = Some(session);
 					}
 				};
@@ -412,7 +453,7 @@ impl AppState {
 			Err(e) => {
 				let session = self.live.as_mut().and_then(|live| live.session.as_mut());
 				if let Some(session) = session {
-					session.command_sender = None;
+					session.session_state = SessionState::Stopping;
 				}
 				self.failure = Some(Failure::InfoDbBuild(e));
 			}
@@ -428,10 +469,10 @@ impl AppState {
 		let live = self.live.as_mut().unwrap();
 		let session = live.session.as_mut().unwrap();
 
-		// ignore status updates when we're shutting down
-		if session.command_sender.is_none() {
+		// ignore status updates if the session is not active
+		let SessionState::Active { active_state, .. } = &mut session.session_state else {
 			return false;
-		}
+		};
 
 		// validate the status update
 		let (new_status, new_pending_status, result) = validate_and_update_status(
@@ -455,14 +496,15 @@ impl AppState {
 			self.failure = Some(failure);
 		}
 
-		// update expectations
-		if let Some(session) = self.live.as_mut().and_then(|l| l.session.as_mut()) {
-			let is_running = session.status.as_deref().is_some_and(|s| s.running.is_some());
-			if session.expecting == Some(Expecting::Start) && is_running
-				|| session.expecting == Some(Expecting::Stop) && !is_running
-			{
-				session.expecting = None;
-			}
+		// if we have an active session, we may need to alter the active state
+		let is_running = session.status.as_deref().is_some_and(|s| s.running.is_some());
+		let now_normal = match active_state {
+			SessionActiveState::EmuStarting => is_running,
+			SessionActiveState::EmuStopping => !is_running,
+			_ => false,
+		};
+		if now_normal {
+			*active_state = SessionActiveState::Normal
 		}
 
 		// kick off an InfoDb rebuild if appropriate
@@ -476,7 +518,7 @@ impl AppState {
 	pub fn session_ended(&mut self) -> ControlFlow<()> {
 		// access the "live" and the session
 		let live = self.live.as_mut().unwrap();
-		let mut session = live.session.take().unwrap();
+		let session = live.session.take().unwrap();
 
 		// join the thread and get the result
 		let result = session.job.join();
@@ -485,37 +527,23 @@ impl AppState {
 		let failure = result.err().map(Failure::SessionError);
 
 		// identify activities that need to happen after the session ends
-		let (reactivate, command, result) = match session.post_session_end.take() {
-			None => (false, None, ControlFlow::Continue(())),
-			Some(PostSessionEnd::Restart { command }) => (true, command, ControlFlow::Continue(())),
-			Some(PostSessionEnd::Shutdown) => (false, None, ControlFlow::Break(())),
+		let (reactivate, start_args, result) = match session.session_state {
+			SessionState::Restarting { start_args } => (true, start_args, ControlFlow::Continue(())),
+			SessionState::ShuttingDown => (false, None, ControlFlow::Break(())),
+			_ => (false, None, ControlFlow::Continue(())),
 		};
-
-		// clear out the session
-		if let Some(live) = self.live.as_mut() {
-			live.session = None;
-		}
 
 		// identify failures
 		self.failure = failure;
 
-		// do we need to reactivate?
+		// do we need to restart the session?
 		if reactivate {
-			self.activate();
-		}
-
-		// do we need to issue a command?
-		if let Some(command) = command {
-			// we do intend to issue a command, but verify that reactivation succeeded in creating one
-			let session = self.live.as_mut().and_then(|live| live.session.as_mut());
-			let has_session = session.is_some();
-			if let Some(session) = session {
-				// if we have a command, its because we're expecting an emulation to start
-				session.expecting = Some(Expecting::Start);
-			}
-			if has_session {
-				self.issue_command(command);
-			}
+			let video = start_args.as_ref().and_then(|x| x.video.as_ref());
+			let Ok(mame_args) = self.make_mame_args(video) else {
+				return ControlFlow::Continue(());
+			};
+			let session = self.start_session(mame_args, start_args);
+			self.live.as_mut().unwrap().session = Some(session);
 		}
 
 		// and we're done!
@@ -525,8 +553,7 @@ impl AppState {
 	pub fn shutdown(&mut self) -> ControlFlow<()> {
 		let session = self.live.as_mut().and_then(|live| live.session.as_mut());
 		if let Some(session) = session {
-			session.command_sender = None;
-			session.post_session_end = Some(PostSessionEnd::Shutdown);
+			session.session_state = SessionState::ShuttingDown;
 			ControlFlow::Continue(())
 		} else {
 			ControlFlow::Break(())
@@ -560,39 +587,49 @@ impl AppState {
 	pub fn report(&self) -> Option<Report> {
 		#[derive(Debug)]
 		enum ReportType<'a> {
+			// session related reports
+			SessionStarting,
+			SessionRestarting,
+			SessionRestartingForEmu,
+			SessionShuttingDown,
+
+			// messages for an emulation starting up or shutting down
+			EmuStarting,
+			EmuStopping,
+
+			// InfoDb building
 			InfoDbBuild(Option<&'a str>),
-			Resetting,
-			Starting,
-			Stopping,
-			ShuttingDown,
+
+			// failure reports
 			FailureReport(&'a Failure),
 		}
 
-		// upfront logic to determine the type of report presented, if any; keep
-		// this logic distinct from the mechanics of displaying the report
-		let session = self.live.as_ref().and_then(|live| live.session.as_ref());
-		let expecting = session.and_then(|session| session.expecting.as_ref());
-		let is_starting_up = session.is_some_and(|session| session.status.is_none());
-		let is_session_stopping = session.is_some_and(|session| session.command_sender.is_none());
-		let is_shutting_down =
-			session.is_some_and(|session| matches!(session.post_session_end, Some(PostSessionEnd::Shutdown)));
-		debug!(info_db_build=?self.info_db_build.as_ref().map(|_| "..."), ?expecting, failure=?self.failure.as_ref(), ?is_starting_up, ?is_shutting_down, "AppState::report()");
-		let report_type = match (
-			self.info_db_build.as_ref(),
-			expecting,
-			self.failure.as_ref(),
-			is_starting_up,
-			is_shutting_down,
-		) {
-			(Some(info_db_build), _, _, _, _) => {
-				Some(ReportType::InfoDbBuild(info_db_build.machine_description.as_deref()))
+		// lots of gnarly logic here
+		let report_type = if let Some(info_db_build) = self.info_db_build.as_ref() {
+			// report that we have an active InfoDb build
+			Some(ReportType::InfoDbBuild(info_db_build.machine_description.as_deref()))
+		} else if let Some(failure) = self.failure.as_ref() {
+			// report that something out there failed
+			Some(ReportType::FailureReport(failure))
+		} else if let Some(session) = self.live.as_ref().and_then(|live| live.session.as_ref()) {
+			match &session.session_state {
+				SessionState::ShuttingDown => Some(ReportType::SessionShuttingDown),
+				SessionState::Stopping => None,
+				SessionState::Restarting { start_args, .. } => {
+					if start_args.is_some() {
+						Some(ReportType::SessionRestartingForEmu)
+					} else {
+						Some(ReportType::SessionRestarting)
+					}
+				}
+				SessionState::Active { active_state, .. } => match active_state {
+					SessionActiveState::Normal => session.status.is_none().then_some(ReportType::SessionStarting),
+					SessionActiveState::EmuStarting => Some(ReportType::EmuStarting),
+					SessionActiveState::EmuStopping => Some(ReportType::EmuStopping),
+				},
 			}
-			(None, Some(Expecting::Start), None, _, _) => Some(ReportType::Starting),
-			(None, Some(Expecting::Stop), None, _, _) => Some(ReportType::Stopping),
-			(None, _, _, _, true) => Some(ReportType::ShuttingDown),
-			(None, _, _, true, false) => Some(ReportType::Resetting),
-			(None, _, Some(failure), false, false) => Some(ReportType::FailureReport(failure)),
-			(None, None, None, false, false) => None,
+		} else {
+			None
 		};
 
 		report_type.map(|report_type| match report_type {
@@ -611,31 +648,35 @@ impl AppState {
 					..Default::default()
 				}
 			}
-			ReportType::Resetting => Report {
+			ReportType::SessionRestarting => Report {
 				message: "Resetting MAME...".into(),
 				is_spinning: true,
 				..Default::default()
 			},
-			ReportType::Starting => {
-				let submessage = match (is_session_stopping, is_starting_up) {
-					(true, _) => "MAME needs to be reset to run this emulation",
-					(false, true) => "MAME is reinitializing",
-					(false, false) => "Waiting for emulation startup to be complete",
-				};
-				Report {
-					message: "Starting emulation...".into(),
-					submessage: Some(submessage.into()),
-					is_spinning: true,
-					..Default::default()
-				}
-			}
-			ReportType::Stopping => Report {
-				message: "Stopping emulation...".into(),
+			ReportType::SessionRestartingForEmu => Report {
+				message: "Starting emulation...".into(),
+				submessage: Some("MAME needs to be reset to run this emulation".into()),
 				is_spinning: true,
 				..Default::default()
 			},
-			ReportType::ShuttingDown => Report {
+			ReportType::SessionStarting => Report {
+				message: "Starting MAME...".into(),
+				submessage: Some("Waiting for emulation startup to be complete".into()),
+				is_spinning: true,
+				..Default::default()
+			},
+			ReportType::SessionShuttingDown => Report {
 				message: "MAME is shutting down...".into(),
+				is_spinning: true,
+				..Default::default()
+			},
+			ReportType::EmuStarting => Report {
+				message: "Starting emulation...".into(),
+				is_spinning: true,
+				..Default::default()
+			},
+			ReportType::EmuStopping => Report {
+				message: "Stopping emulation...".into(),
 				is_spinning: true,
 				..Default::default()
 			},

--- a/src/appstate.rs
+++ b/src/appstate.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::mem::replace;
 use std::ops::ControlFlow;
 use std::path::Path;
 use std::path::PathBuf;
@@ -6,6 +7,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::mpsc::Sender;
+use std::thread::sleep;
 use std::time::Duration;
 
 use anyhow::Error;
@@ -20,10 +22,14 @@ use throttle::Throttle;
 use tracing::info;
 
 use crate::action::Action;
+use crate::audit::Asset;
+use crate::audit::AuditResult;
+use crate::audit::AuditSeverity;
 use crate::info::InfoDb;
 use crate::interaction_monitor::InteractionMonitor;
 use crate::job::Canceller;
 use crate::job::Job;
+use crate::mconfig::MachineConfig;
 use crate::prefs::Preferences;
 use crate::prefs::PreflightProblem;
 use crate::prefs::PrefsVideo;
@@ -91,6 +97,11 @@ enum SessionActiveState {
 	Normal,
 	EmuStarting,
 	EmuStopping,
+	Auditing {
+		job: Job<AuditJobResult>,
+		start_args: MameStartArgs,
+		current_asset_name: Option<SmolStr>,
+	},
 }
 
 #[derive(Debug, EnumProperty)]
@@ -115,6 +126,15 @@ enum Failure {
 
 	#[strum(props(Message = "Processing machine information from MAME was cancelled"))]
 	InfoDbBuildCancelled,
+
+	#[strum(props(Message = "Audit failure before run"))]
+	AuditResults(Box<[(Asset, AuditResult)]>),
+
+	#[strum(props(Message = "Unexpected error auditing before run"))]
+	AuditError(Error),
+
+	#[strum(props(Message = "Audit was cancelled"))]
+	AuditCancelled,
 }
 
 struct Fixed {
@@ -125,10 +145,20 @@ struct Fixed {
 	callback: ActionCallback,
 }
 
+#[derive(Debug)]
+pub enum AuditJobResult {
+	Success,
+	Cancelled,
+	Failed(Box<[(Asset, AuditResult)]>),
+}
+
 type ActionCallback = Rc<dyn Fn(Action) + 'static>;
 
 // progress messages should be throttled
 const PROGRESS_THROTTLE_TIMEOUT: Duration = Duration::from_millis(100);
+
+// debugging feature to make auditing easier to debug
+const AUDIT_DELAY: Option<Duration> = None;
 
 #[derive(Default, Debug)]
 pub struct Report {
@@ -139,6 +169,7 @@ pub struct Report {
 	pub button: Option<Button>,
 	pub is_spinning: bool,
 	pub issues: Vec<Issue>,
+	pub audit_results: Box<[(Asset, AuditResult)]>,
 }
 
 #[derive(Clone, Debug)]
@@ -208,9 +239,13 @@ impl AppState {
 	pub fn activate(&mut self) -> bool {
 		info!("AppState::activate(): starting");
 
+		// clear out any failure
+		let had_failure = self.failure.is_some();
+		self.failure = None;
+
 		// if we already have a session (in any form, we're already active) or if we're shutting down, don't proceed
 		if self.live.as_ref().is_some_and(|live| live.session.is_some()) {
-			return false;
+			return had_failure;
 		}
 
 		// get or load the InfoDb
@@ -305,24 +340,34 @@ impl AppState {
 	}
 
 	pub fn start(&mut self, start_args: MameStartArgs) -> bool {
+		info!(?start_args, "AppState::start()");
+
+		// access the InfoDb now
+		let info_db = self.info_db().unwrap().clone();
+
 		// access the live session (which had better be present)
 		let session = self.live.as_mut().unwrap().session.as_mut().unwrap();
 
 		// do we have an active session that with the expected video state?
-		if let SessionState::Active {
-			command_sender,
-			active_state,
-		} = &mut session.session_state
+		if let SessionState::Active { active_state, .. } = &mut session.session_state
 			&& session.video == start_args.video
 		{
-			// there is indeed - use this session; build the command that will ultimately be issued to MAME/worker_ui
-			let command = MameCommand::start(&start_args);
-
-			// dispatch the command
-			command_sender.send(command).unwrap();
-
-			// and set the state to "starting"
-			*active_state = SessionActiveState::EmuStarting;
+			// there is indeed - start an auditing session
+			let rom_paths = self.preferences.paths.roms.clone();
+			let sample_paths = self.preferences.paths.samples.clone();
+			let callback = self.fixed.callback.clone();
+			let job = match spawn_audit(info_db, rom_paths, sample_paths, AUDIT_DELAY, &start_args, callback) {
+				Ok(job) => job,
+				Err(e) => {
+					self.failure = Some(Failure::AuditError(e));
+					return true;
+				}
+			};
+			*active_state = SessionActiveState::Auditing {
+				job,
+				start_args,
+				current_asset_name: None,
+			};
 		} else {
 			// the session is unusable either because it is shutting down and/or the video is wrong; we need to restart
 			let start_args = Some(start_args);
@@ -331,6 +376,94 @@ impl AppState {
 			// cancel the current session
 			session.job.cancel();
 		};
+		true
+	}
+
+	pub fn audit_progress(&mut self, asset_name: SmolStr) -> bool {
+		// access the live session (which had better be present)
+		let session = self.live.as_mut().unwrap().session.as_mut().unwrap();
+
+		// access the auditing session
+		let SessionState::Active {
+			active_state: SessionActiveState::Auditing { current_asset_name, .. },
+			..
+		} = &mut session.session_state
+		else {
+			// should never happen because `Action::AuditProgress` will only be invoked by an auditing job
+			panic!("audit_progress() called without session");
+		};
+
+		// record progress
+		*current_asset_name = Some(asset_name);
+		true
+	}
+
+	pub fn audit_cancel(&mut self) -> bool {
+		// access the live session (which had better be present)
+		let session = self.live.as_mut().unwrap().session.as_mut().unwrap();
+
+		// access the auditing session
+		let SessionState::Active {
+			active_state: SessionActiveState::Auditing { job, .. },
+			..
+		} = &session.session_state
+		else {
+			// should never happen because `Action::AuditProgress` will only be invoked by an auditing job
+			panic!("audit_progress() called without session");
+		};
+
+		// cancel the job
+		job.cancel();
+		true
+	}
+
+	pub fn audit_complete(&mut self) -> bool {
+		info!("AppState::audit_complete()");
+
+		// access the live session (which had better be present)
+		let session = self.live.as_mut().unwrap().session.as_mut().unwrap();
+
+		// and the session should be active
+		let SessionState::Active {
+			command_sender,
+			active_state,
+		} = &mut session.session_state
+		else {
+			// should never happen because `Action::AuditComplete` will only be invoked by an auditing job
+			panic!("audit_complete() called without session");
+		};
+
+		// ...and the active session should be auditing
+		let active_state_moved = replace(active_state, SessionActiveState::Normal);
+		let SessionActiveState::Auditing { job, start_args, .. } = active_state_moved else {
+			// should never happen because `Action::AuditComplete` will only be invoked by an auditing job
+			panic!("audit_complete() called without auditing session");
+		};
+
+		// get the results
+		let audit_result = job.join();
+
+		// how did the audit go?
+		match audit_result {
+			AuditJobResult::Success => {
+				// the audit succeeded and we're ready to go; build the command that will ultimately
+				// be issued to MAME/worker_ui
+				let command = MameCommand::start(&start_args);
+
+				// dispatch the command
+				command_sender.send(command).unwrap();
+
+				// and set the state to "starting"
+				*active_state = SessionActiveState::EmuStarting;
+			}
+			AuditJobResult::Cancelled => {
+				self.failure = Some(Failure::AuditCancelled);
+			}
+			AuditJobResult::Failed(items) => {
+				self.failure = Some(Failure::AuditResults(items));
+			}
+		}
+
 		true
 	}
 
@@ -596,6 +729,7 @@ impl AppState {
 			// messages for an emulation starting up or shutting down
 			EmuStarting,
 			EmuStopping,
+			Auditing(Option<&'a SmolStr>),
 
 			// InfoDb building
 			InfoDbBuild(Option<&'a str>),
@@ -626,6 +760,9 @@ impl AppState {
 					SessionActiveState::Normal => session.status.is_none().then_some(ReportType::SessionStarting),
 					SessionActiveState::EmuStarting => Some(ReportType::EmuStarting),
 					SessionActiveState::EmuStopping => Some(ReportType::EmuStopping),
+					SessionActiveState::Auditing { current_asset_name, .. } => {
+						Some(ReportType::Auditing(current_asset_name.as_ref()))
+					}
 				},
 			}
 		} else {
@@ -680,6 +817,19 @@ impl AppState {
 				is_spinning: true,
 				..Default::default()
 			},
+			ReportType::Auditing(current_asset_name) => {
+				let button = Button {
+					text: "Cancel".into(),
+					command: Action::AuditCancel,
+				};
+				Report {
+					message: "Auditing assets...".into(),
+					submessage: current_asset_name.cloned(),
+					is_spinning: true,
+					button: Some(button),
+					..Default::default()
+				}
+			}
 			ReportType::FailureReport(failure) => failure.report(),
 		})
 	}
@@ -731,7 +881,7 @@ impl Failure {
 		// secondary message
 		let submessage: Option<&dyn Display> = match self {
 			Self::SessionError(error) => Some(error),
-			Self::InfoDbBuild(error) => Some(error),
+			Self::InfoDbBuild(error) | Self::AuditError(error) => Some(error),
 			_ => None,
 		};
 		let submessage = submessage
@@ -772,10 +922,12 @@ impl Failure {
 
 		// action button
 		let button = match self {
-			Self::SessionError(_) => Some(Button {
-				text: "Continue".into(),
-				command: Action::ReactivateMame,
-			}),
+			Self::SessionError(_) | Self::AuditResults(_) | Self::AuditError(_) | Self::AuditCancelled => {
+				Some(Button {
+					text: "Continue".into(),
+					command: Action::ReactivateMame,
+				})
+			}
 			Self::InfoDbBuild(_) => Some(Button {
 				text: "Retry".into(),
 				command: Action::HelpRefreshInfoDb,
@@ -787,6 +939,13 @@ impl Failure {
 			_ => None,
 		};
 
+		// auditing results
+		let audit_results = if let Self::AuditResults(audit_results) = self {
+			audit_results.clone()
+		} else {
+			Default::default()
+		};
+
 		Report {
 			message,
 			submessage,
@@ -795,6 +954,7 @@ impl Failure {
 			mame_exit_code,
 			button,
 			is_spinning: false,
+			audit_results,
 		}
 	}
 }
@@ -820,6 +980,74 @@ fn spawn_infodb_build_thread(
 	let mame_executable_path = mame_executable_path.to_string();
 	let callback_bubble = ThreadLocalBubble::new(callback);
 	Job::new(move |canceller| infodb_build_thread_proc(&prefs_path, &mame_executable_path, callback_bubble, canceller))
+}
+
+fn spawn_audit(
+	info_db: Rc<InfoDb>,
+	rom_paths: Vec<impl AsRef<Path> + Send + 'static>,
+	sample_paths: Vec<impl AsRef<Path> + Send + 'static>,
+	audit_delay: Option<Duration>,
+	start_args: &MameStartArgs,
+	callback: ActionCallback,
+) -> Result<Job<AuditJobResult>> {
+	// create the MachineConfig
+	let machine_config = MachineConfig::from_mame_start_args(info_db.clone(), start_args)?;
+
+	// create the assets
+	let assets = Asset::from_machine_config(&machine_config);
+
+	// progress messages need to be throttled
+	let mut throttle = Throttle::new(PROGRESS_THROTTLE_TIMEOUT, 1);
+
+	// create the job
+	let callback_bubble = ThreadLocalBubble::new(callback);
+	let job = Job::new(move |canceller| {
+		// we need to invoke actions on the main thread
+		let invoke_action = make_invoke_action(callback_bubble, canceller.clone());
+
+		// audit each asset
+		let audit_results = assets
+			.into_iter()
+			.map(|asset| {
+				if canceller.status().is_break() {
+					Err(())
+				} else {
+					// do we need to display a progress message?
+					if throttle.accept().is_ok() {
+						let action = Action::AuditProgress(asset.name.as_str().into());
+						invoke_action(action, true);
+					}
+
+					// this is only for debugging purposes
+					if let Some(audit_delay) = audit_delay {
+						sleep(audit_delay);
+					}
+
+					// audit the asset
+					let audit_result = asset.run_audit(&rom_paths, &sample_paths);
+					Ok((asset, audit_result))
+				}
+			})
+			.collect::<std::result::Result<Vec<_>, ()>>();
+
+		// determine what the job result should be
+		let job_result = match audit_results {
+			Ok(results) => {
+				let max_severity = results.iter().map(|(_, audit_result)| audit_result.severity()).max();
+				if max_severity.is_none_or(|x| x < AuditSeverity::Fail) {
+					AuditJobResult::Success
+				} else {
+					AuditJobResult::Failed(results.into())
+				}
+			}
+			Err(()) => AuditJobResult::Cancelled,
+		};
+
+		// signal completion and return
+		invoke_action(Action::AuditComplete, false);
+		job_result
+	});
+	Ok(job)
 }
 
 fn infodb_build_thread_proc(

--- a/src/appstate.rs
+++ b/src/appstate.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::ops::ControlFlow;
 use std::path::Path;
 use std::path::PathBuf;
@@ -14,6 +15,7 @@ use slint::invoke_from_event_loop;
 use smol_str::SmolStr;
 use smol_str::ToSmolStr;
 use smol_str::format_smolstr;
+use strum::EnumProperty;
 use throttle::Throttle;
 use tracing::debug;
 use tracing::info;
@@ -80,12 +82,27 @@ enum PostSessionEnd {
 	Restart { command: Option<MameCommand> },
 }
 
-#[derive(Debug)]
+#[derive(Debug, EnumProperty)]
 enum Failure {
+	#[strum(props(Message = "BletchMAME requires additional configuration in order to properly interface with MAME"))]
 	Preflight(Box<[PreflightProblem]>),
+
+	#[strum(props(Message = "MAME has errored and shut down"))]
 	SessionError(SessionError),
-	StatusValidationProblem(ValidationError),
+
+	#[strum(props(Submessage = "This is a very unexpected internal error"))]
+	InfoDbStatusMismatch {
+		status_build: MameVersion,
+		infodb_build: MameVersion,
+	},
+
+	#[strum(props(Message = "Status update from MAME is incorrect"))]
+	InvalidStatusUpdate(Vec<UpdateXmlProblem>),
+
+	#[strum(props(Message = "Failure processing machine information from MAME"))]
 	InfoDbBuild(Error),
+
+	#[strum(props(Message = "Processing machine information from MAME was cancelled"))]
 	InfoDbBuildCancelled,
 }
 
@@ -366,12 +383,12 @@ impl AppState {
 						info_db,
 					);
 
-					if let Err(e) = result {
+					self.failure = if let Err(error) = result {
 						session.command_sender = None;
-						self.failure = Some(Failure::StatusValidationProblem(e));
+						Some(error.into())
 					} else {
-						self.failure = None;
-					}
+						None
+					};
 
 					session.status = status;
 					session.pending_status = pending_status;
@@ -428,7 +445,7 @@ impl AppState {
 		let (failure, rebuild_info_db) = match result {
 			Ok(()) => (None, false),
 			Err(ValidationError::VersionMismatch(_, _)) => (None, self.info_db_build.is_none()),
-			Err(e) => (Some(Failure::StatusValidationProblem(e)), false),
+			Err(e) => (Some(e.into()), false),
 		};
 
 		// and munge this into the new state
@@ -548,11 +565,7 @@ impl AppState {
 			Starting,
 			Stopping,
 			ShuttingDown,
-			PreflightFailure(&'a [PreflightProblem]),
-			SessionError(&'a SessionError),
-			InvalidStatusUpdate(&'a [UpdateXmlProblem]),
-			InfoDbBuildFailure(Option<&'a Error>),
-			InfoDbStatusMismatch(&'a MameVersion, &'a MameVersion),
+			FailureReport(&'a Failure),
 		}
 
 		// upfront logic to determine the type of report presented, if any; keep
@@ -578,22 +591,7 @@ impl AppState {
 			(None, Some(Expecting::Stop), None, _, _) => Some(ReportType::Stopping),
 			(None, _, _, _, true) => Some(ReportType::ShuttingDown),
 			(None, _, _, true, false) => Some(ReportType::Resetting),
-			(None, _, Some(Failure::Preflight(preflight_problems)), false, false) => {
-				Some(ReportType::PreflightFailure(preflight_problems.as_ref()))
-			}
-			(None, _, Some(Failure::SessionError(e)), false, false) => Some(ReportType::SessionError(e)),
-			(None, _, Some(Failure::StatusValidationProblem(ValidationError::Invalid(e))), false, false) => {
-				Some(ReportType::InvalidStatusUpdate(e.as_slice()))
-			}
-			(
-				None,
-				_,
-				Some(Failure::StatusValidationProblem(ValidationError::VersionMismatch(status_build, infodb_build))),
-				false,
-				false,
-			) => Some(ReportType::InfoDbStatusMismatch(status_build, infodb_build)),
-			(None, _, Some(Failure::InfoDbBuild(e)), false, false) => Some(ReportType::InfoDbBuildFailure(Some(e))),
-			(None, _, Some(Failure::InfoDbBuildCancelled), false, false) => Some(ReportType::InfoDbBuildFailure(None)),
+			(None, _, Some(failure), false, false) => Some(ReportType::FailureReport(failure)),
 			(None, None, None, false, false) => None,
 		};
 
@@ -622,7 +620,7 @@ impl AppState {
 				let submessage = match (is_session_stopping, is_starting_up) {
 					(true, _) => "MAME needs to be reset to run this emulation",
 					(false, true) => "MAME is reinitializing",
-					(false, false) => "Waiting for emulation startup to be complete"
+					(false, false) => "Waiting for emulation startup to be complete",
 				};
 				Report {
 					message: "Starting emulation...".into(),
@@ -630,7 +628,7 @@ impl AppState {
 					is_spinning: true,
 					..Default::default()
 				}
-			},
+			}
 			ReportType::Stopping => Report {
 				message: "Stopping emulation...".into(),
 				is_spinning: true,
@@ -641,88 +639,7 @@ impl AppState {
 				is_spinning: true,
 				..Default::default()
 			},
-			ReportType::PreflightFailure(preflight_problems) => {
-				let message = "BletchMAME requires additional configuration in order to properly interface with MAME".into();
-
-				let issues = preflight_problems
-					.iter()
-					.map(|problem| {
-						let text = problem.to_smolstr();
-						let button = problem.problem_type().map(|path_type| {
-							let text = format_smolstr!("Choose {path_type}");
-							let command = Action::SettingsPaths(Some(path_type));
-							Button { text, command }
-						});
-						Issue { text, button }
-					})
-					.collect();
-				Report {
-					message,
-					issues,
-					..Default::default()
-				}
-			}
-			ReportType::SessionError(error) => {
-				let button = Button {
-					text: "Continue".into(),
-					command: Action::ReactivateMame
-				};
-				Report {
-					message: "MAME has errored and shut down".into(),
-					submessage: Some(format!("{error}").into()),
-					mame_stderr_output: error.mame_stderr_text.clone(),
-					mame_exit_code: error.exit_code,
-					button: Some(button),
-					..Default::default()
-				}
-			}
-			ReportType::InvalidStatusUpdate(errors) => {
-				let issues = errors
-					.iter()
-					.map(|e| Issue {
-						text: format!("{e}").into(),
-						button: None,
-					})
-					.collect();
-				Report {
-					message: "Status update from MAME is incorrect".into(),
-					issues,
-					..Default::default()
-				}
-			}
-			ReportType::InfoDbBuildFailure(error) => {
-				let message = if error.is_some() {
-					"Failure processing machine information from MAME"
-				} else {
-					"Processing machine information from MAME was cancelled"
-				};
-				let message = message.into();
-				let submessage = error.map(|e| e.to_smolstr());
-				let button = Button {
-					text: "Retry".into(),
-					command: Action::HelpRefreshInfoDb,
-				};
-				Report {
-					message,
-					submessage,
-					button: Some(button),
-					..Default::default()
-				}
-			}
-			ReportType::InfoDbStatusMismatch(status_build, infodb_build) => {
-				let message = format!("The MAME Status Update is reporting version {status_build} and the MAME Machine Info output is reporting version {infodb_build}").into();
-				let submessage = Some("This is a very unexpected internal error".into());
-				let button = Button {
-					text: "Retry".into(),
-					command: Action::HelpRefreshInfoDb,
-				};
-				Report {
-					message,
-					submessage,
-					button: Some(button),
-					..Default::default()
-				}
-			}
+			ReportType::FailureReport(failure) => failure.report(),
 		})
 	}
 
@@ -752,6 +669,104 @@ impl AppState {
 			*interaction_monitor = Some(InteractionMonitor::new()?);
 		}
 		Ok(())
+	}
+}
+
+impl Failure {
+	pub fn report(&self) -> Report {
+		// primary message
+		let message = if let Self::InfoDbStatusMismatch {
+			status_build,
+			infodb_build,
+		} = self
+		{
+			format_smolstr!(
+				"The MAME Status Update is reporting version {status_build} and the MAME Machine Info output is reporting version {infodb_build}"
+			)
+		} else {
+			self.get_str("Message").unwrap().into()
+		};
+
+		// secondary message
+		let submessage: Option<&dyn Display> = match self {
+			Self::SessionError(error) => Some(error),
+			Self::InfoDbBuild(error) => Some(error),
+			_ => None,
+		};
+		let submessage = submessage
+			.map(|x| format_smolstr!("{x}"))
+			.or_else(|| self.get_str("Submessage").map(SmolStr::new_static));
+
+		// issues
+		let issues = match self {
+			Self::Preflight(preflight_problems) => preflight_problems
+				.iter()
+				.map(|problem| {
+					let text = problem.to_smolstr();
+					let button = problem.problem_type().map(|path_type| {
+						let text = format_smolstr!("Choose {path_type}");
+						let command = Action::SettingsPaths(Some(path_type));
+						Button { text, command }
+					});
+					Issue { text, button }
+				})
+				.collect(),
+
+			Self::InvalidStatusUpdate(errors) => errors
+				.iter()
+				.map(|e| Issue {
+					text: format!("{e}").into(),
+					button: None,
+				})
+				.collect(),
+			_ => Default::default(),
+		};
+
+		// MAME error output and exit code
+		let (mame_stderr_output, mame_exit_code) = if let Failure::SessionError(error) = self {
+			(error.mame_stderr_text.clone(), error.exit_code)
+		} else {
+			(None, None)
+		};
+
+		// action button
+		let button = match self {
+			Self::SessionError(_) => Some(Button {
+				text: "Continue".into(),
+				command: Action::ReactivateMame,
+			}),
+			Self::InfoDbBuild(_) => Some(Button {
+				text: "Retry".into(),
+				command: Action::HelpRefreshInfoDb,
+			}),
+			Self::InfoDbStatusMismatch { .. } => Some(Button {
+				text: "Retry".into(),
+				command: Action::ReactivateMame,
+			}),
+			_ => None,
+		};
+
+		Report {
+			message,
+			submessage,
+			issues,
+			mame_stderr_output,
+			mame_exit_code,
+			button,
+			is_spinning: false,
+		}
+	}
+}
+
+impl From<ValidationError> for Failure {
+	fn from(value: ValidationError) -> Self {
+		match value {
+			ValidationError::VersionMismatch(status_build, infodb_build) => Failure::InfoDbStatusMismatch {
+				status_build,
+				infodb_build,
+			},
+			ValidationError::Invalid(update_xml_problems) => Failure::InvalidStatusUpdate(update_xml_problems),
+		}
 	}
 }
 

--- a/src/appstate.rs
+++ b/src/appstate.rs
@@ -100,10 +100,13 @@ struct Fixed {
 	mame_stderr: MameStderr,
 	mame_windowing: MameWindowing,
 	interaction_monitor: Arc<Mutex<Option<InteractionMonitor>>>,
-	callback: CommandCallback,
+	callback: ActionCallback,
 }
 
-type CommandCallback = Rc<dyn Fn(Action) + 'static>;
+type ActionCallback = Rc<dyn Fn(Action) + 'static>;
+
+// progress messages should be throttled
+const PROGRESS_THROTTLE_TIMEOUT: Duration = Duration::from_millis(100);
 
 #[derive(Default, Debug)]
 pub struct Report {
@@ -310,33 +313,34 @@ impl AppState {
 	}
 
 	pub fn infodb_build_progress(&mut self, machine_description: String) -> bool {
-		self.info_db_build.as_mut().unwrap().machine_description = Some(machine_description);
+		self.info_db_build
+			.as_mut()
+			.expect("infodb_build_progress() invoked with no info_db_build")
+			.machine_description = Some(machine_description);
 		true
 	}
 
-	pub fn infodb_build_complete(&mut self) -> bool {
-		self.internal_infodb_build_complete(false)
-	}
-
 	pub fn infodb_build_cancel(&mut self) -> bool {
-		self.internal_infodb_build_complete(true)
+		info!("AppState::infodb_build_cancel()");
+		self.info_db_build
+			.as_ref()
+			.expect("infodb_build_cancel() invoked with no info_db_build")
+			.job
+			.cancel();
+		false
 	}
 
-	fn internal_infodb_build_complete(&mut self, cancel: bool) -> bool {
-		// we expect to be in the process of building, and to be able to "take" the job
-		let info_db_build = self.info_db_build.take().unwrap();
+	pub fn infodb_build_complete(&mut self) -> bool {
+		info!("AppState::infodb_build_complete()");
 
-		// if specified, cancel the build
-		if cancel {
-			info_db_build.job.cancel();
-		}
+		// we expect to be in the process of building, and to be able to "take" the job
+		let info_db_build = self
+			.info_db_build
+			.take()
+			.expect("infodb_build_complete() invoked with no info_db_build");
 
 		// join the job (which we expect to complete) and digest the result
-		//
-		// take note that when we cancel, we ignore the result from the job; there
-		// can be a race condition where the job actually yields something other than `Ok(None)`
 		let result = info_db_build.job.join();
-		let result = if cancel { Ok(None) } else { result };
 
 		// this next bit is pretty involved
 		match result {
@@ -754,7 +758,7 @@ impl AppState {
 fn spawn_infodb_build_thread(
 	prefs_path: &Path,
 	mame_executable_path: &str,
-	callback: CommandCallback,
+	callback: ActionCallback,
 ) -> Job<Result<Option<InfoDb>>> {
 	let prefs_path = prefs_path.to_path_buf();
 	let mame_executable_path = mame_executable_path.to_string();
@@ -765,35 +769,23 @@ fn spawn_infodb_build_thread(
 fn infodb_build_thread_proc(
 	prefs_path: &Path,
 	mame_executable_path: &str,
-	callback_bubble: ThreadLocalBubble<CommandCallback>,
+	callback_bubble: ThreadLocalBubble<ActionCallback>,
 	canceller: Canceller,
 ) -> Result<Option<InfoDb>> {
 	// progress messages need to be throttled
-	let mut throttle = Throttle::new(Duration::from_millis(100), 1);
+	let mut throttle = Throttle::new(PROGRESS_THROTTLE_TIMEOUT, 1);
 
-	// lambda to invoke a command on the main event loop; there is some nontrivial stuff here
-	// because of the need to put the callback in the "bubble" as well as to ensure that we
-	// don't invoke the command if the user cancelled
-	let cancelled_clone = canceller.clone();
-	let invoke_command = move |command| {
-		let callback_bubble = callback_bubble.clone();
-		let cancelled_clone = cancelled_clone.clone();
-		invoke_from_event_loop(move || {
-			if cancelled_clone.status().is_continue() {
-				(callback_bubble.unwrap())(command);
-			}
-		})
-		.unwrap();
-	};
+	// create a lambda to invoke an action on the main event loop
+	let invoke_action = make_invoke_action(callback_bubble, canceller.clone());
 
 	// prep a callback for progress
-	let invoke_command_clone = invoke_command.clone();
+	let invoke_action_clone = invoke_action.clone();
 	let callback = move |machine_description: &str| {
 		// do we need to update
 		if throttle.accept().is_ok() {
 			let machine_description = machine_description.to_string();
 			let command = Action::InfoDbBuildProgress { machine_description };
-			invoke_command_clone(command);
+			invoke_action_clone(command, true);
 		}
 
 		// have we cancelled?
@@ -809,10 +801,29 @@ fn infodb_build_thread_proc(
 	}
 
 	// signal that we're done
-	invoke_command(Action::InfoDbBuildComplete);
+	invoke_action(Action::InfoDbBuildComplete, false);
 
 	// and return the result
 	result
+}
+
+fn make_invoke_action(
+	callback_bubble: ThreadLocalBubble<ActionCallback>,
+	canceller: Canceller,
+) -> impl Fn(Action, bool) + Clone {
+	// lambda to invoke a command on the main event loop; there is some nontrivial stuff here
+	// because of the need to put the callback in the "bubble" as well as to ensure that we
+	// don't invoke the command if the user cancelled
+	move |action, silent_when_cancelled| {
+		let callback_bubble = callback_bubble.clone();
+		let canceller = canceller.clone();
+		invoke_from_event_loop(move || {
+			if !silent_when_cancelled || canceller.status().is_continue() {
+				(callback_bubble.unwrap())(action);
+			}
+		})
+		.unwrap();
+	}
 }
 
 #[allow(clippy::type_complexity)]

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -81,6 +81,7 @@ use crate::guiutils::is_context_menu_event;
 use crate::guiutils::modal::ModalStack;
 use crate::history::History;
 use crate::history_xml::HistoryXml;
+use crate::models::audit::audit_static_model;
 use crate::models::collectionsview::CollectionsViewModel;
 use crate::models::itemstable::EmptyReason;
 use crate::models::itemstable::ItemsTableModel;
@@ -414,7 +415,8 @@ impl AppModel {
 					.unwrap_or_default(),
 			);
 			let issues = report
-				.map(|r| r.issues)
+				.as_ref()
+				.map(|r| r.issues.as_slice())
 				.unwrap_or_default()
 				.iter()
 				.map(|issue| {
@@ -430,6 +432,11 @@ impl AppModel {
 			let issues = VecModel::from(issues);
 			let issues = ModelRc::new(issues);
 			app_window.set_report_issues(issues);
+
+			let icons = Icons::get(&app_window);
+			let audit_results = report.map(|r| r.audit_results).unwrap_or_default();
+			let audit_results = audit_static_model(&audit_results, icons);
+			app_window.set_report_audit_assets(audit_results);
 		}
 
 		// menus
@@ -1651,6 +1658,15 @@ fn handle_action(model: &Rc<AppModel>, action: Action) {
 		}
 		Action::ShowFile(path) => {
 			show_path_in_file_manager(&path);
+		}
+		Action::AuditProgress(asset_name) => {
+			model.update_state(|state| state.audit_progress(asset_name));
+		}
+		Action::AuditCancel => {
+			model.update_state(AppState::audit_cancel);
+		}
+		Action::AuditComplete => {
+			model.update_state(AppState::audit_complete);
 		}
 	};
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -22,7 +22,7 @@ use crate::info::Machine;
 use crate::info::View;
 use crate::mconfig::MachineConfig;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)] // TODO - `Clone` should not be necessary
 pub struct Asset {
 	pub kind: AssetKind,
 	pub name: SharedString,
@@ -47,13 +47,13 @@ pub enum AuditSeverity {
 	Fail,
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)] // TODO - `Clone` should not be necessary
 pub struct AuditResult {
 	pub path: Option<(PathBuf, PathType)>,
 	pub messages: Box<[AuditMessage]>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)] // TODO - `Clone` should not be necessary
 pub enum AuditMessage {
 	NotFound,
 	NotFoundNoGoodDump,

--- a/src/mconfig.rs
+++ b/src/mconfig.rs
@@ -16,6 +16,7 @@ use crate::info::Machine;
 use crate::info::Slot;
 use crate::info::View;
 use crate::info::strip_tag_prefix;
+use crate::runtime::MameStartArgs;
 
 #[derive(Clone)]
 pub struct MachineConfig {
@@ -142,6 +143,18 @@ impl MachineConfig {
 		}
 
 		Ok(result)
+	}
+
+	pub fn from_mame_start_args(info_db: Rc<InfoDb>, start_args: &MameStartArgs) -> Result<Self> {
+		let opts = start_args
+			.slots
+			.iter()
+			.filter_map(|(name, value)| {
+				let name = name.as_str().strip_prefix("&")?;
+				Some((name, (!value.is_empty()).then_some(value.as_str())))
+			})
+			.collect::<Vec<_>>();
+		Self::from_machine_name_and_slots(info_db, &start_args.machine_name, &opts)
 	}
 
 	pub fn machine(&self) -> Machine<'_> {

--- a/src/models/audit.rs
+++ b/src/models/audit.rs
@@ -181,3 +181,13 @@ fn make_ui_asset(asset: &Asset, audit_result: Option<&AuditResult>, icons: &Audi
 		browse_action,
 	}
 }
+
+pub fn audit_static_model(audit_results: &[(Asset, AuditResult)], icons: Icons<'_>) -> ModelRc<crate::ui::AuditAsset> {
+	let icons = AuditIcons::new(icons);
+	let data = audit_results
+		.iter()
+		.map(|(asset, audit_result)| make_ui_asset(asset, Some(audit_result), &icons))
+		.collect::<Vec<_>>();
+	let model = VecModel::from(data);
+	ModelRc::new(model)
+}

--- a/src/models/audit.rs
+++ b/src/models/audit.rs
@@ -27,15 +27,18 @@ pub struct AuditModel {
 	rom_paths: Arc<[SmolStr]>,
 	sample_paths: Arc<[SmolStr]>,
 	audit_results: RefCell<Box<[Option<AuditResult>]>>,
-
-	icon_rom: Image,
-	icon_disk: Image,
-	icon_sample: Image,
-	icon_audit_pending: Image,
-	icon_audit_warning: Image,
-	icon_audit_failed: Image,
-
+	icons: AuditIcons,
 	notify: ModelNotify,
+}
+
+#[derive(Debug)]
+struct AuditIcons {
+	rom: Image,
+	disk: Image,
+	sample: Image,
+	audit_pending: Image,
+	audit_warning: Image,
+	audit_failed: Image,
 }
 
 impl AuditModel {
@@ -50,18 +53,14 @@ impl AuditModel {
 			.collect::<Arc<[_]>>();
 		let audit_results = (0..assets.len()).map(|_| None).collect::<Box<_>>();
 		let audit_results = RefCell::new(audit_results);
+		let icons = AuditIcons::new(icons);
 
 		Self {
 			assets,
 			rom_paths,
 			sample_paths,
 			audit_results,
-			icon_rom: icons.get_rom(),
-			icon_disk: icons.get_harddisk(),
-			icon_sample: icons.get_sample(),
-			icon_audit_pending: icons.get_audit_pending(),
-			icon_audit_warning: icons.get_audit_warning(),
-			icon_audit_failed: icons.get_audit_failed(),
+			icons,
 			notify: ModelNotify::default(),
 		}
 	}
@@ -94,13 +93,13 @@ impl AuditModel {
 		}
 	}
 
-	pub fn get_model(model: &ModelRc<crate::ui::Asset>) -> &Self {
+	pub fn get_model(model: &ModelRc<crate::ui::AuditAsset>) -> &Self {
 		model.as_any().downcast_ref::<Self>().unwrap()
 	}
 }
 
 impl Model for AuditModel {
-	type Data = crate::ui::Asset;
+	type Data = crate::ui::AuditAsset;
 
 	fn row_count(&self) -> usize {
 		self.assets.len()
@@ -108,56 +107,8 @@ impl Model for AuditModel {
 
 	fn row_data(&self, row: usize) -> Option<Self::Data> {
 		let asset = self.assets.get(row)?;
-		let (browse_command, max_severity, audit_messages) = {
-			let audit_results = self.audit_results.borrow();
-			let audit_result = &audit_results[row];
-			let max_severity = audit_result.as_ref().map(AuditResult::severity);
-			let audit_messages = audit_result
-				.as_ref()
-				.map(|r| r.messages.as_ref())
-				.unwrap_or_default()
-				.iter()
-				.map(|r| r.to_shared_string())
-				.collect::<Vec<_>>();
-			let audit_messages = VecModel::from(audit_messages);
-			let audit_messages = ModelRc::new(audit_messages);
-			let browse_command = audit_result
-				.as_ref()
-				.and_then(|r| r.path.as_ref())
-				.map(|(path, path_type)| {
-					let action = match path_type {
-						PathType::File => Action::ShowFile(path.clone().into()),
-						PathType::Zip => Action::Launch(OsString::from(path).into()),
-					};
-					action.encode_for_slint()
-				})
-				.unwrap_or_default();
-			(browse_command, max_severity, audit_messages)
-		};
-
-		let icon = match asset.kind {
-			AssetKind::Rom => self.icon_rom.clone(),
-			AssetKind::Disk => self.icon_disk.clone(),
-			AssetKind::Sample => self.icon_sample.clone(),
-		};
-		let overlay = match max_severity {
-			None => self.icon_audit_pending.clone(),
-			Some(AuditSeverity::Info) => Image::default(),
-			Some(AuditSeverity::Warning) => self.icon_audit_warning.clone(),
-			Some(AuditSeverity::Fail) => self.icon_audit_failed.clone(),
-		};
-
-		let name = asset.name.clone();
-		let size = asset.size.map(|s| s.to_shared_string()).unwrap_or_default();
-		let data = Self::Data {
-			icon,
-			overlay,
-			name,
-			size,
-			audit_messages,
-			browse_command,
-		};
-		Some(data)
+		let ui_asset = make_ui_asset(asset, self.audit_results.borrow()[row].as_ref(), &self.icons);
+		Some(ui_asset)
 	}
 
 	fn model_tracker(&self) -> &dyn ModelTracker {
@@ -166,5 +117,67 @@ impl Model for AuditModel {
 
 	fn as_any(&self) -> &dyn Any {
 		self
+	}
+}
+
+impl AuditIcons {
+	pub fn new(icons: Icons<'_>) -> Self {
+		Self {
+			rom: icons.get_rom(),
+			disk: icons.get_harddisk(),
+			sample: icons.get_sample(),
+			audit_pending: icons.get_audit_pending(),
+			audit_warning: icons.get_audit_warning(),
+			audit_failed: icons.get_audit_failed(),
+		}
+	}
+}
+
+fn make_ui_asset(asset: &Asset, audit_result: Option<&AuditResult>, icons: &AuditIcons) -> crate::ui::AuditAsset {
+	let (browse_action, max_severity, audit_messages) = {
+		let max_severity = audit_result.map(AuditResult::severity);
+		let audit_messages = audit_result
+			.map(|r| r.messages.as_ref())
+			.unwrap_or_default()
+			.iter()
+			.map(|r| r.to_shared_string())
+			.collect::<Vec<_>>();
+		let audit_messages = VecModel::from(audit_messages);
+		let audit_messages = ModelRc::new(audit_messages);
+		let browse_action = audit_result
+			.as_ref()
+			.and_then(|r| r.path.as_ref())
+			.map(|(path, path_type)| {
+				let action = match path_type {
+					PathType::File => Action::ShowFile(path.clone().into()),
+					PathType::Zip => Action::Launch(OsString::from(path).into()),
+				};
+				action.encode_for_slint()
+			})
+			.unwrap_or_default();
+		(browse_action, max_severity, audit_messages)
+	};
+
+	let icon = match asset.kind {
+		AssetKind::Rom => icons.rom.clone(),
+		AssetKind::Disk => icons.disk.clone(),
+		AssetKind::Sample => icons.sample.clone(),
+	};
+	let overlay = match max_severity {
+		None => icons.audit_pending.clone(),
+		Some(AuditSeverity::Info) => Image::default(),
+		Some(AuditSeverity::Warning) => icons.audit_warning.clone(),
+		Some(AuditSeverity::Fail) => icons.audit_failed.clone(),
+	};
+
+	let name = asset.name.clone();
+	let size = asset.size.map(|s| s.to_shared_string()).unwrap_or_default();
+	crate::ui::AuditAsset {
+		icon,
+		overlay,
+		name,
+		size,
+		audit_messages,
+		browse_action,
 	}
 }

--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -23,6 +23,7 @@ import { SimpleMenuEntry } from "common.slint";
 import { Icons } from "icons.slint";
 import { TapeControl, Cassette } from "tapecontrol.slint";
 import { HorizontalSplitter } from "splitter.slint";
+import { AuditAsset, AuditAssetView } from "audit.slint";
 
 struct CollectionContextMenuInfo {
     move-up-action: string,
@@ -247,6 +248,7 @@ export component AppWindow inherits Window {
     in property <bool> report-spinning;
     in property <string> report-button-text;
     in property <[ReportIssue]> report-issues;
+    in property <[AuditAsset]> report-audit-assets;
     property <string> monospace-font-family: "Consolas";
     callback report-button-clicked();
     callback issue-button-clicked(int);
@@ -1032,6 +1034,16 @@ export component AppWindow inherits Window {
                             text: issue.button-text;
                             clicked => {
                                 root.issue-button-clicked(index);
+                            }
+                        }
+                    }
+
+                    // report audit assets
+                    VerticalLayout {
+                        for asset in report-audit-assets: AuditAssetView {
+                            asset: asset;
+                            menu-item-action(action) => {
+                                root.menu-item-action(action);
                             }
                         }
                     }

--- a/ui/audit.slint
+++ b/ui/audit.slint
@@ -1,0 +1,66 @@
+import { HorizontalBox, VerticalBox } from "std-widgets.slint";
+
+export struct AuditAsset {
+    icon: image,
+    overlay: image,
+    name: string,
+    size: string,
+    audit-messages: [string],
+    browse-action: string,
+}
+
+export component AuditAssetView {
+    in property <AuditAsset> asset;
+    callback menu-item-action(action: string);
+
+    TouchArea {
+        ContextMenuArea {
+            Menu {
+                MenuItem {
+                    title: "Browse...";
+                    enabled: asset.browse-action != "";
+                    activated => {
+                        root.menu-item-action(asset.browse-action);
+                    }
+                }
+            }
+
+            HorizontalBox {
+                Rectangle {
+                    width: 24px;
+                    height: 24px;
+                    Image {
+                        width: 24px;
+                        height: 24px;
+                        source: asset.icon;
+                    }
+
+                    Image {
+                        width: 24px;
+                        height: 24px;
+                        source: asset.overlay;
+                    }
+                }
+
+                Text {
+                    text: asset.name;
+                    horizontal-stretch: 1;
+                    vertical-alignment: center;
+                }
+
+                Text {
+                    text: asset.size;
+                    vertical-alignment: center;
+                }
+            }
+
+            if asset.audit-messages.length > 0: Tooltip {
+                VerticalBox {
+                    for message in asset.audit-messages: Text {
+                        text: asset.name + " " + message;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ui/dialogs/configure.slint
+++ b/ui/dialogs/configure.slint
@@ -18,17 +18,9 @@ import {
 } from "../devimageslist.slint";
 import { Icons } from "../icons.slint";
 import { VideoConfigComponent, VideoSettings } from "../videoconfig.slint";
+import { AuditAsset, AuditAssetView } from "../audit.slint";
 
 struct SoftwareMachine { machine-index: int, description: string, checked: bool}
-
-struct Asset {
-    icon: image,
-    overlay: image,
-    name: string,
-    size: string,
-    audit-messages: [string],
-    browse-command: string,
-}
 
 export component ConfigureDialog inherits Window {
     title: dialog-title;
@@ -44,7 +36,7 @@ export component ConfigureDialog inherits Window {
     in-out property <int> ram-sizes-index;
     in property <[string]> bios-selection-model;
     in-out property <int> bios-selection-index;
-    in property <[Asset]> audit-assets;
+    in property <[AuditAsset]> audit-assets;
     in property <string> audit-context-menu-browse-command;
     in property <[SoftwareMachine]> software-machines;
     in property <bool> software-machines-bulk-all-enabled;
@@ -165,54 +157,10 @@ export component ConfigureDialog inherits Window {
                     title: "Audit";
                     VerticalBox {
                         ListView {
-                            for asset in root.audit-assets: TouchArea {
-                                ContextMenuArea {
-                                    Menu {
-                                        MenuItem {
-                                            title: "Browse...";
-                                            enabled: asset.browse-command != "";
-                                            activated => {
-                                                root.menu-item-action(asset.browse-command);
-                                            }
-                                        }
-                                    }
-
-                                    HorizontalBox {
-                                        Rectangle {
-                                            width: 24px;
-                                            height: 24px;
-                                            Image {
-                                                width: 24px;
-                                                height: 24px;
-                                                source: asset.icon;
-                                            }
-
-                                            Image {
-                                                width: 24px;
-                                                height: 24px;
-                                                source: asset.overlay;
-                                            }
-                                        }
-
-                                        Text {
-                                            text: asset.name;
-                                            horizontal-stretch: 1;
-                                            vertical-alignment: center;
-                                        }
-
-                                        Text {
-                                            text: asset.size;
-                                            vertical-alignment: center;
-                                        }
-                                    }
-
-                                    if asset.audit-messages.length > 0: Tooltip {
-                                        VerticalBox {
-                                            for message in asset.audit-messages: Text {
-                                                text: asset.name + " " + message;
-                                            }
-                                        }
-                                    }
+                            for asset in root.audit-assets: AuditAssetView {
+                                asset: asset;
+                                menu-item-action(action) => {
+                                    root.menu-item-action(action);
                                 }
                             }
                         }


### PR DESCRIPTION
When MAME audits ROMs and Samples and fails, MAME will shut down and will present an error message that we cannot really scrape well.  So BletchMAME needs to do its own auditing.

This was also accompanied by general surgery on `AppState` and similar data structures to make "special states" easier to represent.
