### PR TITLE
Fixing some auditing false positives

### DIFF
--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -429,13 +429,47 @@ where
 mod tests {
 	use std::io::Cursor;
 	use std::io::Read;
+	use std::ops::ControlFlow;
 
 	use sevenz_rust2::ArchiveReader as SevenZArchiveReader;
 	use test_case::test_case;
 	use zip::ZipArchive;
 
+	use crate::info::InfoDb;
+	use crate::mconfig::MachineConfig;
+
+	use super::Asset;
 	use super::SevenZArchiveReaderExt as _;
 	use super::ZipArchiveExt as _;
+
+	#[test_case(0, include_str!("../info/test_data/listxml_alienar.xml"), "alienar")]
+	#[test_case(1, include_str!("../info/test_data/listxml_coco.xml"), "coco2b")]
+	#[test_case(2, include_str!("../info/test_data/listxml_c64.xml"), "c64")]
+	#[test_case(3, include_str!("../info/test_data/listxml_fake.xml"), "fake")]
+	#[test_case(4, include_str!("../info/test_data/listxml_fake.xml"), "blah")]
+	#[test_case(5, include_str!("../info/test_data/listxml_fake.xml"), "fakefake")]
+	fn assets_from_machine_config(_index: usize, xml: &str, machine_name: &str) {
+		// set the insta snapshot suffix; this is a parameterized test
+		let mut settings = insta::Settings::clone_current();
+		settings.set_snapshot_suffix(machine_name);
+		let _guard = settings.bind_to_scope();
+
+		// load the InfoDb
+		let info_db = InfoDb::from_listxml_output(xml.as_bytes(), |_| ControlFlow::Continue(()))
+			.unwrap()
+			.unwrap()
+			.into();
+
+		// create a MachineConifg
+		let opts: &[(&str, Option<&str>)] = &[];
+		let machine_config = MachineConfig::from_machine_name_and_slots(info_db, machine_name, opts).unwrap();
+
+		// identify audit assets
+		let assets = Asset::from_machine_config(&machine_config);
+
+		// and validate
+		insta::assert_debug_snapshot!(assets);
+	}
 
 	#[test_case(0, "correct_name.bin", None, Ok(("correct_name.bin", 0x3b5b2bc1)))]
 	#[test_case(1, "nonexistent_name.bin", Some(0x098825db), Ok(("wrong_name.bin", 0x098825db)))]

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -115,7 +115,7 @@ impl Asset {
 
 		debug!(machine=?machine.name(), ?bios, ?machine_type, "Asset::from_machine_internal()");
 
-		let machine_names = [Some(machine.name()), machine.clone_of().map(|x| x.name())]
+		let machine_names = [Some(machine.name()), machine.rom_of().map(|x| x.name())]
 			.iter()
 			.flatten()
 			.copied()

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -150,7 +150,7 @@ impl Asset {
 			machine_names: machine_names.clone(),
 			asset_hash: AssetHash::default(),
 			status: AssetStatus::Good,
-			is_optional: false,
+			is_optional: true, // samples are always optional; MAME just doesn't play the same if they are missing
 		});
 		results.extend(roms.chain(disks).chain(samples));
 

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@alienar.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@alienar.snap
@@ -1,0 +1,184 @@
+---
+source: src/audit/mod.rs
+expression: assets
+---
+[
+    Asset {
+        kind: Rom,
+        name: "aarom10",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: CRC(6feb0314) SHA1(5cf30f097bc695cbd388cb408e78394926362a7b),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "aarom11",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: CRC(ae3a270e) SHA1(867fff32062bc876390e8ca6bd7cedae47cd92c9),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "aarom12",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: CRC(6be9f09e) SHA1(98821c9b94301c5fd6e7f5d9e4bc9c1bdbab53ec),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "aarom01",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: CRC(bb0c21be) SHA1(dbf122870adaa49cd99e2c1e9fa4b78fb74ef2c1),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "aarom02",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: CRC(165acd37) SHA1(12466c94bcf5a98f154a639ecc2e95d5193cbab2),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "aarom03",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: CRC(e5d51d92) SHA1(598c928499e977a30906319c97ffa1ef2b9395d1),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "aarom04",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: CRC(24f6feb8) SHA1(c1b7d764785b4edfe80a90ffdc52a67c8dbbfea5),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "aarom05",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: CRC(5b1ac59b) SHA1(9b312eb419e994a006fda2ae61c58c31f048bace),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "aarom06",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: CRC(da7195a2) SHA1(ef2c2750c504176fd6a11e8463278d97cac9a5c5),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "aarom07",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: CRC(f9812be4) SHA1(5f116345f09cd79790612672aa48ede63fc91f56),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "aarom08",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: CRC(cd7f3a87) SHA1(59577059308931139ecc036d06953660a148d91c),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "aarom09",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: CRC(e6ce77b4) SHA1(bd4354100067654d0ad2e590591582dbdfb845b6),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Disk,
+        name: "fakedisk.chd",
+        size: None,
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: SHA1(0123456789abcdef0123456789abcdef01234567),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Sample,
+        name: "fakesample.wav",
+        size: None,
+        machine_names: [
+            "alienar",
+        ],
+        asset_hash: <<NONE>>,
+        status: Good,
+        is_optional: false,
+    },
+]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@alienar.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@alienar.snap
@@ -179,6 +179,6 @@ expression: assets
         ],
         asset_hash: <<NONE>>,
         status: Good,
-        is_optional: false,
+        is_optional: true,
     },
 ]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@blah.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@blah.snap
@@ -1,0 +1,72 @@
+---
+source: src/audit/mod.rs
+expression: assets
+---
+[
+    Asset {
+        kind: Rom,
+        name: "garbage.bin",
+        size: Some(
+            32768,
+        ),
+        machine_names: [
+            "blah",
+            "fake",
+        ],
+        asset_hash: CRC(0faf9fdb) SHA1(c27909184ee9170707c1be9a4cfbe83b359672e1),
+        status: Good,
+        is_optional: true,
+    },
+    Asset {
+        kind: Rom,
+        name: "nodump.bin",
+        size: Some(
+            32768,
+        ),
+        machine_names: [
+            "blah",
+            "fake",
+        ],
+        asset_hash: <<NONE>>,
+        status: NoDump,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "baddump.bin",
+        size: Some(
+            32768,
+        ),
+        machine_names: [
+            "blah",
+            "fake",
+        ],
+        asset_hash: <<NONE>>,
+        status: BadDump,
+        is_optional: false,
+    },
+    Asset {
+        kind: Disk,
+        name: "samplechd.chd",
+        size: None,
+        machine_names: [
+            "blah",
+            "fake",
+        ],
+        asset_hash: SHA1(bfec48ae2439308ac3a547231a13f122ef303c76),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Sample,
+        name: "fakesample.wav",
+        size: None,
+        machine_names: [
+            "blah",
+            "fake",
+        ],
+        asset_hash: <<NONE>>,
+        status: Good,
+        is_optional: false,
+    },
+]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@blah.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@blah.snap
@@ -67,6 +67,6 @@ expression: assets
         ],
         asset_hash: <<NONE>>,
         status: Good,
-        is_optional: false,
+        is_optional: true,
     },
 ]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@c64.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@c64.snap
@@ -1,0 +1,84 @@
+---
+source: src/audit/mod.rs
+expression: assets
+---
+[
+    Asset {
+        kind: Rom,
+        name: "901227-03.u4",
+        size: Some(
+            8192,
+        ),
+        machine_names: [
+            "c64",
+        ],
+        asset_hash: CRC(dbe3e7c7) SHA1(1d503e56df85a62fee696e7618dc5b4e781df1bb),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "901226-01.u3",
+        size: Some(
+            8192,
+        ),
+        machine_names: [
+            "c64",
+        ],
+        asset_hash: CRC(f833d117) SHA1(79015323128650c742a3694c9429aa91f355905e),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "901225-01.u5",
+        size: Some(
+            4096,
+        ),
+        machine_names: [
+            "c64",
+        ],
+        asset_hash: CRC(ec4272ee) SHA1(adc7c31e18c7c7413d54802ef2f4193da14711aa),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "906114-01.u17",
+        size: Some(
+            245,
+        ),
+        machine_names: [
+            "c64",
+        ],
+        asset_hash: CRC(54c89351) SHA1(efb315f560b6f72444b8f0b2ca4b0ccbcd144a1b),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "901229-06 aa.uab5",
+        size: Some(
+            8192,
+        ),
+        machine_names: [
+            "c1541",
+        ],
+        asset_hash: CRC(3a235039) SHA1(c7f94f4f51d6de4cdc21ecbb7e57bb209f0530c0),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "325302-01.uab4",
+        size: Some(
+            8192,
+        ),
+        machine_names: [
+            "c1541",
+        ],
+        asset_hash: CRC(29ae9752) SHA1(8e0547430135ba462525c224e76356bd3d430f11),
+        status: Good,
+        is_optional: false,
+    },
+]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@coco2b.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@coco2b.snap
@@ -1,0 +1,47 @@
+---
+source: src/audit/mod.rs
+expression: assets
+---
+[
+    Asset {
+        kind: Rom,
+        name: "bas13.rom",
+        size: Some(
+            8192,
+        ),
+        machine_names: [
+            "coco2b",
+            "coco",
+        ],
+        asset_hash: CRC(d8f4d15e) SHA1(28b92bebe35fa4f026a084416d6ea3b1552b63d3),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "extbas11.rom",
+        size: Some(
+            8192,
+        ),
+        machine_names: [
+            "coco2b",
+            "coco",
+        ],
+        asset_hash: CRC(a82a6254) SHA1(ad927fb4f30746d820cb8b860ebb585e7f095dea),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "disk11.rom",
+        size: Some(
+            8192,
+        ),
+        machine_names: [
+            "coco_fdc",
+        ],
+        asset_hash: CRC(0b9c5415) SHA1(10bdc5aa2d7d7f205f67b47b19003a4bd89defd1),
+        status: Good,
+        is_optional: false,
+    },
+]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fake.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fake.snap
@@ -1,0 +1,54 @@
+---
+source: src/audit/mod.rs
+expression: assets
+---
+[
+    Asset {
+        kind: Rom,
+        name: "garbage.bin",
+        size: Some(
+            32768,
+        ),
+        machine_names: [
+            "fake",
+        ],
+        asset_hash: CRC(0faf9fdb) SHA1(c27909184ee9170707c1be9a4cfbe83b359672e1),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "nodump.bin",
+        size: Some(
+            32768,
+        ),
+        machine_names: [
+            "fake",
+        ],
+        asset_hash: <<NONE>>,
+        status: NoDump,
+        is_optional: false,
+    },
+    Asset {
+        kind: Disk,
+        name: "samplechd.chd",
+        size: None,
+        machine_names: [
+            "fake",
+        ],
+        asset_hash: SHA1(bfec48ae2439308ac3a547231a13f122ef303c76),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Sample,
+        name: "fakesample.wav",
+        size: None,
+        machine_names: [
+            "fake",
+        ],
+        asset_hash: <<NONE>>,
+        status: Good,
+        is_optional: false,
+    },
+]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fake.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fake.snap
@@ -49,6 +49,6 @@ expression: assets
         ],
         asset_hash: <<NONE>>,
         status: Good,
-        is_optional: false,
+        is_optional: true,
     },
 ]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fakefake.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fakefake.snap
@@ -1,0 +1,58 @@
+---
+source: src/audit/mod.rs
+expression: assets
+---
+[
+    Asset {
+        kind: Rom,
+        name: "garbage.bin",
+        size: Some(
+            32768,
+        ),
+        machine_names: [
+            "fakefake",
+            "fake",
+        ],
+        asset_hash: CRC(0faf9fdb) SHA1(c27909184ee9170707c1be9a4cfbe83b359672e1),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "nodump.bin",
+        size: Some(
+            32768,
+        ),
+        machine_names: [
+            "fakefake",
+            "fake",
+        ],
+        asset_hash: <<NONE>>,
+        status: NoDump,
+        is_optional: false,
+    },
+    Asset {
+        kind: Disk,
+        name: "samplechd.chd",
+        size: None,
+        machine_names: [
+            "fakefake",
+            "fake",
+        ],
+        asset_hash: SHA1(bfec48ae2439308ac3a547231a13f122ef303c76),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Sample,
+        name: "fakesample.wav",
+        size: None,
+        machine_names: [
+            "fakefake",
+            "fake",
+        ],
+        asset_hash: <<NONE>>,
+        status: Good,
+        is_optional: false,
+    },
+]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fakefake.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fakefake.snap
@@ -53,6 +53,6 @@ expression: assets
         ],
         asset_hash: <<NONE>>,
         status: Good,
-        is_optional: false,
+        is_optional: true,
     },
 ]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fakefake.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fakefake.snap
@@ -11,7 +11,6 @@ expression: assets
         ),
         machine_names: [
             "fakefake",
-            "fake",
         ],
         asset_hash: CRC(0faf9fdb) SHA1(c27909184ee9170707c1be9a4cfbe83b359672e1),
         status: Good,
@@ -25,7 +24,6 @@ expression: assets
         ),
         machine_names: [
             "fakefake",
-            "fake",
         ],
         asset_hash: <<NONE>>,
         status: NoDump,
@@ -37,7 +35,6 @@ expression: assets
         size: None,
         machine_names: [
             "fakefake",
-            "fake",
         ],
         asset_hash: SHA1(bfec48ae2439308ac3a547231a13f122ef303c76),
         status: Good,
@@ -49,7 +46,6 @@ expression: assets
         size: None,
         machine_names: [
             "fakefake",
-            "fake",
         ],
         asset_hash: <<NONE>>,
         status: Good,

--- a/src/info/test_data/listxml_fake.xml
+++ b/src/info/test_data/listxml_fake.xml
@@ -196,7 +196,7 @@
 		<device_ref name="<<INVALID>>"/>
 		<softwarelist tag=":cart_list" name="coco_cart" status="original"/>
 	</machine>
-	<machine name="blah" sourcefile="fake_machine.cpp" cloneof="fake">
+	<machine name="blah" sourcefile="fake_machine.cpp" cloneof="fake" romof="fake">
 		<description>Fake Machine</description>
 		<year>2021</year>
 		<manufacturer>&lt;Bletch&gt;</manufacturer>


### PR DESCRIPTION
* Samples are always optional
* Using `romof` instead of `cloneof` to identify ROM compatible systems