### PR TITLE
When determining machine search paths, allow `romof` chains of arbitrary length

### DIFF
--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -460,6 +460,9 @@ mod tests {
 	#[test_case(3, include_str!("../info/test_data/listxml_fake.xml"), "fake")]
 	#[test_case(4, include_str!("../info/test_data/listxml_fake.xml"), "blah")]
 	#[test_case(5, include_str!("../info/test_data/listxml_fake.xml"), "fakefake")]
+	#[test_case(6, include_str!("../info/test_data/listxml_fake.xml"), "phony_withbios")]
+	#[test_case(7, include_str!("../info/test_data/listxml_fake.xml"), "phony_withbios_alpha")]
+	#[test_case(8, include_str!("../info/test_data/listxml_fake.xml"), "phony_withbios_bravo")]
 	fn assets_from_machine_config(_index: usize, xml: &str, machine_name: &str) {
 		// set the insta snapshot suffix; this is a parameterized test
 		let mut settings = insta::Settings::clone_current();

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::io::Cursor;
 use std::io::Read;
 use std::io::Seek;
+use std::iter::successors;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -116,11 +117,8 @@ impl Asset {
 
 		debug!(machine=?machine.name(), ?bios, ?machine_type, "Asset::from_machine_internal()");
 
-		let machine_names = [Some(machine.name()), machine.rom_of().map(|x| x.name())]
-			.iter()
-			.flatten()
-			.copied()
-			.map(SmolStr::from)
+		let machine_names = successors(Some(machine), |machine| machine.rom_of())
+			.map(|machine| machine.name().into())
 			.collect::<Arc<[_]>>();
 		let roms = machine
 			.roms()

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios.snap
@@ -1,0 +1,32 @@
+---
+source: src/audit/mod.rs
+expression: assets
+---
+[
+    Asset {
+        kind: Rom,
+        name: "garbage.bin",
+        size: Some(
+            32768,
+        ),
+        machine_names: [
+            "phony_withbios",
+        ],
+        asset_hash: CRC(0faf9fdb) SHA1(c27909184ee9170707c1be9a4cfbe83b359672e1),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "nodump.bin",
+        size: Some(
+            32768,
+        ),
+        machine_names: [
+            "phony_withbios",
+        ],
+        asset_hash: <<NONE>>,
+        status: NoDump,
+        is_optional: false,
+    },
+]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios_alpha.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios_alpha.snap
@@ -1,0 +1,20 @@
+---
+source: src/audit/mod.rs
+expression: assets
+---
+[
+    Asset {
+        kind: Rom,
+        name: "alpha.bin",
+        size: Some(
+            32768,
+        ),
+        machine_names: [
+            "phony_withbios_alpha",
+            "phony_withbios",
+        ],
+        asset_hash: CRC(1faf9fdb) SHA1(d27909184ee9170707c1be9a4cfbe83b359672e1),
+        status: Good,
+        is_optional: false,
+    },
+]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios_bravo.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios_bravo.snap
@@ -12,6 +12,7 @@ expression: assets
         machine_names: [
             "phony_withbios_bravo",
             "phony_withbios_alpha",
+            "phony_withbios",
         ],
         asset_hash: CRC(2faf9fdb) SHA1(e27909184ee9170707c1be9a4cfbe83b359672e1),
         status: Good,

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios_bravo.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios_bravo.snap
@@ -1,0 +1,20 @@
+---
+source: src/audit/mod.rs
+expression: assets
+---
+[
+    Asset {
+        kind: Rom,
+        name: "bravo.bin",
+        size: Some(
+            32768,
+        ),
+        machine_names: [
+            "phony_withbios_bravo",
+            "phony_withbios_alpha",
+        ],
+        asset_hash: CRC(2faf9fdb) SHA1(e27909184ee9170707c1be9a4cfbe83b359672e1),
+        status: Good,
+        is_optional: false,
+    },
+]

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -732,7 +732,7 @@ mod test {
 
 	#[test_case(0, include_str!("test_data/listxml_alienar.xml"), "0.229 (mame0229)", 13, 1, &["alienar", "ipt_merge_any_hi", "ls157"])]
 	#[test_case(1, include_str!("test_data/listxml_coco.xml"), "0.284 (mame0284)", 211, 10, &["93c06_16", "acia6850", "adaptator_multitap"])]
-	#[test_case(2, include_str!("test_data/listxml_fake.xml"), "<<fake build>>", 6, 3, &["blah", "fake", "fakefake", "floppy_525_dd", "floppy_connector", "mc6809e"])]
+	#[test_case(2, include_str!("test_data/listxml_fake.xml"), "<<fake build>>", 9, 6, &["blah", "fake", "fakefake", "floppy_525_dd", "floppy_connector", "mc6809e"])]
 	pub fn test(
 		_index: usize,
 		xml: &str,

--- a/src/info/test_data/listxml_fake.xml
+++ b/src/info/test_data/listxml_fake.xml
@@ -248,4 +248,23 @@
 		<sound channels="1"/>
 		<softwarelist tag=":cart_list" name="coco_cart" status="original"/>
 	</machine>
+	<machine name="phony_withbios"  sourcefile="phony_machine_with_bios.cpp" isbios="yes">
+		<description>Phony Machine With Bios</description>
+		<year>2021</year>
+		<manufacturer>&lt;Bletch&gt;</manufacturer>
+		<rom name="garbage.bin" size="32768" crc="0faf9fdb" sha1="c27909184ee9170707c1be9a4cfbe83b359672e1" region="maincpu" offset="0000"/>
+		<rom name="nodump.bin" size="32768" status="nodump" region="maincpu" offset="8000"/>
+	</machine>
+	<machine name="phony_withbios_alpha"  sourcefile="phony_machine_with_bios.cpp" romof="phony_withbios">
+		<description>Phony Machine With Bios Alpha</description>
+		<year>2021</year>
+		<manufacturer>&lt;Bletch&gt;</manufacturer>
+		<rom name="alpha.bin" size="32768" crc="1faf9fdb" sha1="d27909184ee9170707c1be9a4cfbe83b359672e1" region="maincpu" offset="0000"/>
+	</machine>
+	<machine name="phony_withbios_bravo"  sourcefile="phony_machine_with_bios.cpp" cloneof="phony_withbios_alpha" romof="phony_withbios_alpha">
+		<description>Phony Machine With Bios Bravo</description>
+		<year>2021</year>
+		<manufacturer>&lt;Bletch&gt;</manufacturer>
+		<rom name="bravo.bin" size="32768" crc="2faf9fdb" sha1="e27909184ee9170707c1be9a4cfbe83b359672e1" region="maincpu" offset="0000"/>
+	</machine>
 </mame>


### PR DESCRIPTION
This will happen with clones of bios machines