### PR TITLE
Auditing (both in the Configuration dialog and before running an emulation) will now audit images

### DIFF
--- a/src/appstate.rs
+++ b/src/appstate.rs
@@ -1008,7 +1008,7 @@ fn spawn_audit(
 	let machine_config = MachineConfig::from_mame_start_args(info_db.clone(), start_args)?;
 
 	// create the assets
-	let assets = Asset::from_machine_config(&machine_config);
+	let assets = Asset::from_machine_config_and_images(&machine_config, &start_args.images);
 
 	// progress messages need to be throttled
 	let mut throttle = Throttle::new(PROGRESS_THROTTLE_TIMEOUT, 1);

--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -1352,18 +1352,9 @@ fn handle_action(model: &Rc<AppModel>, action: Action) {
 			let fut = dialog_message_box::<OkOnly>(model_clone.modal_stack.clone(), "Error", message);
 			spawn_local(fut).unwrap();
 		}
-		Action::Start(start_args) => match start_args.preflight() {
-			Ok(_) => {
-				model.update_state(|state| state.start(start_args));
-			}
-			Err(errors) => {
-				let message = errors.into_iter().map(|e| e.to_string()).collect::<String>();
-				let message =
-					format!("The emulation could not be started due to the following problems:\n\n{message}",);
-				let fut = dialog_message_box::<OkOnly>(model.modal_stack.clone(), "Error", message);
-				spawn_local(fut).unwrap();
-			}
-		},
+		Action::Start(start_args) => {
+			model.update_state(|state| state.start(start_args));
+		}
 		Action::IssueMameCommand(command) => {
 			model.issue_command(command);
 		}

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -1,3 +1,4 @@
+use std::cell::OnceCell;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fs::File;
@@ -26,7 +27,9 @@ use zip::result::ZipResult;
 
 use crate::assethash::AssetHash;
 use crate::chd::chd_asset_hash;
+use crate::imagedesc::ImageDesc;
 use crate::info::AssetStatus;
+use crate::info::DeviceType;
 use crate::info::Machine;
 use crate::info::View;
 use crate::mconfig::MachineConfig;
@@ -36,7 +39,7 @@ pub struct Asset {
 	pub kind: AssetKind,
 	pub name: SharedString,
 	pub size: Option<u64>,
-	machine_names: Arc<[SmolStr]>,
+	location: AssetLocation,
 	asset_hash: AssetHash,
 	status: AssetStatus,
 	is_optional: bool,
@@ -47,6 +50,7 @@ pub enum AssetKind {
 	Rom,
 	Disk,
 	Sample,
+	ImageFile(DeviceType),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -54,6 +58,12 @@ pub enum AuditSeverity {
 	Info,
 	Warning,
 	Fail,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AssetLocation {
+	MachinePaths(Arc<[SmolStr]>),
+	Absolute(SmolStr),
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)] // TODO - `Clone` should not be necessary
@@ -83,7 +93,10 @@ enum MachineType<'a> {
 }
 
 impl Asset {
-	pub fn from_machine_config(machine_config: &MachineConfig) -> Vec<Self> {
+	pub fn from_machine_config_and_images<'a>(
+		machine_config: &MachineConfig,
+		images: impl IntoIterator<Item = &'a (SmolStr, ImageDesc)> + 'a,
+	) -> Vec<Self> {
 		let mut results = Vec::new();
 		Self::from_machine_internal(&mut results, machine_config.machine(), None, MachineType::Root);
 		machine_config.visit_slots(|_, _, _, _, slot_data| {
@@ -92,10 +105,43 @@ impl Asset {
 			}
 		});
 
+		// available ports should only be evaluated once
+		let available_ports = OnceCell::new();
+		let available_ports = || available_ports.get_or_init(crate::imagedesc::available_ports);
+
+		// add images
+		for (tag, image_desc) in images {
+			if let ImageDesc::File(filename) = image_desc
+				&& available_ports().iter().all(|p| p.port_name != *filename)
+			{
+				let name = Path::new(&filename)
+					.file_name()
+					.unwrap_or_default()
+					.to_string_lossy()
+					.as_ref()
+					.into();
+				let device_type = machine_config
+					.lookup_device_tag(tag)
+					.ok()
+					.map(|(_, device)| device.device_type())
+					.unwrap_or(DeviceType::Unknown);
+				let asset = Asset {
+					kind: AssetKind::ImageFile(device_type),
+					name,
+					size: None,
+					location: AssetLocation::Absolute(filename.clone()),
+					asset_hash: AssetHash::default(),
+					status: AssetStatus::Good,
+					is_optional: false,
+				};
+				results.push(asset);
+			}
+		}
+
 		// remove duplicates and return
 		let results = results
 			.into_iter()
-			.unique_by(|x| (x.kind, x.name.clone(), x.machine_names.clone()))
+			.unique_by(|x| (x.kind, x.name.clone(), x.location.clone()))
 			.collect();
 
 		debug!(?machine_config, ?results, "Asset::from_machine_config()");
@@ -120,6 +166,7 @@ impl Asset {
 		let machine_names = successors(Some(machine), |machine| machine.rom_of())
 			.map(|machine| machine.name().into())
 			.collect::<Arc<[_]>>();
+		let location = AssetLocation::MachinePaths(machine_names);
 		let roms = machine
 			.roms()
 			.iter()
@@ -128,7 +175,7 @@ impl Asset {
 				kind: AssetKind::Rom,
 				name: rom.name().into(),
 				size: rom.size().into(),
-				machine_names: machine_names.clone(),
+				location: location.clone(),
 				asset_hash: rom.asset_hash(),
 				status: rom.status(),
 				is_optional: rom.is_optional(),
@@ -137,7 +184,7 @@ impl Asset {
 			kind: AssetKind::Disk,
 			name: format!("{}.chd", disk.name()).into(),
 			size: None,
-			machine_names: machine_names.clone(),
+			location: location.clone(),
 			asset_hash: disk.asset_hash(),
 			status: disk.status(),
 			is_optional: disk.is_optional(),
@@ -146,7 +193,7 @@ impl Asset {
 			kind: AssetKind::Sample,
 			name: format!("{}.wav", sample.name()).into(),
 			size: None,
-			machine_names: machine_names.clone(),
+			location: location.clone(),
 			asset_hash: AssetHash::default(),
 			status: AssetStatus::Good,
 			is_optional: true, // samples are always optional; MAME just doesn't play the same if they are missing
@@ -168,8 +215,8 @@ impl Asset {
 		fn hash_func_rom(file: &mut dyn Read) -> Result<AssetHash> {
 			AssetHash::calculate(file)
 		}
-		fn hash_func_sample(_file: &mut dyn Read) -> Result<AssetHash> {
-			unreachable!("Samples don't get hashed");
+		fn hash_func_bogus(_file: &mut dyn Read) -> Result<AssetHash> {
+			panic!("This asset type doesn't get hashed");
 		}
 		fn hash_func_disk(file: &mut dyn Read) -> Result<AssetHash> {
 			chd_asset_hash(file)
@@ -178,27 +225,73 @@ impl Asset {
 		// do different things based on the `AssetKind`
 		let (asset_paths, support_archives, hash_func) = match self.kind {
 			AssetKind::Rom => (Either::Left(rom_paths), true, hash_func_rom as HashFunc),
-			AssetKind::Sample => (Either::Right(sample_paths), true, hash_func_sample as HashFunc),
+			AssetKind::Sample => (Either::Right(sample_paths), true, hash_func_bogus as HashFunc),
 			AssetKind::Disk => (Either::Left(rom_paths), false, hash_func_disk as HashFunc),
+			AssetKind::ImageFile(_) => (Either::Left([].as_slice()), false, hash_func_bogus as HashFunc),
 		};
 
-		// normalize the paths iterator
-		let paths_iter = asset_paths
+		// normalize the iterator for asset paths
+		let asset_paths_iter = asset_paths
 			.map_left(|paths| paths.iter().map(|x| x.as_ref()))
 			.map_right(|paths| paths.iter().map(|x| x.as_ref()));
 
-		// now do the heavy lifting
-		audit_single(
-			&self.name,
-			self.size,
-			&self.asset_hash,
-			self.status,
-			self.is_optional,
-			self.machine_names.as_ref(),
-			paths_iter,
-			support_archives,
-			hash_func,
-		)
+		// iterate through everything that can identify an asset
+		let iter = match &self.location {
+			AssetLocation::MachinePaths(machine_names) => {
+				let path_types = if support_archives {
+					[PathType::File, PathType::Zip, PathType::SevenZ].as_slice()
+				} else {
+					[PathType::File].as_slice()
+				};
+				let iter = machine_names
+					.as_ref()
+					.iter()
+					.flat_map(|machine_name| asset_paths_iter.clone().map(|path| (path, machine_name.as_str())))
+					.flat_map(|(path, machine_name)| {
+						path_types.iter().map(move |path_type| (path, machine_name, *path_type))
+					})
+					.map(|(path, machine_name, path_type)| {
+						let mut path = path.join(machine_name);
+						if let Some(archive_extension) = path_type.get_str("ArchiveExtension") {
+							path.set_extension(archive_extension);
+						} else {
+							path = path.join(&self.name);
+						}
+						(path, path_type)
+					});
+				Either::Left(iter)
+			}
+			AssetLocation::Absolute(path) => {
+				let path = Path::new(&path).to_path_buf();
+				Either::Right(std::iter::once((path, PathType::File)))
+			}
+		};
+
+		let result = iter
+			.filter_map(|(path, path_type)| {
+				try_audit(
+					&self.name,
+					self.size,
+					&self.asset_hash,
+					self.status,
+					path,
+					path_type,
+					hash_func,
+				)
+				.ok()
+			})
+			.next()
+			.unwrap_or_else(|| {
+				let message = match (self.status, self.is_optional) {
+					(AssetStatus::NoDump, _) => AuditMessage::NotFoundNoGoodDump,
+					(_, false) => AuditMessage::NotFound,
+					(_, true) => AuditMessage::NotFoundButOptional,
+				};
+				let messages = [message].into();
+				AuditResult { path: None, messages }
+			});
+		debug!(?self, ?result, "Asset::run_audit()");
+		result
 	}
 }
 
@@ -246,110 +339,42 @@ pub enum PathType {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn audit_single<'a>(
-	asset_name: &str,
-	expected_size: Option<u64>,
-	expected_asset_hash: &AssetHash,
-	status: AssetStatus,
-	is_optional: bool,
-	machine_names: &[impl AsRef<str>],
-	paths_iter: impl Iterator<Item = &'a Path> + Clone,
-	support_archives: bool,
-	hash_func: fn(&mut dyn Read) -> Result<AssetHash>,
-) -> AuditResult {
-	let path_types = if support_archives {
-		[PathType::File, PathType::Zip, PathType::SevenZ].as_slice()
-	} else {
-		[PathType::File].as_slice()
-	};
-
-	let result = machine_names
-		.iter()
-		.flat_map(|machine_name| paths_iter.clone().map(|path| (machine_name.as_ref(), path)))
-		.flat_map(|(machine_name, path)| path_types.iter().map(move |path_type| (machine_name, path, *path_type)))
-		.filter_map(|(machine_name, path, path_type)| {
-			try_audit(
-				asset_name,
-				expected_size,
-				expected_asset_hash,
-				status,
-				machine_name,
-				path,
-				path_type,
-				hash_func,
-			)
-			.ok()
-		})
-		.next()
-		.unwrap_or_else(|| {
-			let message = match (status, is_optional) {
-				(AssetStatus::NoDump, _) => AuditMessage::NotFoundNoGoodDump,
-				(_, false) => AuditMessage::NotFound,
-				(_, true) => AuditMessage::NotFoundButOptional,
-			};
-			let messages = [message].into();
-			AuditResult { path: None, messages }
-		});
-	debug!(
-		?asset_name,
-		?expected_size,
-		?expected_asset_hash,
-		?status,
-		?is_optional,
-		machine_names = ?machine_names.iter().map(|x| x.as_ref()).collect::<Vec<_>>(),
-		?result,
-		"audit_single()"
-	);
-	result
-}
-
-#[allow(clippy::too_many_arguments)]
 fn try_audit(
 	asset_name: &str,
 	expected_size: Option<u64>,
 	expected_asset_hash: &AssetHash,
 	status: AssetStatus,
-	machine_name: &str,
-	path: &Path,
+	path: PathBuf,
 	path_type: PathType,
 	hash_func: fn(&mut dyn Read) -> Result<AssetHash>,
 ) -> Result<AuditResult> {
 	// open the file
-	let mut path = path.join(machine_name);
-	if let Some(archive_extension) = path_type.get_str("ArchiveExtension") {
-		path.set_extension(archive_extension);
-	} else {
-		path = path.join(asset_name);
-	}
 	let file_result = File::open(&path);
 	debug!(?path_type, ?path, ?file_result, "try_audit(): Invoked File::open()");
 	let mut file = file_result?;
+
+	// lambda to get actual hash
+	let get_actual_hash = |file| (!expected_asset_hash.is_default()).then(|| hash_func(file)).transpose();
 
 	// these operations depend on the type of file
 	let (actual_size, actual_hash) = match path_type {
 		PathType::File => {
 			let actual_size = file.metadata()?.len();
-			let actual_hash = (!expected_asset_hash.is_default())
-				.then(|| hash_func(&mut file))
-				.transpose()?;
+			let actual_hash = get_actual_hash(&mut file)?;
 			(actual_size, actual_hash)
 		}
 		PathType::Zip => {
 			let mut zip_archive = ZipArchive::new(file)?;
 			let mut zip_file = zip_archive.by_name_or_crc(asset_name, expected_asset_hash.crc)?;
 			let actual_size = zip_file.size();
-			let actual_hash = (!expected_asset_hash.is_default())
-				.then(|| hash_func(&mut zip_file))
-				.transpose()?;
+			let actual_hash = get_actual_hash(&mut zip_file)?;
 			(actual_size, actual_hash)
 		}
 		PathType::SevenZ => {
 			let data = SevenZArchiveReader::new(file, Default::default())?
 				.read_file_by_name_or_crc(asset_name, expected_asset_hash.crc)?;
 			let actual_size = data.len() as u64;
-			let actual_hash = (!expected_asset_hash.is_default())
-				.then(|| hash_func(&mut Cursor::new(&data)))
-				.transpose()?;
+			let actual_hash = get_actual_hash(&mut Cursor::new(&data))?;
 			(actual_size, actual_hash)
 		}
 	};
@@ -478,7 +503,7 @@ mod tests {
 		let machine_config = MachineConfig::from_machine_name_and_slots(info_db, machine_name, opts).unwrap();
 
 		// identify audit assets
-		let assets = Asset::from_machine_config(&machine_config);
+		let assets = Asset::from_machine_config_and_images(&machine_config, &[]);
 
 		// and validate
 		insta::assert_debug_snapshot!(assets);

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@alienar.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@alienar.snap
@@ -9,9 +9,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: CRC(6feb0314) SHA1(5cf30f097bc695cbd388cb408e78394926362a7b),
         status: Good,
         is_optional: false,
@@ -22,9 +24,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: CRC(ae3a270e) SHA1(867fff32062bc876390e8ca6bd7cedae47cd92c9),
         status: Good,
         is_optional: false,
@@ -35,9 +39,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: CRC(6be9f09e) SHA1(98821c9b94301c5fd6e7f5d9e4bc9c1bdbab53ec),
         status: Good,
         is_optional: false,
@@ -48,9 +54,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: CRC(bb0c21be) SHA1(dbf122870adaa49cd99e2c1e9fa4b78fb74ef2c1),
         status: Good,
         is_optional: false,
@@ -61,9 +69,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: CRC(165acd37) SHA1(12466c94bcf5a98f154a639ecc2e95d5193cbab2),
         status: Good,
         is_optional: false,
@@ -74,9 +84,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: CRC(e5d51d92) SHA1(598c928499e977a30906319c97ffa1ef2b9395d1),
         status: Good,
         is_optional: false,
@@ -87,9 +99,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: CRC(24f6feb8) SHA1(c1b7d764785b4edfe80a90ffdc52a67c8dbbfea5),
         status: Good,
         is_optional: false,
@@ -100,9 +114,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: CRC(5b1ac59b) SHA1(9b312eb419e994a006fda2ae61c58c31f048bace),
         status: Good,
         is_optional: false,
@@ -113,9 +129,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: CRC(da7195a2) SHA1(ef2c2750c504176fd6a11e8463278d97cac9a5c5),
         status: Good,
         is_optional: false,
@@ -126,9 +144,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: CRC(f9812be4) SHA1(5f116345f09cd79790612672aa48ede63fc91f56),
         status: Good,
         is_optional: false,
@@ -139,9 +159,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: CRC(cd7f3a87) SHA1(59577059308931139ecc036d06953660a148d91c),
         status: Good,
         is_optional: false,
@@ -152,9 +174,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: CRC(e6ce77b4) SHA1(bd4354100067654d0ad2e590591582dbdfb845b6),
         status: Good,
         is_optional: false,
@@ -163,9 +187,11 @@ expression: assets
         kind: Disk,
         name: "fakedisk.chd",
         size: None,
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: SHA1(0123456789abcdef0123456789abcdef01234567),
         status: Good,
         is_optional: false,
@@ -174,9 +200,11 @@ expression: assets
         kind: Sample,
         name: "fakesample.wav",
         size: None,
-        machine_names: [
-            "alienar",
-        ],
+        location: MachinePaths(
+            [
+                "alienar",
+            ],
+        ),
         asset_hash: <<NONE>>,
         status: Good,
         is_optional: true,

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@blah.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@blah.snap
@@ -9,10 +9,12 @@ expression: assets
         size: Some(
             32768,
         ),
-        machine_names: [
-            "blah",
-            "fake",
-        ],
+        location: MachinePaths(
+            [
+                "blah",
+                "fake",
+            ],
+        ),
         asset_hash: CRC(0faf9fdb) SHA1(c27909184ee9170707c1be9a4cfbe83b359672e1),
         status: Good,
         is_optional: true,
@@ -23,10 +25,12 @@ expression: assets
         size: Some(
             32768,
         ),
-        machine_names: [
-            "blah",
-            "fake",
-        ],
+        location: MachinePaths(
+            [
+                "blah",
+                "fake",
+            ],
+        ),
         asset_hash: <<NONE>>,
         status: NoDump,
         is_optional: false,
@@ -37,10 +41,12 @@ expression: assets
         size: Some(
             32768,
         ),
-        machine_names: [
-            "blah",
-            "fake",
-        ],
+        location: MachinePaths(
+            [
+                "blah",
+                "fake",
+            ],
+        ),
         asset_hash: <<NONE>>,
         status: BadDump,
         is_optional: false,
@@ -49,10 +55,12 @@ expression: assets
         kind: Disk,
         name: "samplechd.chd",
         size: None,
-        machine_names: [
-            "blah",
-            "fake",
-        ],
+        location: MachinePaths(
+            [
+                "blah",
+                "fake",
+            ],
+        ),
         asset_hash: SHA1(bfec48ae2439308ac3a547231a13f122ef303c76),
         status: Good,
         is_optional: false,
@@ -61,10 +69,12 @@ expression: assets
         kind: Sample,
         name: "fakesample.wav",
         size: None,
-        machine_names: [
-            "blah",
-            "fake",
-        ],
+        location: MachinePaths(
+            [
+                "blah",
+                "fake",
+            ],
+        ),
         asset_hash: <<NONE>>,
         status: Good,
         is_optional: true,

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@c64.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@c64.snap
@@ -9,9 +9,11 @@ expression: assets
         size: Some(
             8192,
         ),
-        machine_names: [
-            "c64",
-        ],
+        location: MachinePaths(
+            [
+                "c64",
+            ],
+        ),
         asset_hash: CRC(dbe3e7c7) SHA1(1d503e56df85a62fee696e7618dc5b4e781df1bb),
         status: Good,
         is_optional: false,
@@ -22,9 +24,11 @@ expression: assets
         size: Some(
             8192,
         ),
-        machine_names: [
-            "c64",
-        ],
+        location: MachinePaths(
+            [
+                "c64",
+            ],
+        ),
         asset_hash: CRC(f833d117) SHA1(79015323128650c742a3694c9429aa91f355905e),
         status: Good,
         is_optional: false,
@@ -35,9 +39,11 @@ expression: assets
         size: Some(
             4096,
         ),
-        machine_names: [
-            "c64",
-        ],
+        location: MachinePaths(
+            [
+                "c64",
+            ],
+        ),
         asset_hash: CRC(ec4272ee) SHA1(adc7c31e18c7c7413d54802ef2f4193da14711aa),
         status: Good,
         is_optional: false,
@@ -48,9 +54,11 @@ expression: assets
         size: Some(
             245,
         ),
-        machine_names: [
-            "c64",
-        ],
+        location: MachinePaths(
+            [
+                "c64",
+            ],
+        ),
         asset_hash: CRC(54c89351) SHA1(efb315f560b6f72444b8f0b2ca4b0ccbcd144a1b),
         status: Good,
         is_optional: false,
@@ -61,9 +69,11 @@ expression: assets
         size: Some(
             8192,
         ),
-        machine_names: [
-            "c1541",
-        ],
+        location: MachinePaths(
+            [
+                "c1541",
+            ],
+        ),
         asset_hash: CRC(3a235039) SHA1(c7f94f4f51d6de4cdc21ecbb7e57bb209f0530c0),
         status: Good,
         is_optional: false,
@@ -74,9 +84,11 @@ expression: assets
         size: Some(
             8192,
         ),
-        machine_names: [
-            "c1541",
-        ],
+        location: MachinePaths(
+            [
+                "c1541",
+            ],
+        ),
         asset_hash: CRC(29ae9752) SHA1(8e0547430135ba462525c224e76356bd3d430f11),
         status: Good,
         is_optional: false,

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@coco2b.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@coco2b.snap
@@ -9,10 +9,12 @@ expression: assets
         size: Some(
             8192,
         ),
-        machine_names: [
-            "coco2b",
-            "coco",
-        ],
+        location: MachinePaths(
+            [
+                "coco2b",
+                "coco",
+            ],
+        ),
         asset_hash: CRC(d8f4d15e) SHA1(28b92bebe35fa4f026a084416d6ea3b1552b63d3),
         status: Good,
         is_optional: false,
@@ -23,10 +25,12 @@ expression: assets
         size: Some(
             8192,
         ),
-        machine_names: [
-            "coco2b",
-            "coco",
-        ],
+        location: MachinePaths(
+            [
+                "coco2b",
+                "coco",
+            ],
+        ),
         asset_hash: CRC(a82a6254) SHA1(ad927fb4f30746d820cb8b860ebb585e7f095dea),
         status: Good,
         is_optional: false,
@@ -37,9 +41,11 @@ expression: assets
         size: Some(
             8192,
         ),
-        machine_names: [
-            "coco_fdc",
-        ],
+        location: MachinePaths(
+            [
+                "coco_fdc",
+            ],
+        ),
         asset_hash: CRC(0b9c5415) SHA1(10bdc5aa2d7d7f205f67b47b19003a4bd89defd1),
         status: Good,
         is_optional: false,

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fake.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fake.snap
@@ -9,9 +9,11 @@ expression: assets
         size: Some(
             32768,
         ),
-        machine_names: [
-            "fake",
-        ],
+        location: MachinePaths(
+            [
+                "fake",
+            ],
+        ),
         asset_hash: CRC(0faf9fdb) SHA1(c27909184ee9170707c1be9a4cfbe83b359672e1),
         status: Good,
         is_optional: false,
@@ -22,9 +24,11 @@ expression: assets
         size: Some(
             32768,
         ),
-        machine_names: [
-            "fake",
-        ],
+        location: MachinePaths(
+            [
+                "fake",
+            ],
+        ),
         asset_hash: <<NONE>>,
         status: NoDump,
         is_optional: false,
@@ -33,9 +37,11 @@ expression: assets
         kind: Disk,
         name: "samplechd.chd",
         size: None,
-        machine_names: [
-            "fake",
-        ],
+        location: MachinePaths(
+            [
+                "fake",
+            ],
+        ),
         asset_hash: SHA1(bfec48ae2439308ac3a547231a13f122ef303c76),
         status: Good,
         is_optional: false,
@@ -44,9 +50,11 @@ expression: assets
         kind: Sample,
         name: "fakesample.wav",
         size: None,
-        machine_names: [
-            "fake",
-        ],
+        location: MachinePaths(
+            [
+                "fake",
+            ],
+        ),
         asset_hash: <<NONE>>,
         status: Good,
         is_optional: true,

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fakefake.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@fakefake.snap
@@ -9,9 +9,11 @@ expression: assets
         size: Some(
             32768,
         ),
-        machine_names: [
-            "fakefake",
-        ],
+        location: MachinePaths(
+            [
+                "fakefake",
+            ],
+        ),
         asset_hash: CRC(0faf9fdb) SHA1(c27909184ee9170707c1be9a4cfbe83b359672e1),
         status: Good,
         is_optional: false,
@@ -22,9 +24,11 @@ expression: assets
         size: Some(
             32768,
         ),
-        machine_names: [
-            "fakefake",
-        ],
+        location: MachinePaths(
+            [
+                "fakefake",
+            ],
+        ),
         asset_hash: <<NONE>>,
         status: NoDump,
         is_optional: false,
@@ -33,9 +37,11 @@ expression: assets
         kind: Disk,
         name: "samplechd.chd",
         size: None,
-        machine_names: [
-            "fakefake",
-        ],
+        location: MachinePaths(
+            [
+                "fakefake",
+            ],
+        ),
         asset_hash: SHA1(bfec48ae2439308ac3a547231a13f122ef303c76),
         status: Good,
         is_optional: false,
@@ -44,9 +50,11 @@ expression: assets
         kind: Sample,
         name: "fakesample.wav",
         size: None,
-        machine_names: [
-            "fakefake",
-        ],
+        location: MachinePaths(
+            [
+                "fakefake",
+            ],
+        ),
         asset_hash: <<NONE>>,
         status: Good,
         is_optional: true,

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios.snap
@@ -9,9 +9,11 @@ expression: assets
         size: Some(
             32768,
         ),
-        machine_names: [
-            "phony_withbios",
-        ],
+        location: MachinePaths(
+            [
+                "phony_withbios",
+            ],
+        ),
         asset_hash: CRC(0faf9fdb) SHA1(c27909184ee9170707c1be9a4cfbe83b359672e1),
         status: Good,
         is_optional: false,
@@ -22,9 +24,11 @@ expression: assets
         size: Some(
             32768,
         ),
-        machine_names: [
-            "phony_withbios",
-        ],
+        location: MachinePaths(
+            [
+                "phony_withbios",
+            ],
+        ),
         asset_hash: <<NONE>>,
         status: NoDump,
         is_optional: false,

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios_alpha.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios_alpha.snap
@@ -9,10 +9,12 @@ expression: assets
         size: Some(
             32768,
         ),
-        machine_names: [
-            "phony_withbios_alpha",
-            "phony_withbios",
-        ],
+        location: MachinePaths(
+            [
+                "phony_withbios_alpha",
+                "phony_withbios",
+            ],
+        ),
         asset_hash: CRC(1faf9fdb) SHA1(d27909184ee9170707c1be9a4cfbe83b359672e1),
         status: Good,
         is_optional: false,

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios_bravo.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config@phony_withbios_bravo.snap
@@ -9,11 +9,13 @@ expression: assets
         size: Some(
             32768,
         ),
-        machine_names: [
-            "phony_withbios_bravo",
-            "phony_withbios_alpha",
-            "phony_withbios",
-        ],
+        location: MachinePaths(
+            [
+                "phony_withbios_bravo",
+                "phony_withbios_alpha",
+                "phony_withbios",
+            ],
+        ),
         asset_hash: CRC(2faf9fdb) SHA1(e27909184ee9170707c1be9a4cfbe83b359672e1),
         status: Good,
         is_optional: false,

--- a/src/dialogs/configure.rs
+++ b/src/dialogs/configure.rs
@@ -20,6 +20,7 @@ use smol_str::SmolStr;
 use tokio::sync::mpsc;
 
 use crate::action::Action;
+use crate::audit::Asset;
 use crate::devimageconfig::DevicesImagesConfig;
 use crate::devimageconfig::EntryDetails;
 use crate::devimageconfig::ListSlots;
@@ -515,10 +516,20 @@ impl State {
 
 		let dialog = self.dialog_weak.unwrap();
 		let audit_model = dimodel_state.with_machine_config(|machine_config| {
+			let images = if let DiModelState::Ok { images, .. } = dimodel_state {
+				images
+					.borrow()
+					.iter()
+					.map(|(tag, image_desc)| (tag.into(), image_desc.clone()))
+					.collect::<Vec<_>>()
+			} else {
+				[].into()
+			};
+			let assets = Asset::from_machine_config_and_images(machine_config, &images);
 			let rom_paths = self.rom_paths.clone();
 			let sample_paths = self.sample_paths.clone();
 			let icons = Icons::get(&dialog);
-			AuditModel::new(machine_config, rom_paths, sample_paths, icons)
+			AuditModel::new(assets, rom_paths, sample_paths, icons)
 		});
 		let audit_model = audit_model.map(ModelRc::new).unwrap_or_default();
 		dialog.set_audit_assets(audit_model);

--- a/src/imagedesc.rs
+++ b/src/imagedesc.rs
@@ -29,8 +29,6 @@ enum ThisError {
 	InvalidHostName(SmolStr),
 	#[error("cannot parse portnumber")]
 	CannotParsePortNumber,
-	#[error("file not found: {0}")]
-	FileNotFound(String),
 	#[error("invalid software name: {0}")]
 	InvalidSoftwareName(SmolStr),
 }
@@ -53,17 +51,6 @@ impl ImageDesc {
 			Self::Software(software) => Cow::Borrowed(software.as_ref()),
 			Self::Socket { hostname, port } => format!("socket.{}:{}", hostname, *port).into(),
 		}
-	}
-
-	pub fn validate(&self) -> Result<()> {
-		if let Self::File(filename) = self
-			&& !Path::new(filename).is_file()
-			&& available_ports().iter().all(|p| p.port_name != *filename)
-		{
-			let error = ThisError::FileNotFound(filename.to_string());
-			return Err(error.into());
-		}
-		Ok(())
 	}
 
 	pub fn display_name(&self) -> Cow<'_, str> {

--- a/src/info/binary.rs
+++ b/src/info/binary.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use strum::EnumCount;
 use strum::EnumString;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
@@ -207,11 +208,103 @@ pub enum ConditionRelation {
 #[repr(C, packed)]
 #[derive(Clone, Copy, Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout, PartialEq, Eq, Hash)]
 pub struct Device {
-	pub type_strindex: UsizeDb,
+	pub device_type: DeviceType,
 	pub tag_strindex: UsizeDb,
 	pub mandatory: bool,
 	pub interfaces_strindex: UsizeDb,
 	pub extensions_strindex: UsizeDb,
+}
+
+#[repr(u8)]
+#[derive(
+	Clone,
+	Copy,
+	Debug,
+	Deserialize,
+	TryFromBytes,
+	IntoBytes,
+	Immutable,
+	KnownLayout,
+	EnumCount,
+	EnumString,
+	PartialEq,
+	Eq,
+	Hash,
+)]
+pub enum DeviceType {
+	Unknown,
+	#[strum(serialize = "bitbanger")]
+	Bitbanger,
+	#[strum(serialize = "bubble")]
+	Bubble,
+	#[strum(serialize = "card")]
+	Card,
+	#[strum(serialize = "cartridge")]
+	Cartridge,
+	#[strum(serialize = "cartridge60pin")]
+	Cartridge60Pin,
+	#[strum(serialize = "cassette")]
+	Cassette,
+	#[strum(serialize = "cdrom")]
+	Cdrom,
+	#[strum(serialize = "connect")]
+	Connect,
+	#[strum(serialize = "ctape")]
+	Ctape,
+	#[strum(serialize = "cylinder")]
+	Cylinder,
+	#[strum(serialize = "datapack")]
+	Datapack,
+	#[strum(serialize = "disk")]
+	Disk,
+	#[strum(serialize = "floppydisk")]
+	FloppyDisk,
+	#[strum(serialize = "harddisk")]
+	HardDisk,
+	#[strum(serialize = "magtape")]
+	MagTape,
+	#[strum(serialize = "memcard")]
+	MemCard,
+	#[strum(serialize = "microtape")]
+	Microtape,
+	#[strum(serialize = "midiin")]
+	MidiIn,
+	#[strum(serialize = "midiout")]
+	MidiOut,
+	#[strum(serialize = "node_id")]
+	NodeId,
+	#[strum(serialize = "parallel")]
+	Parallel,
+	#[strum(serialize = "picture")]
+	Picture,
+	#[strum(serialize = "port")]
+	Port,
+	#[strum(serialize = "printout")]
+	PrintOut,
+	#[strum(serialize = "promimage")]
+	PromImage,
+	#[strum(serialize = "punchtape")]
+	PunchTape,
+	#[strum(serialize = "quickload")]
+	QuickLoad,
+	#[strum(serialize = "romimage")]
+	RomImage,
+	#[strum(serialize = "sasihd")]
+	SasiHd,
+	#[strum(serialize = "serial")]
+	Serial,
+	#[strum(serialize = "snapshot")]
+	Snapshot,
+	#[strum(serialize = "ssd")]
+	Ssd,
+	#[strum(serialize = "tape")]
+	Tape,
+	#[strum(serialize = "vidfile")]
+	VidFile,
+	#[strum(serialize = "winchester")]
+	Winchester,
+	#[strum(serialize = "yamahaminicart")]
+	YamahaMiniCart,
 }
 
 #[repr(C, packed)]

--- a/src/info/build.rs
+++ b/src/info/build.rs
@@ -18,6 +18,7 @@ use itertools::Itertools;
 use more_asserts::assert_le;
 use more_asserts::assert_lt;
 use primal::is_prime;
+use strum::EnumCount;
 use tracing::debug;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
@@ -36,6 +37,7 @@ use crate::info::binary::ASSET_FLAG_HAS_SHA1;
 use crate::info::binary::ASSET_FLAG_NODUMP;
 use crate::info::binary::ASSET_FLAG_OPTIONAL;
 use crate::info::binary::ASSET_FLAG_WRITABLE;
+use crate::info::binary::DeviceType;
 use crate::info::binary::Fixup;
 use crate::info::entities::AssetStatus;
 use crate::info::strings::StringTableBuilder;
@@ -453,15 +455,17 @@ impl State {
 			(Phase::Machine, b"device") => {
 				let [device_type, tag, mandatory, interface] =
 					evt.find_attributes([b"type", b"tag", b"mandatory", b"interface"])?;
+				let device_type = device_type
+					.and_then(|x| x.parse::<DeviceType>().ok())
+					.unwrap_or(DeviceType::Unknown);
 				let tag = tag.mandatory("tag")?;
 				let tag = normalize_tag(tag);
-				let type_strindex = self.strings.lookup(&device_type.unwrap_or_default());
 				let tag_strindex = self.strings.lookup(&tag);
 				let mandatory = mandatory.map(parse_mame_bool).transpose()?.unwrap_or(false);
 				let interfaces = interface.unwrap_or_default().split(',').sorted().join("\0");
 				let interfaces_strindex = self.strings.lookup(&interfaces);
 				let device = binary::Device {
-					type_strindex,
+					device_type,
 					tag_strindex,
 					mandatory,
 					interfaces_strindex,
@@ -1064,6 +1068,7 @@ pub fn calculate_sizes_hash() -> U64 {
 		size_of::<binary::SoftwareList>(),
 		size_of::<binary::MachineSoftwareList>(),
 		size_of::<binary::RamOption>(),
+		binary::DeviceType::COUNT,
 	]
 	.into_iter()
 	.fold(0, |value, item| {

--- a/src/info/entities.rs
+++ b/src/info/entities.rs
@@ -8,6 +8,7 @@ use strum::EnumString;
 use crate::assethash::AssetHash;
 use crate::info::ChipType;
 use crate::info::ConditionRelation;
+use crate::info::DeviceType;
 use crate::info::IndirectView;
 use crate::info::Object;
 use crate::info::SimpleView;
@@ -349,8 +350,8 @@ impl<'a> ConfigurationSettingCondition<'a> {
 }
 
 impl<'a> Device<'a> {
-	pub fn device_type(&self) -> &'a str {
-		self.string(|x| x.type_strindex)
+	pub fn device_type(&self) -> DeviceType {
+		self.obj().device_type
 	}
 
 	pub fn tag(&self) -> &'a str {

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -47,6 +47,7 @@ use crate::version::MameVersion;
 
 pub use self::binary::ChipType;
 pub use self::binary::ConditionRelation;
+pub use self::binary::DeviceType;
 pub use self::binary::SoftwareListStatus;
 pub use self::entities::AssetStatus;
 pub use self::entities::BiosSet;
@@ -727,6 +728,7 @@ mod test {
 	use crate::info::entities::AssetStatus;
 
 	use super::ChipType;
+	use super::DeviceType;
 	use super::InfoDb;
 	use super::View;
 
@@ -934,16 +936,16 @@ mod test {
 		assert_eq!(expected, actual);
 	}
 
-	#[test_case(0, include_str!("test_data/listxml_coco.xml"), "coco2b", "ext:fdc:wd17xx:0:525dd", "floppydisk", &["floppy_5_25"],
+	#[test_case(0, include_str!("test_data/listxml_coco.xml"), "coco2b", "ext:fdc:wd17xx:0:525dd", crate::info::DeviceType::FloppyDisk, &["floppy_5_25"],
 		&["1dd", "86f", "cqi", "cqm", "d77", "d88", "dfi", "dmk", "dsk", "imd", "jvc", "mfi", "mfm", "os9", "sdf", "td0", "vdk"])]
-	#[test_case(1, include_str!("test_data/listxml_c64.xml"), "c64", "exp", "cartridge", &["c64_cart" ,"vic10_cart"],
+	#[test_case(1, include_str!("test_data/listxml_c64.xml"), "c64", "exp", crate::info::DeviceType::Cartridge, &["c64_cart" ,"vic10_cart"],
 		&["80", "a0", "crt", "e0"])]
 	pub fn devices(
 		_index: usize,
 		xml: &str,
 		machine: &str,
 		device_tag: &str,
-		expected_type: &str,
+		expected_type: DeviceType,
 		expected_interfaces: &[&str],
 		expected_extensions: &[&str],
 	) {
@@ -961,13 +963,13 @@ mod test {
 			.map_err(|e| e.to_string())
 			.unwrap();
 		let actual = (
-			device.device_type().to_string(),
+			device.device_type(),
 			device.interfaces().map(|x| x.to_string()).collect::<Vec<_>>(),
 			device.extensions().map(|x| x.to_string()).collect::<Vec<_>>(),
 		);
 
 		let expected = (
-			expected_type.to_string(),
+			expected_type,
 			expected_interfaces.iter().map(|x| x.to_string()).collect::<Vec<_>>(),
 			expected_extensions.iter().map(|x| x.to_string()).collect::<Vec<_>>(),
 		);

--- a/src/models/audit.rs
+++ b/src/models/audit.rs
@@ -19,7 +19,7 @@ use crate::audit::AssetKind;
 use crate::audit::AuditResult;
 use crate::audit::AuditSeverity;
 use crate::audit::PathType;
-use crate::mconfig::MachineConfig;
+use crate::info::DeviceType;
 use crate::ui::Icons;
 
 pub struct AuditModel {
@@ -39,18 +39,18 @@ struct AuditIcons {
 	audit_pending: Image,
 	audit_warning: Image,
 	audit_failed: Image,
+	cassette: Image,
+	image_unknown: Image,
 }
 
 impl AuditModel {
 	pub fn new(
-		machine_config: &MachineConfig,
+		assets: impl IntoIterator<Item = Asset>,
 		rom_paths: Arc<[SmolStr]>,
 		sample_paths: Arc<[SmolStr]>,
 		icons: Icons<'_>,
 	) -> Self {
-		let assets = Asset::from_machine_config(machine_config)
-			.into_iter()
-			.collect::<Arc<[_]>>();
+		let assets = assets.into_iter().collect::<Arc<[_]>>();
 		let audit_results = (0..assets.len()).map(|_| None).collect::<Box<_>>();
 		let audit_results = RefCell::new(audit_results);
 		let icons = AuditIcons::new(icons);
@@ -129,6 +129,8 @@ impl AuditIcons {
 			audit_pending: icons.get_audit_pending(),
 			audit_warning: icons.get_audit_warning(),
 			audit_failed: icons.get_audit_failed(),
+			cassette: icons.get_cassette(),
+			image_unknown: icons.get_image_unknown(),
 		}
 	}
 }
@@ -162,6 +164,10 @@ fn make_ui_asset(asset: &Asset, audit_result: Option<&AuditResult>, icons: &Audi
 		AssetKind::Rom => icons.rom.clone(),
 		AssetKind::Disk => icons.disk.clone(),
 		AssetKind::Sample => icons.sample.clone(),
+		AssetKind::ImageFile(DeviceType::Cassette) => icons.cassette.clone(),
+		AssetKind::ImageFile(DeviceType::HardDisk) => icons.disk.clone(),
+		AssetKind::ImageFile(DeviceType::RomImage) => icons.rom.clone(),
+		AssetKind::ImageFile(_) => icons.image_unknown.clone(),
 	};
 	let overlay = match max_severity {
 		None => icons.audit_pending.clone(),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3,7 +3,6 @@ pub mod command;
 pub mod session;
 mod watchdog;
 
-use anyhow::Error;
 use serde::Deserialize;
 use serde::Serialize;
 use smol_str::SmolStr;
@@ -37,17 +36,4 @@ pub struct MameStartArgs {
 	pub slots: Vec<(SmolStr, SmolStr)>,
 	pub images: Vec<(SmolStr, ImageDesc)>,
 	pub video: Option<PrefsVideo>,
-}
-
-impl MameStartArgs {
-	pub fn preflight(&self) -> Result<(), Vec<Error>> {
-		let errors = self
-			.images
-			.iter()
-			.map(|(_, image_desc)| image_desc.validate())
-			.filter_map(|x| x.err())
-			.collect::<Vec<_>>();
-
-		if errors.is_empty() { Ok(()) } else { Err(errors) }
-	}
 }

--- a/ui/icons.slint
+++ b/ui/icons.slint
@@ -14,4 +14,5 @@ export global Icons {
     out property <image> audit-warning: @image_url("icons/audit-warning.svg");
     out property <image> audit-failed: @image_url("icons/audit-failed.svg");
     out property <image> cassette: @image_url("icons/cassette.png");
+    out property <image> image-unknown: @image_url("icons/image-unknown.svg");
 }

--- a/ui/icons/image-unknown.svg
+++ b/ui/icons/image-unknown.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="-3 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    
+    <title>text-document</title>
+    <desc>Created with Sketch Beta.</desc>
+    <defs>
+
+</defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="Icon-Set" sketch:type="MSLayerGroup" transform="translate(-103.000000, -99.000000)" fill="#000000">
+            <path d="M122,115 L110,115 C109.448,115 109,115.448 109,116 C109,116.553 109.448,117 110,117 L122,117 C122.552,117 123,116.553 123,116 C123,115.448 122.552,115 122,115 L122,115 Z M122,121 L110,121 C109.448,121 109,121.447 109,122 C109,122.553 109.448,123 110,123 L122,123 C122.552,123 123,122.553 123,122 C123,121.447 122.552,121 122,121 L122,121 Z M123,107 C121.896,107 121,106.104 121,105 L121,101 L127,107 L123,107 L123,107 Z M127,127 C127,128.104 126.104,129 125,129 L107,129 C105.896,129 105,128.104 105,127 L105,103 C105,101.896 105.896,101 107,101 L118.972,101 C118.954,103.395 119,105 119,105 C119,107.209 120.791,109 123,109 L127,109 L127,127 L127,127 Z M121,99 L121,99.028 C120.872,99.028 120.338,98.979 119,99 L107,99 C104.791,99 103,100.791 103,103 L103,127 C103,129.209 104.791,131 107,131 L125,131 C127.209,131 129,129.209 129,127 L129,107 L121,99 L121,99 Z" id="text-document" sketch:type="MSShapeGroup">
+
+</path>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
This replaces the quick file existence check that ran before
    
Limitations
- Only files for now (software list items are not yet supported)
- We don't have icons for most of the device types