### PR TITLE
Enabling the "Audit" tab on the Configuration dialog for software items

### DIFF
--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -93,6 +93,10 @@ enum MachineType<'a> {
 }
 
 impl Asset {
+	pub fn from_machine_config(machine_config: &MachineConfig) -> Vec<Self> {
+		Self::from_machine_config_and_images(machine_config, &[])
+	}
+
 	pub fn from_machine_config_and_images<'a>(
 		machine_config: &MachineConfig,
 		images: impl IntoIterator<Item = &'a (SmolStr, ImageDesc)> + 'a,
@@ -503,7 +507,7 @@ mod tests {
 		let machine_config = MachineConfig::from_machine_name_and_slots(info_db, machine_name, opts).unwrap();
 
 		// identify audit assets
-		let assets = Asset::from_machine_config_and_images(&machine_config, &[]);
+		let assets = Asset::from_machine_config(&machine_config);
 
 		// and validate
 		insta::assert_debug_snapshot!(assets);

--- a/src/dialogs/configure.rs
+++ b/src/dialogs/configure.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use anyhow::Error;
+use anyhow::Result;
 use itertools::Itertools;
 use showfile::show_path_in_file_manager;
 use slint::CloseRequestResponse;
@@ -13,6 +14,7 @@ use slint::Global;
 use slint::Model;
 use slint::ModelRc;
 use slint::SharedString;
+use slint::ToSharedString;
 use slint::VecModel;
 use slint::Weak;
 use slint::spawn_local;
@@ -82,6 +84,12 @@ enum DiModelState {
 		info_db: Rc<InfoDb>,
 		machine_index: usize,
 	},
+}
+
+#[derive(thiserror::Error, Debug)]
+enum ThisError {
+	#[error("Can only audit a single machine")]
+	CanOnlyAuditSingleMachine,
 }
 
 pub async fn dialog_configure(
@@ -374,8 +382,8 @@ impl State {
 		};
 		if matches!(&state.core, CoreState::Machine { .. }) {
 			state.update_images();
-			state.update_audit();
 		}
+		state.update_audit();
 		state
 	}
 
@@ -510,32 +518,64 @@ impl State {
 	}
 
 	pub fn update_audit(&self) {
-		let CoreState::Machine { dimodel_state, .. } = &self.core else {
-			unreachable!()
-		};
+		let assets_result = self.audit_assets();
 
 		let dialog = self.dialog_weak.unwrap();
-		let audit_model = dimodel_state.with_machine_config(|machine_config| {
-			let images = if let DiModelState::Ok { images, .. } = dimodel_state {
-				images
-					.borrow()
-					.iter()
-					.map(|(tag, image_desc)| (tag.into(), image_desc.clone()))
-					.collect::<Vec<_>>()
-			} else {
-				[].into()
-			};
-			let assets = Asset::from_machine_config_and_images(machine_config, &images);
-			let rom_paths = self.rom_paths.clone();
-			let sample_paths = self.sample_paths.clone();
-			let icons = Icons::get(&dialog);
-			AuditModel::new(assets, rom_paths, sample_paths, icons)
-		});
-		let audit_model = audit_model.map(ModelRc::new).unwrap_or_default();
+		dialog.set_audit_error_message(
+			assets_result
+				.as_ref()
+				.err()
+				.map(|e| e.to_shared_string())
+				.unwrap_or_default(),
+		);
+		let assets = assets_result.unwrap_or_default();
+		let rom_paths = self.rom_paths.clone();
+		let sample_paths = self.sample_paths.clone();
+		let icons = Icons::get(&dialog);
+		let audit_model = AuditModel::new(assets, rom_paths, sample_paths, icons);
+		let audit_model = ModelRc::new(audit_model);
 		dialog.set_audit_assets(audit_model);
 
 		// start running the audit!
 		self.start_run_audit();
+	}
+
+	fn audit_assets(&self) -> Result<Vec<Asset>> {
+		let assets = match &self.core {
+			CoreState::Machine { dimodel_state, .. } => {
+				let images = if let DiModelState::Ok { images, .. } = dimodel_state {
+					images
+						.borrow()
+						.iter()
+						.map(|(tag, image_desc)| (tag.into(), image_desc.clone()))
+						.collect::<Vec<_>>()
+				} else {
+					[].into()
+				};
+				let assets = dimodel_state.with_machine_config(|machine_config| {
+					Asset::from_machine_config_and_images(machine_config, &images)
+				});
+				assets.unwrap_or_default()
+			}
+			CoreState::Software {
+				info_db,
+				software_machines,
+				..
+			} => {
+				let machine_index = software_machines
+					.iter()
+					.filter(|x| x.checked)
+					.exactly_one()
+					.map_err(|_| ThisError::CanOnlyAuditSingleMachine)?
+					.machine_index
+					.try_into()
+					.unwrap();
+				let info_db = info_db.clone();
+				let machine_config = MachineConfig::new(info_db, machine_index);
+				Asset::from_machine_config(&machine_config)
+			}
+		};
+		Ok(assets)
 	}
 
 	pub fn start_run_audit(&self) {

--- a/ui/dialogs/configure.slint
+++ b/ui/dialogs/configure.slint
@@ -20,7 +20,7 @@ import { Icons } from "../icons.slint";
 import { VideoConfigComponent, VideoSettings } from "../videoconfig.slint";
 import { AuditAsset, AuditAssetView } from "../audit.slint";
 
-struct SoftwareMachine { machine-index: int, description: string, checked: bool}
+struct SoftwareMachine { machine-index: int, description: string, checked: bool }
 
 export component ConfigureDialog inherits Window {
     title: dialog-title;
@@ -37,6 +37,7 @@ export component ConfigureDialog inherits Window {
     in property <[string]> bios-selection-model;
     in-out property <int> bios-selection-index;
     in property <[AuditAsset]> audit-assets;
+    in property <string> audit-error-message;
     in property <string> audit-context-menu-browse-command;
     in property <[SoftwareMachine]> software-machines;
     in property <bool> software-machines-bulk-all-enabled;
@@ -156,7 +157,7 @@ export component ConfigureDialog inherits Window {
                 Tab {
                     title: "Audit";
                     VerticalBox {
-                        ListView {
+                        if root.audit-error-message == "": ListView {
                             for asset in root.audit-assets: AuditAssetView {
                                 asset: asset;
                                 menu-item-action(action) => {
@@ -165,11 +166,15 @@ export component ConfigureDialog inherits Window {
                             }
                         }
 
-                        Button {
+                        if root.audit-error-message == "": Button {
                             text: "Run Audit";
                             clicked => {
                                 root.run-audit-clicked();
                             }
+                        }
+
+                        if root.audit-error-message != "": Text {
+                            text: root.audit-error-message;
                         }
                     }
                 }
@@ -212,6 +217,31 @@ export component ConfigureDialog inherits Window {
                             Text {
                                 text: data.description;
                             }
+                        }
+                    }
+                }
+
+                Tab {
+                    title: "Audit";
+                    VerticalBox {
+                        if root.audit-error-message == "": ListView {
+                            for asset in root.audit-assets: AuditAssetView {
+                                asset: asset;
+                                menu-item-action(action) => {
+                                    root.menu-item-action(action);
+                                }
+                            }
+                        }
+
+                        if root.audit-error-message == "": Button {
+                            text: "Run Audit";
+                            clicked => {
+                                root.run-audit-clicked();
+                            }
+                        }
+
+                        if root.audit-error-message != "": Text {
+                            text: root.audit-error-message;
                         }
                     }
                 }


### PR DESCRIPTION
This requires that only a single Preferred Machine to be set, because it really only makes sense to audit in the context of a single machine