### PR TITLE
Updates for BletchMAME Version 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "bletchmame"
-version = "0.3.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-authors = ["Bletch <npwoods@alumni.cmu.edu>"]
+authors = ["Bletch"]
 edition = "2024"
 name = "bletchmame"
-version = "0.3.0"
+version = "3.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/dialogs/about.rs
+++ b/src/dialogs/about.rs
@@ -5,9 +5,14 @@ use crate::dialogs::SenderExt;
 use crate::guiutils::modal::ModalStack;
 use crate::ui::AboutDialog;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub async fn dialog_about(modal_stack: ModalStack) {
 	let modal = modal_stack.modal(|| AboutDialog::new().unwrap());
 	let (tx, mut rx) = mpsc::channel(1);
+
+	// set the version
+	modal.dialog().set_version(VERSION.into());
 
 	// set up the close handler
 	let tx_clone = tx.clone();

--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -62,7 +62,7 @@ export component AppWindow inherits Window {
 
     // properties that influence the title
     in property <bool> prefix-title-with-mode: false;
-    in property <string> apptitle: @tr("BletchMAME 3.0 prototype");
+    in property <string> apptitle: @tr("BletchMAME");
     in property <string> running-machine-desc;
 
     // the menu bar

--- a/ui/dialogs/about.slint
+++ b/ui/dialogs/about.slint
@@ -9,6 +9,8 @@ import { Icons } from "../icons.slint";
 export component AboutDialog inherits Window {
     title: "About BletchMAME";
     icon: Icons.bletchmame;
+    in property <string> version;
+
     HorizontalBox {
         Image {
             width: 192px;
@@ -18,7 +20,7 @@ export component AboutDialog inherits Window {
 
         VerticalBox {
             Text {
-                text: "BletchMAME";
+                text: "BletchMAME " + version;
                 font-size: 24px;
                 horizontal-alignment: center;
             }


### PR DESCRIPTION
- Updated `Cargo.toml`
- Removed hardcoded version and "prototype" from title bar
- Version # is shown in "About" dialog