### PR TITLE
Not showing any cassette displays on the status bar if a report is present

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -352,6 +352,7 @@ impl AppModel {
 				let images = running.as_ref().map(|r| r.images.as_ref()).unwrap_or_default();
 				cassettes
 					.iter()
+					.filter(|_| report.is_none())
 					.filter_map(|cassette| {
 						images
 							.iter()


### PR DESCRIPTION
The purpose of this is to hide this display when shutting down, but this broader approach is still correct