### PR TITLE
Increased size of Tape Control buttons

### DIFF
--- a/ui/tapecontrol.slint
+++ b/ui/tapecontrol.slint
@@ -24,7 +24,7 @@ export component TapeControl {
     property <float> timer-adjustment: 0.0;
 
     // const parameters
-    property <length> button-length: 32px;
+    property <length> button-length: 40px;
     property <length> slider-width: 150px;
     property <float> fast-forward-multiple: 10.0;
 


### PR DESCRIPTION
Slint buttons don't really work well below a certain size (https://github.com/slint-ui/slint/issues/12603)