### PR TITLE
Conditionally enabling the debugger based on whether it is present

### DIFF
--- a/src/appwindow.rs
+++ b/src/appwindow.rs
@@ -1714,6 +1714,7 @@ fn update_menus(model: &AppModel) {
 	let can_refresh_info_db = has_mame_executable && !state.is_building_infodb();
 	let is_fullscreen = model.app_window().window().is_fullscreen();
 	let is_recording = running.as_ref().map(|r| r.is_recording).unwrap_or_default();
+	let is_debugging_present = running.as_ref().map(|r| r.debugger_present).unwrap_or_default();
 	let has_last_save_state = is_running && state.last_save_state().is_some();
 	let input_classes = running
 		.map(|x| x.inputs.as_ref())
@@ -1728,6 +1729,7 @@ fn update_menus(model: &AppModel) {
 	let app_window = model.app_window();
 	app_window.set_is_paused(is_paused);
 	app_window.set_is_recording(is_recording);
+	app_window.set_is_debugging_present(is_debugging_present);
 	app_window.set_is_throttled(is_throttled);
 	app_window.set_is_fullscreen(is_fullscreen);
 	app_window.set_is_sound_enabled(is_sound_enabled);

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -51,6 +51,7 @@ impl Status {
 			let has_input_using_mouse = running
 				.has_input_using_mouse
 				.unwrap_or(status_running.has_input_using_mouse);
+			let debugger_present = running.debugger_present.unwrap_or(status_running.debugger_present);
 
 			let images = running.images.map(|images| {
 				images
@@ -93,6 +94,7 @@ impl Status {
 				is_recording,
 				polling_input_seq,
 				has_input_using_mouse,
+				debugger_present,
 				cheats,
 				images,
 				cassettes,
@@ -135,6 +137,7 @@ pub struct Running {
 	pub is_recording: bool,
 	pub polling_input_seq: bool,
 	pub has_input_using_mouse: bool,
+	pub debugger_present: bool,
 	pub cheats: Arc<[Cheat]>,
 	pub images: Arc<[Image]>,
 	pub cassettes: Arc<[Cassette]>,
@@ -249,6 +252,7 @@ struct RunningUpdate {
 	pub is_recording: Option<bool>,
 	pub polling_input_seq: Option<bool>,
 	pub has_input_using_mouse: Option<bool>,
+	pub debugger_present: Option<bool>,
 	pub cheats: Option<Vec<Cheat>>,
 	pub images: Option<Vec<ImageUpdate>>,
 	pub cassettes: Option<Vec<Cassette>>,

--- a/src/status/parse.rs
+++ b/src/status/parse.rs
@@ -90,6 +90,7 @@ impl State {
 					app_version,
 					polling_input_seq,
 					has_input_using_mouse,
+					debugger_present,
 				] = evt.find_attributes([
 					b"romname",
 					b"paused",
@@ -97,16 +98,14 @@ impl State {
 					b"app_version",
 					b"polling_input_seq",
 					b"has_input_using_mouse",
+					b"debugger_present",
 				])?;
 				let machine_name = romname.unwrap_or_default().into();
 				let is_paused = is_paused.map(parse_mame_bool).transpose()?;
 				let polling_input_seq = polling_input_seq.map(parse_mame_bool).transpose()?;
 				let has_input_using_mouse = has_input_using_mouse.map(parse_mame_bool).transpose()?;
-				debug!(
-					machine_name=?machine_name,
-					is_paused=?is_paused,
-					"status State::handle_start()"
-				);
+				let debugger_present = debugger_present.map(parse_mame_bool).transpose()?;
+				debug!(?machine_name, ?is_paused, "status State::handle_start()");
 
 				let app_build = app_build.map(MameVersion::from);
 				let app_version = app_version.and_then(MameVersion::parse_simple);
@@ -116,6 +115,7 @@ impl State {
 				self.running.is_paused = is_paused;
 				self.running.polling_input_seq = polling_input_seq;
 				self.running.has_input_using_mouse = has_input_using_mouse;
+				self.running.debugger_present = debugger_present;
 				Some(Phase::Status)
 			}
 			(Phase::Status, b"video") => {

--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -69,6 +69,7 @@ export component AppWindow inherits Window {
     in property <bool> menubar-visible: true;
     in property <bool> is-paused;
     in property <bool> is-recording;
+    in property <bool> is-debugging-present;
     in property <bool> is-throttled;
     in property <bool> is-fullscreen;
     in property <bool> is-sound-enabled;
@@ -362,7 +363,7 @@ export component AppWindow inherits Window {
 
             MenuItem {
                 title: @tr("MenuBar" => "Debugger...");
-                enabled: mode() == "running";
+                enabled: root.is-debugging-present;
                 activated => {
                     menu-item-action(root.menu-action-file-debugger);
                 }


### PR DESCRIPTION
This does not actually change any user-visible behavior, because we're currently always running with `-debug`, so the debugger will (currently) always be present in practice.