### PR TITLE
Properly parsing `<machine><driver/></machine>`

### DIFF
--- a/src/info/build.rs
+++ b/src/info/build.rs
@@ -560,6 +560,18 @@ impl State {
 				self.phase_specific = Some(PhaseSpecificState::RamOption(is_default));
 				Some(Phase::MachineRamOption)
 			}
+			(Phase::Machine, b"driver") => {
+				let [status, emulation, savestate] = evt.find_attributes([b"status", b"emulation", b"savestate"])?;
+				let status = status.as_deref().map(|s| s.parse()).transpose()?;
+				let emulation = emulation.as_deref().map(|s| s.parse()).transpose()?;
+				let savestate = savestate.as_deref().map(|s| s.parse()).transpose()?;
+				self.machines.modify_last(|machine| {
+					machine.driver_status = status.unwrap_or(machine.driver_status);
+					machine.driver_emulation = emulation.unwrap_or(machine.driver_emulation);
+					machine.driver_savestate = savestate.unwrap_or(machine.driver_savestate);
+				});
+				None
+			}
 			(Phase::Machine, b"feature") => {
 				let [feature_type, status, overall] = evt.find_attributes([b"type", b"status", b"overall"])?;
 				let feature_type_attr = feature_type.mandatory("type")?;

--- a/src/info/entities.rs
+++ b/src/info/entities.rs
@@ -10,6 +10,7 @@ use crate::info::ChipType;
 use crate::info::ConditionRelation;
 use crate::info::DeviceType;
 use crate::info::DriverQuality;
+use crate::info::DriverSavestate;
 use crate::info::IndirectView;
 use crate::info::Object;
 use crate::info::SimpleView;
@@ -152,6 +153,14 @@ impl<'a> Machine<'a> {
 
 	pub fn driver_status(&self) -> DriverQuality {
 		self.obj().driver_status
+	}
+
+	pub fn driver_emulation(&self) -> DriverQuality {
+		self.obj().driver_emulation
+	}
+
+	pub fn driver_savestate(&self) -> DriverSavestate {
+		self.obj().driver_savestate
 	}
 }
 

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -49,6 +49,7 @@ pub use self::binary::ChipType;
 pub use self::binary::ConditionRelation;
 pub use self::binary::DeviceType;
 pub use self::binary::DriverQuality;
+pub use self::binary::DriverSavestate;
 pub use self::binary::SoftwareListStatus;
 pub use self::entities::AssetStatus;
 pub use self::entities::BiosSet;
@@ -734,6 +735,8 @@ mod test {
 	use test_case::test_case;
 
 	use crate::assethash::AssetHash;
+	use crate::info::DriverQuality;
+	use crate::info::DriverSavestate;
 	use crate::info::entities::AssetStatus;
 
 	use super::ChipType;
@@ -866,6 +869,28 @@ mod test {
 			let other_machine = db.machines().find(machine.name()).unwrap();
 			assert_eq!(other_machine.name(), machine.name());
 		}
+	}
+
+	#[test_case(0, include_str!("test_data/listxml_coco.xml"), "coco2b", DriverQuality::Good, DriverQuality::Good, DriverSavestate::Supported)]
+	#[test_case(1, include_str!("test_data/listxml_fake.xml"), "fake", DriverQuality::Preliminary, DriverQuality::Preliminary, DriverSavestate::Unsupported)]
+	pub fn driver(
+		_index: usize,
+		xml: &str,
+		machine: &str,
+		expected_status: DriverQuality,
+		expected_emulation: DriverQuality,
+		expected_savestate: DriverSavestate,
+	) {
+		let db = InfoDb::from_listxml_output(xml.as_bytes(), |_| ControlFlow::Continue(()))
+			.unwrap()
+			.unwrap();
+		let machine = db.machines().find(machine).unwrap();
+		let actual = (
+			machine.driver_status(),
+			machine.driver_emulation(),
+			machine.driver_savestate(),
+		);
+		assert_eq!((expected_status, expected_emulation, expected_savestate), actual);
 	}
 
 	#[allow(clippy::too_many_arguments)]

--- a/src/info/test_data/listxml_fake.xml
+++ b/src/info/test_data/listxml_fake.xml
@@ -178,7 +178,7 @@
 			<control type="joy" player="1" buttons="2" ways="8"/>
 			<control type="joy" player="2" buttons="2" ways="8"/>
 		</input>
-		<driver status="good" emulation="good" savestate="supported"/>
+		<driver status="preliminary" emulation="preliminary" savestate="unsupported"/>
 		<slot name=":ext:">
 			<slotoption name="fdcv11" devname="coco_fdc_v11" default="yes"/>
 		</slot>

--- a/src/models/itemstable.rs
+++ b/src/models/itemstable.rs
@@ -677,7 +677,9 @@ impl ItemsTableModel {
 		let selected_index = self.current_selected_index()?;
 		let items = self.items.borrow();
 		let item = items.get(usize::try_from(selected_index).unwrap())?;
-		item_info_display(item)
+		let result = item_info_display(item);
+		debug!(?result, "ItemsTableModel::current_selected_info_display()");
+		result
 	}
 
 	fn current_selected_index(&self) -> Option<u32> {


### PR DESCRIPTION
We were neglecting to do so earlier