### PR TITLE
Fixing issue where we incorrectly interpreted `<rom>` tags in software lists without names

### DIFF
--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -630,6 +630,7 @@ mod tests {
 	}
 
 	#[test_case(0, include_str!("../info/test_data/listxml_coco.xml"), include_str!("../software/test_data/softlist_coco_cart.xml"), "coco2b", "dagorath")]
+	#[test_case(1, include_str!("../info/test_data/listxml_bbcm.xml"), include_str!("../software/test_data/softlist_bbcm_cart.xml"), "bbcm", "click100")]
 	fn assets_from_machine_config_and_software(
 		_index: usize,
 		info_xml: &str,

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -9,6 +9,7 @@ use std::io::Seek;
 use std::iter::successors;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use anyhow::Result;
 use default_ext::DefaultExt;
@@ -34,6 +35,7 @@ use crate::info::DeviceType;
 use crate::info::Machine;
 use crate::info::View;
 use crate::mconfig::MachineConfig;
+use crate::software::SoftwareList;
 use crate::software::SoftwareListDispenser;
 
 #[derive(Clone, Debug)] // TODO - `Clone` should not be necessary
@@ -112,8 +114,9 @@ impl Asset {
 		software_list_paths: &[SmolStr],
 		images: impl IntoIterator<Item = &'a (SmolStr, ImageDesc)> + 'a,
 	) -> Vec<Self> {
-		let software_list_dispenser = SoftwareListDispenser::new(&machine_config.info_db, software_list_paths);
-		Self::internal_from_machine_config_and_images(machine_config, software_list_dispenser, images)
+		let mut software_list_dispenser = SoftwareListDispenser::new(&machine_config.info_db, software_list_paths);
+		let dispense_software_list = |name: &str| software_list_dispenser.get(name).ok().map(|(_, sl)| sl);
+		assets_from_machine_config_and_images(machine_config, dispense_software_list, images)
 	}
 
 	pub fn from_machine_config_and_software(
@@ -131,182 +134,9 @@ impl Asset {
 			.find(|x| x.name == software)
 			.ok_or_else(|| ThisError::UnknownSoftware(software.into()))?;
 		let images = ImageDesc::from_software(&machine_config.machine(), Some(software_list_name), software)?;
-		let results = Self::internal_from_machine_config_and_images(machine_config, software_list_dispenser, &images);
+		let dispense_software_list = |name: &str| software_list_dispenser.get(name).ok().map(|(_, sl)| sl);
+		let results = assets_from_machine_config_and_images(machine_config, dispense_software_list, &images);
 		Ok(results)
-	}
-
-	fn internal_from_machine_config_and_images<'a>(
-		machine_config: &MachineConfig,
-		mut software_list_dispenser: SoftwareListDispenser<'_>,
-		images: impl IntoIterator<Item = &'a (SmolStr, ImageDesc)> + 'a,
-	) -> Vec<Self> {
-		let mut results = Vec::new();
-		Self::from_machine_internal(&mut results, machine_config.machine(), None, MachineType::Root);
-		machine_config.visit_slots(|_, _, _, _, slot_data| {
-			if let Some(machine) = slot_data.map(|(_, machine_config)| machine_config.machine()) {
-				Self::from_machine_internal(&mut results, machine, None, MachineType::Slot);
-			}
-		});
-
-		// available ports should only be evaluated once
-		let available_ports = OnceCell::new();
-		let available_ports = || available_ports.get_or_init(crate::imagedesc::available_ports);
-
-		// add images
-		for (tag, image_desc) in images {
-			let device = machine_config.lookup_device_tag(tag).ok().map(|(_, device)| device);
-			let device_type = device.map(|d| d.device_type()).unwrap_or(DeviceType::Unknown);
-
-			match image_desc {
-				ImageDesc::File(filename) => {
-					if available_ports().iter().all(|p| p.port_name != *filename) {
-						let name = Path::new(&filename)
-							.file_name()
-							.unwrap_or_default()
-							.to_string_lossy()
-							.as_ref()
-							.into();
-						let asset = Asset {
-							kind: AssetKind::ImageFile {
-								device_type,
-								use_absolute_path: true,
-							},
-							name,
-							size: None,
-							location: AssetLocation::Absolute(filename.clone()),
-							asset_hash: AssetHash::default(),
-							status: AssetStatus::Good,
-							is_optional: false,
-						};
-						results.push(asset);
-					}
-				}
-				ImageDesc::Software { list, name, part } => {
-					let list = list.as_deref();
-					let part = part.as_deref();
-					let target_interfaces_iter = device.iter().flat_map(|x| x.interfaces());
-
-					let software_list_iter = machine_config
-						.machine()
-						.machine_software_lists()
-						.iter()
-						.map(|info_msl| info_msl.software_list())
-						.filter(|info_sl| list.is_none_or(|x| x == info_sl.name()))
-						.filter_map(|info_sl| software_list_dispenser.get(info_sl.name()).ok())
-						.map(|(_, sl)| sl);
-					for software_list in software_list_iter {
-						let asset_iter = software_list
-							.software
-							.iter()
-							.filter(|s| s.name.as_str() == name)
-							.flat_map(|s| &s.parts)
-							.filter(|sp| {
-								part.is_none_or(|x| sp.name == x)
-									&& target_interfaces_iter.clone().any(|i| i == sp.interface.as_str())
-							})
-							.flat_map(|sp| sp.data_areas.iter())
-							.flat_map(|sda| sda.assets.iter())
-							.map(|sa| {
-								let software_list_name = Some(software_list.name.clone());
-								let targets = [name.clone()].into_iter().collect();
-								let location = AssetLocation::Paths {
-									software_list_name,
-									targets,
-								};
-								Asset {
-									kind: AssetKind::ImageFile {
-										device_type,
-										use_absolute_path: false,
-									},
-									name: sa.name.as_str().into(),
-									size: Some(sa.size),
-									location,
-									asset_hash: sa.hash,
-									status: sa.status,
-									is_optional: false,
-								}
-							});
-						results.extend(asset_iter)
-					}
-				}
-				ImageDesc::Socket { .. } => {
-					// nothing to audit
-				}
-			}
-		}
-
-		// remove duplicates and return
-		let results = results
-			.into_iter()
-			.unique_by(|x| (x.kind, x.name.clone(), x.location.clone()))
-			.collect();
-
-		debug!(?machine_config, ?results, "Asset::from_machine_config()");
-		results
-	}
-
-	fn from_machine_internal(
-		results: &mut Vec<Self>,
-		machine: Machine<'_>,
-		bios: Option<&str>,
-		machine_type: MachineType<'_>,
-	) {
-		// we were passed a BIOS; if `None` was specified use the machine's default BIOS
-		let bios = bios.or_else(|| {
-			machine
-				.default_biosset_index()
-				.map(|index| machine.biossets().get(index).unwrap().name())
-		});
-
-		debug!(machine=?machine.name(), ?bios, ?machine_type, "Asset::from_machine_internal()");
-
-		let targets = successors(Some(machine), |machine| machine.rom_of())
-			.map(|machine| machine.name().into())
-			.collect();
-		let location = AssetLocation::Paths {
-			software_list_name: None,
-			targets,
-		};
-		let roms = machine
-			.roms()
-			.iter()
-			.filter(|r| r.bios().is_none_or(|b| bios == Some(b)))
-			.map(|rom| Asset {
-				kind: AssetKind::Rom,
-				name: rom.name().into(),
-				size: rom.size().into(),
-				location: location.clone(),
-				asset_hash: rom.asset_hash(),
-				status: rom.status(),
-				is_optional: rom.is_optional(),
-			});
-		let disks = machine.disks().iter().map(|disk| Asset {
-			kind: AssetKind::Disk,
-			name: format!("{}.chd", disk.name()).into(),
-			size: None,
-			location: location.clone(),
-			asset_hash: disk.asset_hash(),
-			status: disk.status(),
-			is_optional: disk.is_optional(),
-		});
-		let samples = machine.samples().iter().map(|sample| Asset {
-			kind: AssetKind::Sample,
-			name: format!("{}.wav", sample.name()).into(),
-			size: None,
-			location: location.clone(),
-			asset_hash: AssetHash::default(),
-			status: AssetStatus::Good,
-			is_optional: true, // samples are always optional; MAME just doesn't play the same if they are missing
-		});
-		results.extend(roms.chain(disks).chain(samples));
-
-		// add devices references
-		for device_ref in machine.device_refs().iter() {
-			if let Some(machine) = device_ref.machine() {
-				let machine_type = MachineType::DeviceRef(device_ref.tag());
-				Self::from_machine_internal(results, machine, None, machine_type);
-			}
-		}
 	}
 
 	pub fn run_audit(&self, rom_paths: &[impl AsRef<Path>], sample_paths: &[impl AsRef<Path>]) -> AuditResult {
@@ -451,6 +281,179 @@ pub enum PathType {
 	SevenZ,
 }
 
+fn assets_from_machine_config_and_images<'a>(
+	machine_config: &MachineConfig,
+	mut dispense_software_list: impl FnMut(&str) -> Option<Arc<SoftwareList>>,
+	images: impl IntoIterator<Item = &'a (SmolStr, ImageDesc)> + 'a,
+) -> Vec<Asset> {
+	let mut results = Vec::new();
+	assets_from_machine_internal(&mut results, machine_config.machine(), None, MachineType::Root);
+	machine_config.visit_slots(|_, _, _, _, slot_data| {
+		if let Some(machine) = slot_data.map(|(_, machine_config)| machine_config.machine()) {
+			assets_from_machine_internal(&mut results, machine, None, MachineType::Slot);
+		}
+	});
+
+	// available ports should only be evaluated once
+	let available_ports = OnceCell::new();
+	let available_ports = || available_ports.get_or_init(crate::imagedesc::available_ports);
+
+	// add images
+	for (tag, image_desc) in images {
+		let device = machine_config.lookup_device_tag(tag).ok().map(|(_, device)| device);
+		let device_type = device.map(|d| d.device_type()).unwrap_or(DeviceType::Unknown);
+
+		match image_desc {
+			ImageDesc::File(filename) => {
+				if available_ports().iter().all(|p| p.port_name != *filename) {
+					let name = Path::new(&filename)
+						.file_name()
+						.unwrap_or_default()
+						.to_string_lossy()
+						.as_ref()
+						.into();
+					let asset = Asset {
+						kind: AssetKind::ImageFile {
+							device_type,
+							use_absolute_path: true,
+						},
+						name,
+						size: None,
+						location: AssetLocation::Absolute(filename.clone()),
+						asset_hash: AssetHash::default(),
+						status: AssetStatus::Good,
+						is_optional: false,
+					};
+					results.push(asset);
+				}
+			}
+			ImageDesc::Software { list, name, part } => {
+				let list = list.as_deref();
+				let part = part.as_deref();
+				let target_interfaces_iter = device.iter().flat_map(|x| x.interfaces());
+
+				let software_list_iter = machine_config
+					.machine()
+					.machine_software_lists()
+					.iter()
+					.map(|info_msl| info_msl.software_list())
+					.filter(|info_sl| list.is_none_or(|x| x == info_sl.name()))
+					.filter_map(|info_sl| dispense_software_list(info_sl.name()));
+				for software_list in software_list_iter {
+					let asset_iter = software_list
+						.software
+						.iter()
+						.filter(|s| s.name.as_str() == name)
+						.flat_map(|s| &s.parts)
+						.filter(|sp| {
+							part.is_none_or(|x| sp.name == x)
+								&& target_interfaces_iter.clone().any(|i| i == sp.interface.as_str())
+						})
+						.flat_map(|sp| sp.data_areas.iter())
+						.flat_map(|sda| sda.assets.iter())
+						.map(|sa| {
+							let software_list_name = Some(software_list.name.clone());
+							let targets = [name.clone()].into_iter().collect();
+							let location = AssetLocation::Paths {
+								software_list_name,
+								targets,
+							};
+							Asset {
+								kind: AssetKind::ImageFile {
+									device_type,
+									use_absolute_path: false,
+								},
+								name: sa.name.as_str().into(),
+								size: Some(sa.size),
+								location,
+								asset_hash: sa.hash,
+								status: sa.status,
+								is_optional: false,
+							}
+						});
+					results.extend(asset_iter)
+				}
+			}
+			ImageDesc::Socket { .. } => {
+				// nothing to audit
+			}
+		}
+	}
+
+	// remove duplicates and return
+	let results = results
+		.into_iter()
+		.unique_by(|x| (x.kind, x.name.clone(), x.location.clone()))
+		.collect();
+
+	debug!(?machine_config, ?results, "assets_from_machine_config()");
+	results
+}
+
+fn assets_from_machine_internal(
+	results: &mut Vec<Asset>,
+	machine: Machine<'_>,
+	bios: Option<&str>,
+	machine_type: MachineType<'_>,
+) {
+	// we were passed a BIOS; if `None` was specified use the machine's default BIOS
+	let bios = bios.or_else(|| {
+		machine
+			.default_biosset_index()
+			.map(|index| machine.biossets().get(index).unwrap().name())
+	});
+
+	debug!(machine=?machine.name(), ?bios, ?machine_type, "assets_from_machine_internal()");
+
+	let targets = successors(Some(machine), |machine| machine.rom_of())
+		.map(|machine| machine.name().into())
+		.collect();
+	let location = AssetLocation::Paths {
+		software_list_name: None,
+		targets,
+	};
+	let roms = machine
+		.roms()
+		.iter()
+		.filter(|r| r.bios().is_none_or(|b| bios == Some(b)))
+		.map(|rom| Asset {
+			kind: AssetKind::Rom,
+			name: rom.name().into(),
+			size: rom.size().into(),
+			location: location.clone(),
+			asset_hash: rom.asset_hash(),
+			status: rom.status(),
+			is_optional: rom.is_optional(),
+		});
+	let disks = machine.disks().iter().map(|disk| Asset {
+		kind: AssetKind::Disk,
+		name: format!("{}.chd", disk.name()).into(),
+		size: None,
+		location: location.clone(),
+		asset_hash: disk.asset_hash(),
+		status: disk.status(),
+		is_optional: disk.is_optional(),
+	});
+	let samples = machine.samples().iter().map(|sample| Asset {
+		kind: AssetKind::Sample,
+		name: format!("{}.wav", sample.name()).into(),
+		size: None,
+		location: location.clone(),
+		asset_hash: AssetHash::default(),
+		status: AssetStatus::Good,
+		is_optional: true, // samples are always optional; MAME just doesn't play the same if they are missing
+	});
+	results.extend(roms.chain(disks).chain(samples));
+
+	// add devices references
+	for device_ref in machine.device_refs().iter() {
+		if let Some(machine) = device_ref.machine() {
+			let machine_type = MachineType::DeviceRef(device_ref.tag());
+			assets_from_machine_internal(results, machine, None, machine_type);
+		}
+	}
+}
+
 #[allow(clippy::too_many_arguments)]
 fn try_audit(
 	asset_name: &str,
@@ -578,17 +581,21 @@ mod tests {
 	use std::io::Cursor;
 	use std::io::Read;
 	use std::ops::ControlFlow;
+	use std::sync::Arc;
 
 	use sevenz_rust2::ArchiveReader as SevenZArchiveReader;
 	use test_case::test_case;
 	use zip::ZipArchive;
 
+	use crate::imagedesc::ImageDesc;
 	use crate::info::InfoDb;
 	use crate::mconfig::MachineConfig;
+	use crate::software::SoftwareList;
 
 	use super::Asset;
 	use super::SevenZArchiveReaderExt as _;
 	use super::ZipArchiveExt as _;
+	use super::assets_from_machine_config_and_images;
 
 	#[test_case(0, include_str!("../info/test_data/listxml_alienar.xml"), "alienar")]
 	#[test_case(1, include_str!("../info/test_data/listxml_coco.xml"), "coco2b")]
@@ -617,6 +624,50 @@ mod tests {
 
 		// identify audit assets
 		let assets = Asset::from_machine_config_and_images(&machine_config, &[], []);
+
+		// and validate
+		insta::assert_debug_snapshot!(assets);
+	}
+
+	#[test_case(0, include_str!("../info/test_data/listxml_coco.xml"), include_str!("../software/test_data/softlist_coco_cart.xml"), "coco2b", "dagorath")]
+	fn assets_from_machine_config_and_software(
+		_index: usize,
+		info_xml: &str,
+		softlist_xml: &str,
+		machine_name: &str,
+		software_name: &str,
+	) {
+		// set the insta snapshot suffix; this is a parameterized test
+		let mut settings = insta::Settings::clone_current();
+		settings.set_snapshot_suffix(format!("{machine_name}_{software_name}"));
+		let _guard = settings.bind_to_scope();
+
+		// load the InfoDb
+		let info_db = InfoDb::from_listxml_output(info_xml.as_bytes(), |_| ControlFlow::Continue(()))
+			.unwrap()
+			.unwrap()
+			.into();
+
+		// create a MachineConifg
+		let opts: &[(&str, Option<&str>)] = &[];
+		let machine_config = MachineConfig::from_machine_name_and_slots(info_db, machine_name, opts).unwrap();
+
+		// load the software list
+		let software_list = SoftwareList::from_reader(softlist_xml.as_bytes()).unwrap();
+		let software_list = Arc::new(software_list);
+
+		// identify image descs
+		let software = software_list
+			.software
+			.iter()
+			.find(|x| x.name == software_name)
+			.unwrap()
+			.as_ref();
+		let images = ImageDesc::from_software(&machine_config.machine(), Some(&software_list.name), software).unwrap();
+
+		// identify audit assets
+		let dispense_software_list = |name: &str| (name == software_list.name).then_some(&software_list).cloned();
+		let assets = assets_from_machine_config_and_images(&machine_config, &dispense_software_list, &images);
 
 		// and validate
 		insta::assert_debug_snapshot!(assets);

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config_and_software@bbcm_click100.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config_and_software@bbcm_click100.snap
@@ -1,0 +1,103 @@
+---
+source: src/audit/mod.rs
+expression: assets
+---
+[
+    Asset {
+        kind: Rom,
+        name: "mos320.ic24",
+        size: Some(
+            131072,
+        ),
+        location: Paths {
+            software_list_name: None,
+            targets: [
+                "bbcm",
+            ],
+        },
+        asset_hash: CRC(0f747ebe) SHA1(eacacbec3892dc4809ad5800e6c8299ff9eb528f),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "mos320.cmos",
+        size: Some(
+            64,
+        ),
+        location: Paths {
+            software_list_name: None,
+            targets: [
+                "bbcm",
+            ],
+        },
+        asset_hash: CRC(c7f9e85a) SHA1(f24cc9db0525910689219f7204bf8b864033ee94),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Sample,
+        name: "motoroff.wav",
+        size: None,
+        location: Paths {
+            software_list_name: None,
+            targets: [
+                "bbcm",
+            ],
+        },
+        asset_hash: <<NONE>>,
+        status: Good,
+        is_optional: true,
+    },
+    Asset {
+        kind: Sample,
+        name: "motoron.wav",
+        size: None,
+        location: Paths {
+            software_list_name: None,
+            targets: [
+                "bbcm",
+            ],
+        },
+        asset_hash: <<NONE>>,
+        status: Good,
+        is_optional: true,
+    },
+    Asset {
+        kind: Rom,
+        name: "saa5050",
+        size: Some(
+            960,
+        ),
+        location: Paths {
+            software_list_name: None,
+            targets: [
+                "saa5050",
+            ],
+        },
+        asset_hash: CRC(201490f3) SHA1(6c8daba70374e5aa3a6402f24cdc5f8677d58a0f),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: ImageFile {
+            device_type: Cartridge,
+            use_absolute_path: false,
+        },
+        name: "Click_M128-1.00.rom",
+        size: Some(
+            16384,
+        ),
+        location: Paths {
+            software_list_name: Some(
+                "bbcm_cart",
+            ),
+            targets: [
+                "click100",
+            ],
+        },
+        asset_hash: CRC(8c633300) SHA1(e7223334fd5cb5b3ed715421aa278b96b3ea39af),
+        status: Good,
+        is_optional: false,
+    },
+]

--- a/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config_and_software@coco2b_dagorath.snap
+++ b/src/audit/snapshots/bletchmame__audit__tests__assets_from_machine_config_and_software@coco2b_dagorath.snap
@@ -1,0 +1,77 @@
+---
+source: src/audit/mod.rs
+expression: assets
+---
+[
+    Asset {
+        kind: Rom,
+        name: "bas13.rom",
+        size: Some(
+            8192,
+        ),
+        location: Paths {
+            software_list_name: None,
+            targets: [
+                "coco2b",
+                "coco",
+            ],
+        },
+        asset_hash: CRC(d8f4d15e) SHA1(28b92bebe35fa4f026a084416d6ea3b1552b63d3),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "extbas11.rom",
+        size: Some(
+            8192,
+        ),
+        location: Paths {
+            software_list_name: None,
+            targets: [
+                "coco2b",
+                "coco",
+            ],
+        },
+        asset_hash: CRC(a82a6254) SHA1(ad927fb4f30746d820cb8b860ebb585e7f095dea),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: Rom,
+        name: "disk11.rom",
+        size: Some(
+            8192,
+        ),
+        location: Paths {
+            software_list_name: None,
+            targets: [
+                "coco_fdc",
+            ],
+        },
+        asset_hash: CRC(0b9c5415) SHA1(10bdc5aa2d7d7f205f67b47b19003a4bd89defd1),
+        status: Good,
+        is_optional: false,
+    },
+    Asset {
+        kind: ImageFile {
+            device_type: Cartridge,
+            use_absolute_path: false,
+        },
+        name: "dungeons of daggorath (1982)(26-3093)(dynamicro).rom",
+        size: Some(
+            8192,
+        ),
+        location: Paths {
+            software_list_name: Some(
+                "coco_cart",
+            ),
+            targets: [
+                "dagorath",
+            ],
+        },
+        asset_hash: CRC(d45e59e3) SHA1(b313259369d93c4badfba9a0126e320438d4a8b9),
+        status: Good,
+        is_optional: false,
+    },
+]

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -786,7 +786,8 @@ mod test {
 	#[test_case(0, include_str!("test_data/listxml_alienar.xml"), "alienar", "Alien Arena", "1985", "Duncan Brown", "williams.cpp", None, None)]
 	#[test_case(1, include_str!("test_data/listxml_c64.xml"), "c64", "Commodore 64 (NTSC)", "1982", "Commodore Business Machines", "commodore/c64.cpp", None, None)]
 	#[test_case(2, include_str!("test_data/listxml_coco.xml"), "coco2b", "Color Computer 2B", "1985?", "Tandy Radio Shack", "trs/coco12.cpp", Some("coco"), Some("coco"))]
-	#[test_case(3, include_str!("test_data/listxml_fake.xml"), "fake", "Fake Machine", "2021", "<Bletch>", "fake_machine.cpp", None, None)]
+	#[test_case(3, include_str!("test_data/listxml_bbcm.xml"), "bbcm", "BBC Master 128", "1986", "Acorn Computers", "acorn/bbcm.cpp", None, None)]
+	#[test_case(4, include_str!("test_data/listxml_fake.xml"), "fake", "Fake Machine", "2021", "<Bletch>", "fake_machine.cpp", None, None)]
 	pub fn machine(
 		_index: usize,
 		xml: &str,

--- a/src/info/test_data/listxml_bbcm.xml
+++ b/src/info/test_data/listxml_bbcm.xml
@@ -1,0 +1,8482 @@
+<?xml version="1.0"?>
+<!DOCTYPE mame [
+<!ELEMENT mame (machine+)>
+	<!ATTLIST mame build CDATA #IMPLIED>
+	<!ATTLIST mame debug (yes|no) "no">
+	<!ATTLIST mame mameconfig CDATA #REQUIRED>
+	<!ELEMENT machine (description, year?, manufacturer?, biosset*, rom*, disk*, device_ref*, sample*, chip*, display*, sound?, input?, dipswitch*, configuration*, port*, adjuster*, driver?, feature*, device*, slot*, softwarelist*, ramoption*)>
+		<!ATTLIST machine name CDATA #REQUIRED>
+		<!ATTLIST machine sourcefile CDATA #IMPLIED>
+		<!ATTLIST machine isbios (yes|no) "no">
+		<!ATTLIST machine isdevice (yes|no) "no">
+		<!ATTLIST machine ismechanical (yes|no) "no">
+		<!ATTLIST machine runnable (yes|no) "yes">
+		<!ATTLIST machine cloneof CDATA #IMPLIED>
+		<!ATTLIST machine romof CDATA #IMPLIED>
+		<!ATTLIST machine sampleof CDATA #IMPLIED>
+		<!ELEMENT description (#PCDATA)>
+		<!ELEMENT year (#PCDATA)>
+		<!ELEMENT manufacturer (#PCDATA)>
+		<!ELEMENT biosset EMPTY>
+			<!ATTLIST biosset name CDATA #REQUIRED>
+			<!ATTLIST biosset description CDATA #REQUIRED>
+			<!ATTLIST biosset default (yes|no) "no">
+		<!ELEMENT rom EMPTY>
+			<!ATTLIST rom name CDATA #REQUIRED>
+			<!ATTLIST rom bios CDATA #IMPLIED>
+			<!ATTLIST rom size CDATA #REQUIRED>
+			<!ATTLIST rom crc CDATA #IMPLIED>
+			<!ATTLIST rom sha1 CDATA #IMPLIED>
+			<!ATTLIST rom merge CDATA #IMPLIED>
+			<!ATTLIST rom region CDATA #IMPLIED>
+			<!ATTLIST rom offset CDATA #IMPLIED>
+			<!ATTLIST rom status (baddump|nodump|good) "good">
+			<!ATTLIST rom optional (yes|no) "no">
+		<!ELEMENT disk EMPTY>
+			<!ATTLIST disk name CDATA #REQUIRED>
+			<!ATTLIST disk sha1 CDATA #IMPLIED>
+			<!ATTLIST disk merge CDATA #IMPLIED>
+			<!ATTLIST disk region CDATA #IMPLIED>
+			<!ATTLIST disk index CDATA #IMPLIED>
+			<!ATTLIST disk writable (yes|no) "no">
+			<!ATTLIST disk status (baddump|nodump|good) "good">
+			<!ATTLIST disk optional (yes|no) "no">
+		<!ELEMENT device_ref EMPTY>
+			<!ATTLIST device_ref tag CDATA #REQUIRED>
+			<!ATTLIST device_ref name CDATA #REQUIRED>
+		<!ELEMENT sample EMPTY>
+			<!ATTLIST sample name CDATA #REQUIRED>
+		<!ELEMENT chip EMPTY>
+			<!ATTLIST chip name CDATA #REQUIRED>
+			<!ATTLIST chip tag CDATA #IMPLIED>
+			<!ATTLIST chip type (cpu|audio) #REQUIRED>
+			<!ATTLIST chip clock CDATA #IMPLIED>
+		<!ELEMENT display EMPTY>
+			<!ATTLIST display tag CDATA #IMPLIED>
+			<!ATTLIST display type (raster|vector|lcd|svg|unknown) #REQUIRED>
+			<!ATTLIST display rotate (0|90|180|270) #IMPLIED>
+			<!ATTLIST display flipx (yes|no) "no">
+			<!ATTLIST display width CDATA #IMPLIED>
+			<!ATTLIST display height CDATA #IMPLIED>
+			<!ATTLIST display refresh CDATA #REQUIRED>
+			<!ATTLIST display pixclock CDATA #IMPLIED>
+			<!ATTLIST display htotal CDATA #IMPLIED>
+			<!ATTLIST display hbend CDATA #IMPLIED>
+			<!ATTLIST display hbstart CDATA #IMPLIED>
+			<!ATTLIST display vtotal CDATA #IMPLIED>
+			<!ATTLIST display vbend CDATA #IMPLIED>
+			<!ATTLIST display vbstart CDATA #IMPLIED>
+		<!ELEMENT sound EMPTY>
+			<!ATTLIST sound channels CDATA #REQUIRED>
+		<!ELEMENT condition EMPTY>
+			<!ATTLIST condition tag CDATA #REQUIRED>
+			<!ATTLIST condition mask CDATA #REQUIRED>
+			<!ATTLIST condition relation (eq|ne|gt|le|lt|ge) #REQUIRED>
+			<!ATTLIST condition value CDATA #REQUIRED>
+		<!ELEMENT input (control*)>
+			<!ATTLIST input service (yes|no) "no">
+			<!ATTLIST input tilt (yes|no) "no">
+			<!ATTLIST input players CDATA #REQUIRED>
+			<!ATTLIST input coins CDATA #IMPLIED>
+			<!ELEMENT control EMPTY>
+				<!ATTLIST control type CDATA #REQUIRED>
+				<!ATTLIST control player CDATA #IMPLIED>
+				<!ATTLIST control buttons CDATA #IMPLIED>
+				<!ATTLIST control minimum CDATA #IMPLIED>
+				<!ATTLIST control maximum CDATA #IMPLIED>
+				<!ATTLIST control sensitivity CDATA #IMPLIED>
+				<!ATTLIST control keydelta CDATA #IMPLIED>
+				<!ATTLIST control reverse (yes|no) "no">
+				<!ATTLIST control ways CDATA #IMPLIED>
+				<!ATTLIST control ways2 CDATA #IMPLIED>
+				<!ATTLIST control ways3 CDATA #IMPLIED>
+		<!ELEMENT dipswitch (condition?, diplocation*, dipvalue*)>
+			<!ATTLIST dipswitch name CDATA #REQUIRED>
+			<!ATTLIST dipswitch tag CDATA #REQUIRED>
+			<!ATTLIST dipswitch mask CDATA #REQUIRED>
+			<!ELEMENT diplocation EMPTY>
+				<!ATTLIST diplocation name CDATA #REQUIRED>
+				<!ATTLIST diplocation number CDATA #REQUIRED>
+				<!ATTLIST diplocation inverted (yes|no) "no">
+			<!ELEMENT dipvalue (condition?)>
+				<!ATTLIST dipvalue name CDATA #REQUIRED>
+				<!ATTLIST dipvalue value CDATA #REQUIRED>
+				<!ATTLIST dipvalue default (yes|no) "no">
+		<!ELEMENT configuration (condition?, conflocation*, confsetting*)>
+			<!ATTLIST configuration name CDATA #REQUIRED>
+			<!ATTLIST configuration tag CDATA #REQUIRED>
+			<!ATTLIST configuration mask CDATA #REQUIRED>
+			<!ELEMENT conflocation EMPTY>
+				<!ATTLIST conflocation name CDATA #REQUIRED>
+				<!ATTLIST conflocation number CDATA #REQUIRED>
+				<!ATTLIST conflocation inverted (yes|no) "no">
+			<!ELEMENT confsetting (condition?)>
+				<!ATTLIST confsetting name CDATA #REQUIRED>
+				<!ATTLIST confsetting value CDATA #REQUIRED>
+				<!ATTLIST confsetting default (yes|no) "no">
+		<!ELEMENT port (analog*)>
+			<!ATTLIST port tag CDATA #REQUIRED>
+			<!ELEMENT analog EMPTY>
+				<!ATTLIST analog mask CDATA #REQUIRED>
+		<!ELEMENT adjuster (condition?)>
+			<!ATTLIST adjuster name CDATA #REQUIRED>
+			<!ATTLIST adjuster default CDATA #REQUIRED>
+		<!ELEMENT driver EMPTY>
+			<!ATTLIST driver status (good|imperfect|preliminary) #REQUIRED>
+			<!ATTLIST driver emulation (good|imperfect|preliminary) #REQUIRED>
+			<!ATTLIST driver cocktail (good|imperfect|preliminary) #IMPLIED>
+			<!ATTLIST driver savestate (supported|unsupported) #REQUIRED>
+			<!ATTLIST driver requiresartwork (yes|no) "no">
+			<!ATTLIST driver unofficial (yes|no) "no">
+			<!ATTLIST driver nosoundhardware (yes|no) "no">
+			<!ATTLIST driver incomplete (yes|no) "no">
+		<!ELEMENT feature EMPTY>
+			<!ATTLIST feature type (protection|timing|graphics|palette|sound|capture|camera|microphone|controls|keyboard|mouse|media|disk|printer|tape|punch|drum|rom|comms|lan|wan) #REQUIRED>
+			<!ATTLIST feature status (unemulated|imperfect) #IMPLIED>
+			<!ATTLIST feature overall (unemulated|imperfect) #IMPLIED>
+		<!ELEMENT device (instance?, extension*)>
+			<!ATTLIST device type CDATA #REQUIRED>
+			<!ATTLIST device tag CDATA #IMPLIED>
+			<!ATTLIST device fixed_image CDATA #IMPLIED>
+			<!ATTLIST device mandatory CDATA #IMPLIED>
+			<!ATTLIST device interface CDATA #IMPLIED>
+			<!ELEMENT instance EMPTY>
+				<!ATTLIST instance name CDATA #REQUIRED>
+				<!ATTLIST instance briefname CDATA #REQUIRED>
+			<!ELEMENT extension EMPTY>
+				<!ATTLIST extension name CDATA #REQUIRED>
+		<!ELEMENT slot (slotoption*)>
+			<!ATTLIST slot name CDATA #REQUIRED>
+			<!ELEMENT slotoption EMPTY>
+				<!ATTLIST slotoption name CDATA #REQUIRED>
+				<!ATTLIST slotoption devname CDATA #REQUIRED>
+				<!ATTLIST slotoption default (yes|no) "no">
+		<!ELEMENT softwarelist EMPTY>
+			<!ATTLIST softwarelist tag CDATA #REQUIRED>
+			<!ATTLIST softwarelist name CDATA #REQUIRED>
+			<!ATTLIST softwarelist status (original|compatible) #REQUIRED>
+			<!ATTLIST softwarelist filter CDATA #IMPLIED>
+		<!ELEMENT ramoption (#PCDATA)>
+			<!ATTLIST ramoption name CDATA #REQUIRED>
+			<!ATTLIST ramoption default CDATA #IMPLIED>
+]>
+
+<mame build="0.289 (mame0289)" debug="no" mameconfig="10">
+	<machine name="bbcm" sourcefile="acorn/bbcm.cpp" sampleof="bbc">
+		<description>BBC Master 128</description>
+		<year>1986</year>
+		<manufacturer>Acorn Computers</manufacturer>
+		<biosset name="320" description="MOS 3.20"/>
+		<biosset name="329" description="MOS 3.29"/>
+		<biosset name="343" description="MOS 3.43"/>
+		<biosset name="350" description="MOS 3.50"/>
+		<rom name="mos320.ic24" bios="320" size="131072" crc="0f747ebe" sha1="eacacbec3892dc4809ad5800e6c8299ff9eb528f" region="rom" offset="20000"/>
+		<rom name="mos329.ic24" bios="329" size="131072" crc="8dd7338b" sha1="4604203c70c04a9fd003103deec438fc5bd44839" region="rom" offset="20000"/>
+		<rom name="caspl_mos343_89.bin" bios="343" size="32768" crc="fa2b881f" sha1="eb7c09d942f9dac378337094416053df16cb3fe2" region="rom" offset="20000"/>
+		<rom name="caspl_mos343_ab.bin" bios="343" size="32768" crc="704d86e9" sha1="c3ee6018230c7201a6dfa10162f25d630f12c795" region="rom" offset="28000"/>
+		<rom name="caspl_mos343_cd.bin" bios="343" size="32768" crc="953b7530" sha1="19c1a59abd817f7011b142177417f7abb9eb3f64" region="rom" offset="30000"/>
+		<rom name="caspl_mos343_ef.bin" bios="343" size="32768" crc="ebc09359" sha1="24ff90709495adda8a01858c60275193e70b2690" region="rom" offset="38000"/>
+		<rom name="mos350.ic24" bios="350" size="131072" crc="141027b9" sha1="85211b5bc7c7a269952d2b063b7ec0e1f0196803" region="rom" offset="20000"/>
+		<rom name="mos320.cmos" bios="320" size="64" crc="c7f9e85a" sha1="f24cc9db0525910689219f7204bf8b864033ee94" region="rtc" offset="0"/>
+		<rom name="mos350.cmos" bios="329" size="64" crc="e84c1854" sha1="f3cb7f12b7432caba28d067f01af575779220aac" region="rtc" offset="0"/>
+		<rom name="mos350.cmos" bios="343" size="64" crc="e84c1854" sha1="f3cb7f12b7432caba28d067f01af575779220aac" region="rtc" offset="0"/>
+		<rom name="mos350.cmos" bios="350" size="64" crc="e84c1854" sha1="f3cb7f12b7432caba28d067f01af575779220aac" region="rtc" offset="0"/>
+		<device_ref tag=":maincpu" name="g65sc12"/>
+		<device_ref tag=":irqs" name="ipt_merge_any_hi"/>
+		<device_ref tag=":ram" name="ram"/>
+		<device_ref tag=":screen" name="screen"/>
+		<device_ref tag=":palette" name="palette"/>
+		<device_ref tag=":saa5050" name="saa5050"/>
+		<device_ref tag=":crtc" name="hd6845s"/>
+		<device_ref tag=":latch" name="ls259"/>
+		<device_ref tag=":sysvia" name="mos6522"/>
+		<device_ref tag=":kbd" name="bbcm_kbd"/>
+		<device_ref tag=":mono" name="speaker"/>
+		<device_ref tag=":sn" name="sn76489a"/>
+		<device_ref tag=":rtc" name="mc146818"/>
+		<device_ref tag=":mc6854" name="mc6854"/>
+		<device_ref tag=":network" name="econet"/>
+		<device_ref tag=":econet" name="econet_slot"/>
+		<device_ref tag=":cartslot1" name="electron_cartslot"/>
+		<device_ref tag=":cartslot2" name="electron_cartslot"/>
+		<device_ref tag=":romslot8" name="bbc_romslot16"/>
+		<device_ref tag=":samples" name="samples"/>
+		<device_ref tag=":cassette" name="cassette_image"/>
+		<device_ref tag=":acia" name="acia6850"/>
+		<device_ref tag=":serproc" name="serproc"/>
+		<device_ref tag=":rs423" name="rs232"/>
+		<device_ref tag=":uservia" name="mos6522"/>
+		<device_ref tag=":printer" name="centronics"/>
+		<device_ref tag=":printer:printer" name="centronics_printer"/>
+		<device_ref tag=":printer:printer:printer" name="printer_image"/>
+		<device_ref tag=":cent_data_out" name="output_latch"/>
+		<device_ref tag=":upd7002" name="upd7002"/>
+		<device_ref tag=":analogue" name="bbc_analogue_slot"/>
+		<device_ref tag=":wdfdc" name="wd1770"/>
+		<device_ref tag=":wdfdc:0" name="floppy_connector"/>
+		<device_ref tag=":wdfdc:0:525qd" name="floppy_525_qd"/>
+		<device_ref tag=":wdfdc:0:525qd:flopsndout" name="speaker"/>
+		<device_ref tag=":wdfdc:0:525qd:flopsnd" name="flopsnd"/>
+		<device_ref tag=":wdfdc:1" name="floppy_connector"/>
+		<device_ref tag=":wdfdc:1:525qd" name="floppy_525_qd"/>
+		<device_ref tag=":wdfdc:1:525qd:flopsndout" name="speaker"/>
+		<device_ref tag=":wdfdc:1:525qd:flopsnd" name="flopsnd"/>
+		<device_ref tag=":1mhzbus" name="bbc_1mhzbus_slot"/>
+		<device_ref tag=":intube" name="bbc_tube_slot"/>
+		<device_ref tag=":extube" name="bbc_tube_slot"/>
+		<device_ref tag=":userport" name="bbc_userport_slot"/>
+		<device_ref tag=":romslot4" name="bbc_romslot32"/>
+		<device_ref tag=":romslot4:ram" name="bbc_ram"/>
+		<device_ref tag=":romslot6" name="bbc_romslot32"/>
+		<device_ref tag=":romslot6:ram" name="bbc_ram"/>
+		<device_ref tag=":internal" name="bbc_internal_slot"/>
+		<device_ref tag=":modem" name="bbc_modem_slot"/>
+		<device_ref tag=":cass_ls" name="software_list"/>
+		<device_ref tag=":flop_ls_m" name="software_list"/>
+		<device_ref tag=":cart_ls_m" name="software_list"/>
+		<device_ref tag=":flop_ls_b" name="software_list"/>
+		<device_ref tag=":flop_ls_b_orig" name="software_list"/>
+		<device_ref tag=":rom_ls" name="software_list"/>
+		<device_ref tag=":hdd_ls" name="software_list"/>
+		<sample name="motoroff"/>
+		<sample name="motoron"/>
+		<chip type="cpu" tag="maincpu" name="GTE G65SC12" clock="2000000"/>
+		<chip type="audio" tag="mono" name="Speaker"/>
+		<chip type="audio" tag="sn" name="SN76489A" clock="4000000"/>
+		<chip type="audio" tag="samples" name="Samples"/>
+		<chip type="audio" tag="cassette" name="Cassette"/>
+		<chip type="audio" tag="wdfdc:0:525qd:flopsndout" name="Speaker"/>
+		<chip type="audio" tag="wdfdc:0:525qd:flopsnd" name="Floppy sound" clock="44100"/>
+		<chip type="audio" tag="wdfdc:1:525qd:flopsndout" name="Speaker"/>
+		<chip type="audio" tag="wdfdc:1:525qd:flopsnd" name="Floppy sound" clock="44100"/>
+		<chip type="audio" tag="1mhzbus" name="BBC Micro 1MHz Bus port" clock="1000000"/>
+		<display tag="screen" type="raster" rotate="0" width="640" height="256" refresh="50.080128" pixclock="16000000" htotal="1024" hbend="0" hbstart="640" vtotal="312" vbend="0" vbstart="256" />
+		<sound channels="3"/>
+		<input players="1">
+			<control type="keyboard" buttons="92"/>
+		</input>
+		<configuration name="Monitor" tag="BBCCONFIG" mask="3">
+			<condition tag="BBCCONFIG" mask="8" relation="eq" value="0"/>
+			<confsetting name="Colour" value="0" default="yes"/>
+			<confsetting name="B&amp;W" value="1"/>
+			<confsetting name="Green" value="2"/>
+			<confsetting name="Amber" value="3"/>
+		</configuration>
+		<configuration name="Econet" tag="BBCCONFIG" mask="4">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="4"/>
+		</configuration>
+		<configuration name="VideoNuLA" tag="BBCCONFIG" mask="8">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="8"/>
+		</configuration>
+		<port tag=":BBCCONFIG">
+		</port>
+		<port tag=":kbd:BREAK">
+		</port>
+		<port tag=":kbd:COL0">
+		</port>
+		<port tag=":kbd:COL1">
+		</port>
+		<port tag=":kbd:COL10">
+		</port>
+		<port tag=":kbd:COL11">
+		</port>
+		<port tag=":kbd:COL12">
+		</port>
+		<port tag=":kbd:COL13">
+		</port>
+		<port tag=":kbd:COL14">
+		</port>
+		<port tag=":kbd:COL15">
+		</port>
+		<port tag=":kbd:COL2">
+		</port>
+		<port tag=":kbd:COL3">
+		</port>
+		<port tag=":kbd:COL4">
+		</port>
+		<port tag=":kbd:COL5">
+		</port>
+		<port tag=":kbd:COL6">
+		</port>
+		<port tag=":kbd:COL7">
+		</port>
+		<port tag=":kbd:COL8">
+		</port>
+		<port tag=":kbd:COL9">
+		</port>
+		<driver status="imperfect" emulation="good" savestate="unsupported"/>
+		<feature type="graphics" status="imperfect"/>
+		<device type="cartridge" tag="cartslot1" interface="bbcm_cart">
+			<instance name="cartridge1" briefname="cart1"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="cartridge" tag="cartslot2" interface="bbcm_cart">
+			<instance name="cartridge2" briefname="cart2"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag="romslot8" interface="bbc_rom">
+			<instance name="romimage1" briefname="rom1"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="cassette" tag="cassette" interface="bbc_cass">
+			<instance name="cassette" briefname="cass"/>
+			<extension name="wav"/>
+			<extension name="flac"/>
+			<extension name="aif"/>
+			<extension name="aiff"/>
+			<extension name="csw"/>
+			<extension name="uef"/>
+		</device>
+		<device type="printout" tag="printer:printer:printer">
+			<instance name="printout" briefname="prin"/>
+			<extension name="prn"/>
+		</device>
+		<device type="floppydisk" tag="wdfdc:0:525qd" interface="floppy_5_25">
+			<instance name="floppydisk1" briefname="flop1"/>
+			<extension name="mfi"/>
+			<extension name="dfi"/>
+			<extension name="mfm"/>
+			<extension name="td0"/>
+			<extension name="imd"/>
+			<extension name="86f"/>
+			<extension name="d77"/>
+			<extension name="d88"/>
+			<extension name="1dd"/>
+			<extension name="cqm"/>
+			<extension name="cqi"/>
+			<extension name="dsk"/>
+			<extension name="ima"/>
+			<extension name="img"/>
+			<extension name="ufi"/>
+			<extension name="360"/>
+			<extension name="ipf"/>
+			<extension name="hfe"/>
+			<extension name="ssd"/>
+			<extension name="bbc"/>
+			<extension name="dsd"/>
+			<extension name="adf"/>
+			<extension name="ads"/>
+			<extension name="adm"/>
+			<extension name="adl"/>
+			<extension name="dds"/>
+			<extension name="fsd"/>
+		</device>
+		<device type="floppydisk" tag="wdfdc:1:525qd" interface="floppy_5_25">
+			<instance name="floppydisk2" briefname="flop2"/>
+			<extension name="mfi"/>
+			<extension name="dfi"/>
+			<extension name="mfm"/>
+			<extension name="td0"/>
+			<extension name="imd"/>
+			<extension name="86f"/>
+			<extension name="d77"/>
+			<extension name="d88"/>
+			<extension name="1dd"/>
+			<extension name="cqm"/>
+			<extension name="cqi"/>
+			<extension name="dsk"/>
+			<extension name="ima"/>
+			<extension name="img"/>
+			<extension name="ufi"/>
+			<extension name="360"/>
+			<extension name="ipf"/>
+			<extension name="hfe"/>
+			<extension name="ssd"/>
+			<extension name="bbc"/>
+			<extension name="dsd"/>
+			<extension name="adf"/>
+			<extension name="ads"/>
+			<extension name="adm"/>
+			<extension name="adl"/>
+			<extension name="dds"/>
+			<extension name="fsd"/>
+		</device>
+		<device type="romimage" tag="romslot4" fixed_image="1" interface="bbc_rom">
+		</device>
+		<device type="romimage" tag="romslot6" fixed_image="1" interface="bbc_rom">
+		</device>
+		<slot name="econet">
+			<slotoption name="e01s" devname="econet_e01s"/>
+			<slotoption name="e01" devname="econet_e01"/>
+		</slot>
+		<slot name="cartslot1">
+		</slot>
+		<slot name="cartslot2">
+		</slot>
+		<slot name="romslot8">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name="rs423">
+			<slotoption name="terminal" devname="serial_terminal"/>
+			<slotoption name="sunkbd" devname="sunkbd_adaptor"/>
+			<slotoption name="votraxtnt" devname="serial_votraxtnt"/>
+			<slotoption name="s97801" devname="s97801_terminal"/>
+			<slotoption name="rs_printer" devname="rs_serial_printer"/>
+			<slotoption name="rs232_sync_io" devname="rs232_sync_io"/>
+			<slotoption name="auto3a" devname="auto3a_terminal"/>
+			<slotoption name="dec_loopback" devname="dec_rs232_loopback"/>
+			<slotoption name="h19" devname="serial_heath_h19"/>
+			<slotoption name="ie15" devname="ie15_terminal"/>
+			<slotoption name="null_modem" devname="null_modem"/>
+			<slotoption name="keyboard" devname="serial_keyboard"/>
+			<slotoption name="patch" devname="rs232_patch_box"/>
+			<slotoption name="swtpc8212" devname="swtpc8212_terminal"/>
+			<slotoption name="printer" devname="serial_printer"/>
+			<slotoption name="scorpion" devname="scorpion_ic"/>
+			<slotoption name="loopback" devname="rs232_loopback"/>
+			<slotoption name="mockingboard" devname="mockingboardd"/>
+			<slotoption name="msystems_mouse" devname="rs232_mouse_hle_msystems"/>
+			<slotoption name="nss_tvi" devname="nss_tvinterface"/>
+			<slotoption name="pty" devname="pseudo_terminal"/>
+		</slot>
+		<slot name="printer">
+			<slotoption name="neomania" devname="neomania_adapter"/>
+			<slotoption name="pc6022" devname="pc6022"/>
+			<slotoption name="nlq401" devname="nlq401"/>
+			<slotoption name="smartboard" devname="centronics_smartboard"/>
+			<slotoption name="chessmec" devname="centronics_chessmec"/>
+			<slotoption name="samdac" devname="centronics_samdac"/>
+			<slotoption name="covox_stereo" devname="covox_stereo"/>
+			<slotoption name="adaptator" devname="adaptator_multitap"/>
+			<slotoption name="digiblst" devname="cpcdigiblst"/>
+			<slotoption name="lx800" devname="lx800"/>
+			<slotoption name="jx80" devname="epson_jx80"/>
+			<slotoption name="ap2000" devname="ap2000"/>
+			<slotoption name="ex800" devname="ex800"/>
+			<slotoption name="fx80" devname="epson_fx80"/>
+			<slotoption name="rx80" devname="epson_rx80"/>
+			<slotoption name="mz1p16" devname="mz1p16"/>
+			<slotoption name="covox" devname="covox"/>
+			<slotoption name="pl80" devname="comx_pl80"/>
+			<slotoption name="lx810l" devname="lx810l"/>
+			<slotoption name="p72" devname="p72"/>
+			<slotoption name="printer" devname="centronics_printer" default="yes"/>
+		</slot>
+		<slot name="analogue">
+			<slotoption name="robinlp" devname="robinlp"/>
+			<slotoption name="stacklp" devname="stacklp"/>
+			<slotoption name="datapen" devname="datapen"/>
+			<slotoption name="quinkey" devname="bbc_quinkey_intf"/>
+			<slotoption name="voltmace3b" devname="bbc_voltmace3b"/>
+			<slotoption name="micromike" devname="micromike"/>
+			<slotoption name="bitstik2" devname="bbc_bitstik2"/>
+			<slotoption name="bitstik1" devname="bbc_bitstik1"/>
+			<slotoption name="stacklr" devname="stacklr"/>
+			<slotoption name="acornjoy" devname="bbc_acornjoy"/>
+		</slot>
+		<slot name="wdfdc:0">
+			<slotoption name="525qd" devname="floppy_525_qd" default="yes"/>
+			<slotoption name="525sd" devname="floppy_525_sd"/>
+			<slotoption name="35dd" devname="floppy_35_dd"/>
+			<slotoption name="525sssd" devname="floppy_525_sssd"/>
+		</slot>
+		<slot name="wdfdc:1">
+			<slotoption name="525qd" devname="floppy_525_qd" default="yes"/>
+			<slotoption name="525sd" devname="floppy_525_sd"/>
+			<slotoption name="35dd" devname="floppy_35_dd"/>
+			<slotoption name="525sssd" devname="floppy_525_sssd"/>
+		</slot>
+		<slot name="1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opusa" devname="bbc_opusa"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+		</slot>
+		<slot name="intube">
+			<slotoption name="rc65816" devname="bbc_tube_rc65816"/>
+			<slotoption name="rc6502" devname="bbc_tube_rc6502"/>
+			<slotoption name="arm7" devname="bbc_tube_arm7"/>
+			<slotoption name="80186" devname="bbc_tube_80186"/>
+			<slotoption name="65c102" devname="bbc_tube_65c102"/>
+		</slot>
+		<slot name="extube">
+			<slotoption name="rc6502" devname="bbc_tube_rc6502"/>
+			<slotoption name="arm7" devname="bbc_tube_arm7"/>
+			<slotoption name="80186" devname="bbc_tube_80186"/>
+			<slotoption name="65c102" devname="bbc_tube_65c102"/>
+			<slotoption name="6502" devname="bbc_tube_6502"/>
+			<slotoption name="80286" devname="bbc_tube_80286"/>
+			<slotoption name="pcplus" devname="bbc_tube_pcplus"/>
+			<slotoption name="z80" devname="bbc_tube_z80"/>
+			<slotoption name="z80w" devname="bbc_tube_z80w"/>
+			<slotoption name="32016" devname="bbc_tube_32016"/>
+			<slotoption name="6502e" devname="bbc_tube_6502e"/>
+			<slotoption name="32016l" devname="bbc_tube_32016l"/>
+			<slotoption name="arm" devname="bbc_tube_arm"/>
+			<slotoption name="matchbox" devname="bbc_tube_matchbox"/>
+			<slotoption name="a500" devname="bbc_tube_a500"/>
+			<slotoption name="rc65816" devname="bbc_tube_rc65816"/>
+			<slotoption name="a500d" devname="bbc_tube_a500d"/>
+			<slotoption name="zep100m" devname="bbc_tube_zep100m"/>
+		</slot>
+		<slot name="userport">
+			<slotoption name="amxmouse" devname="bbc_amxmouse"/>
+			<slotoption name="beebspch" devname="bbc_beebspch"/>
+			<slotoption name="chameleon" devname="bbc_chameleon"/>
+			<slotoption name="sdcard" devname="bbc_sdcard"/>
+			<slotoption name="lcd" devname="bbc_lcd"/>
+			<slotoption name="cpalette" devname="bbc_cpalette"/>
+			<slotoption name="m4000" devname="bbc_m4000"/>
+			<slotoption name="m512mouse" devname="bbc_m512mouse"/>
+			<slotoption name="usersplit" devname="bbc_usersplit"/>
+			<slotoption name="sdcardt" devname="bbc_sdcardt"/>
+			<slotoption name="lvlecho" devname="bbc_lvlecho"/>
+			<slotoption name="tracker" devname="bbc_tracker"/>
+			<slotoption name="voicebox" devname="bbc_voicebox"/>
+		</slot>
+		<slot name="internal">
+			<slotoption name="overlay" devname="bbc_overlay"/>
+			<slotoption name="morleyaa" devname="bbc_morleyaa"/>
+		</slot>
+		<slot name="modem">
+			<slotoption name="scsiaiv" devname="bbc_scsiaiv"/>
+			<slotoption name="meup" devname="bbc_meup"/>
+		</slot>
+		<softwarelist tag="cass_ls" name="bbc_cass" status="original" filter="A,B,M"/>
+		<softwarelist tag="flop_ls_m" name="bbcm_flop" status="original"/>
+		<softwarelist tag="cart_ls_m" name="bbcm_cart" status="original"/>
+		<softwarelist tag="flop_ls_b" name="bbcb_flop" status="compatible"/>
+		<softwarelist tag="flop_ls_b_orig" name="bbcb_flop_orig" status="compatible"/>
+		<softwarelist tag="rom_ls" name="bbc_rom" status="original" filter="M"/>
+		<softwarelist tag="hdd_ls" name="bbc_hdd" status="original" filter="M"/>
+		<ramoption name="128K" default="yes">131072</ramoption>
+	</machine>
+	<machine name="24c512" sourcefile="devices/machine/i2cmem.cpp" isdevice="yes" runnable="no">
+		<description>24C512 I2C Memory</description>
+	</machine>
+	<machine name="93c06_16" sourcefile="devices/machine/eepromser.cpp" isdevice="yes" runnable="no">
+		<description>Serial EEPROM 93C06 (16x16)</description>
+	</machine>
+	<machine name="acia6850" sourcefile="devices/machine/6850acia.cpp" isdevice="yes" runnable="no">
+		<description>MC6850 ACIA</description>
+	</machine>
+	<machine name="acorn_bus" sourcefile="devices/bus/acorn/bus.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Bus</description>
+	</machine>
+	<machine name="acorn_bus_slot" sourcefile="devices/bus/acorn/bus.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Bus Eurocard slot</description>
+	</machine>
+	<machine name="acorn_vidc1" sourcefile="devices/machine/acorn_vidc.cpp" isdevice="yes" runnable="no">
+		<description>Acorn VIDC1</description>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:dac0" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:dac1" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:dac2" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:dac3" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:dac4" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:dac5" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:dac6" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:dac7" name="dac_16bit_r2r_tc"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":dac0" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":dac1" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":dac2" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":dac3" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":dac4" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":dac5" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":dac6" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":dac7" name="16-Bit R-2R Twos Complement DAC"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="adaptator_multitap" sourcefile="devices/bus/centronics/adaptator.cpp" isdevice="yes" runnable="no">
+		<description>The Adaptator 2x DE-9 Multitap</description>
+		<device_ref tag=":_tmp:joy_p1" name="vcs_control_port"/>
+		<device_ref tag=":_tmp:joy_p2" name="vcs_control_port"/>
+		<slot name=":joy_p1">
+			<slotoption name="trakball" devname="atari_trakball"/>
+			<slotoption name="wheel" devname="vcs_wheel"/>
+			<slotoption name="joybstr" devname="vcs_joystick_booster"/>
+			<slotoption name="cx85" devname="atari_cx85"/>
+			<slotoption name="keypad" devname="vcs_keypad"/>
+			<slotoption name="lp" devname="vcs_lightpen"/>
+			<slotoption name="pad" devname="vcs_paddles"/>
+			<slotoption name="mouse" devname="vcs_mouse"/>
+			<slotoption name="joy" devname="vcs_joystick" default="yes"/>
+		</slot>
+		<slot name=":joy_p2">
+			<slotoption name="trakball" devname="atari_trakball"/>
+			<slotoption name="wheel" devname="vcs_wheel"/>
+			<slotoption name="joybstr" devname="vcs_joystick_booster"/>
+			<slotoption name="cx85" devname="atari_cx85"/>
+			<slotoption name="keypad" devname="vcs_keypad"/>
+			<slotoption name="lp" devname="vcs_lightpen"/>
+			<slotoption name="pad" devname="vcs_paddles"/>
+			<slotoption name="mouse" devname="vcs_mouse"/>
+			<slotoption name="joy" devname="vcs_joystick" default="yes"/>
+		</slot>
+	</machine>
+	<machine name="address_map_bank" sourcefile="devices/machine/bankdev.cpp" isdevice="yes" runnable="no">
+		<description>Address Map Bank</description>
+	</machine>
+	<machine name="ap2000" sourcefile="devices/bus/centronics/epson_lx810l.cpp" isdevice="yes" runnable="no">
+		<description>Epson ActionPrinter 2000</description>
+		<rom name="ap2k.ic3c" size="32768" crc="ee7294b7" sha1="219ffa6ff661ce95d5772c9fc1967093718f04e9" region="maincpu" offset="0"/>
+		<rom name="at93c06" size="32" status="nodump" region="eeprom" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="upd7810"/>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:dac" name="dac"/>
+		<device_ref tag=":_tmp:e05a30" name="e05a30"/>
+		<device_ref tag=":_tmp:eeprom" name="93c06_16"/>
+		<device_ref tag=":_tmp:bitmap_printer" name="bitmap_printer"/>
+		<device_ref tag=":_tmp:bitmap_printer:screen" name="screen"/>
+		<device_ref tag=":_tmp:bitmap_printer:pf_stepper" name="stepper"/>
+		<device_ref tag=":_tmp:bitmap_printer:cr_stepper" name="stepper"/>
+		<chip type="cpu" tag=":maincpu" name="NEC uPD7810" clock="14745600"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":dac" name="1-Bit DAC"/>
+		<display tag=":bitmap_printer:screen" type="raster" rotate="0" width="1024" height="384" refresh="60.000000" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="6"/>
+		</input>
+		<dipswitch name="Character spacing" tag=":DIPSW1" mask="1">
+			<diplocation name="SW 1" number="1" inverted="yes"/>
+			<dipvalue name="10 cpi" value="0" default="yes"/>
+			<dipvalue name="12 cpi" value="1"/>
+		</dipswitch>
+		<dipswitch name="Shape of zero" tag=":DIPSW1" mask="2">
+			<diplocation name="SW 1" number="2" inverted="yes"/>
+			<dipvalue name="Not slashed" value="0" default="yes"/>
+			<dipvalue name="Slashed" value="2"/>
+		</dipswitch>
+		<dipswitch name="Page length" tag=":DIPSW1" mask="12">
+			<diplocation name="SW 1" number="3" inverted="yes"/>
+			<diplocation name="SW 1" number="4" inverted="yes"/>
+			<dipvalue name="8.5&quot;" value="8"/>
+			<dipvalue name="11&quot;" value="0" default="yes"/>
+			<dipvalue name="11.7&quot; (A4)" value="12"/>
+			<dipvalue name="12&quot;" value="4"/>
+		</dipswitch>
+		<dipswitch name="Character table" tag=":DIPSW1" mask="16">
+			<diplocation name="SW 1" number="5" inverted="yes"/>
+			<dipvalue name="Italics" value="0" default="yes"/>
+			<dipvalue name="Graphics" value="16"/>
+		</dipswitch>
+		<dipswitch name="International character set" tag=":DIPSW1" mask="224">
+			<diplocation name="SW 1" number="6" inverted="yes"/>
+			<diplocation name="SW 1" number="7" inverted="yes"/>
+			<diplocation name="SW 1" number="8" inverted="yes"/>
+			<dipvalue name="USA (PC 437)" value="224" default="yes"/>
+			<dipvalue name="France (PC 850)" value="96"/>
+			<dipvalue name="Germany (PC 860)" value="160"/>
+			<dipvalue name="UK (PC 863)" value="32"/>
+			<dipvalue name="Denmark (PC 865)" value="192"/>
+			<dipvalue name="Sweden (PC 437)" value="64"/>
+			<dipvalue name="Italy (PC 437)" value="128"/>
+			<dipvalue name="Spain (PC 437)" value="0"/>
+		</dipswitch>
+		<dipswitch name="Short tear-off" tag=":DIPSW2" mask="1">
+			<diplocation name="SW 2" number="1" inverted="yes"/>
+			<dipvalue name="Invalid" value="1" default="yes"/>
+			<dipvalue name="Valid" value="0"/>
+		</dipswitch>
+		<dipswitch name="Cut-sheet feeder mode" tag=":DIPSW2" mask="2">
+			<diplocation name="SW 2" number="2" inverted="yes"/>
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="2"/>
+		</dipswitch>
+		<dipswitch name="Skip over perforation" tag=":DIPSW2" mask="4">
+			<diplocation name="SW 2" number="3" inverted="yes"/>
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="1&quot;" value="4"/>
+		</dipswitch>
+		<dipswitch name="Auto line feed" tag=":DIPSW2" mask="8">
+			<diplocation name="SW 2" number="4" inverted="yes"/>
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="8"/>
+		</dipswitch>
+		<configuration name="Draw Inch Marks" tag=":bitmap_printer:DRAWMARKS" mask="3">
+			<confsetting name="Off" value="0"/>
+			<confsetting name="with marks" value="1"/>
+			<confsetting name="with numbers" value="2" default="yes"/>
+		</configuration>
+		<adjuster name="Printer Bottom Margin" default="18"/>
+		<adjuster name="Printer Top Margin" default="18"/>
+	</machine>
+	<machine name="archimedes_keyboard" sourcefile="devices/machine/archimedes_keyb.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Archimedes Keyboard</description>
+		<rom name="acorn_0280,022-01_philips_8051ah-2.bin" size="4096" crc="95095d38" sha1="b9fd0000d77987f76fd48348fe2c6988818f40cb" region="mcu" offset="0"/>
+		<device_ref tag=":_tmp:mcu" name="i8051"/>
+		<chip type="cpu" tag=":mcu" name="Intel 8051" clock="12000000"/>
+		<input players="1">
+			<control type="mouse" minimum="0" maximum="65535" sensitivity="100"/>
+			<control type="keyboard" buttons="106"/>
+		</input>
+	</machine>
+	<machine name="arm7_le" sourcefile="devices/cpu/arm7/arm7.cpp" isdevice="yes" runnable="no">
+		<description>ARM7 (little)</description>
+	</machine>
+	<machine name="arm_cpu" sourcefile="devices/cpu/arm/arm.cpp" isdevice="yes" runnable="no">
+		<description>ARM</description>
+	</machine>
+	<machine name="ata_interface" sourcefile="devices/bus/ata/ataintf.cpp" isdevice="yes" runnable="no">
+		<description>ATA Interface</description>
+		<device_ref tag=":_tmp:0" name="ata_slot"/>
+		<device_ref tag=":_tmp:1" name="ata_slot"/>
+		<slot name=":0">
+		</slot>
+		<slot name=":1">
+		</slot>
+	</machine>
+	<machine name="ata_slot" sourcefile="devices/bus/ata/atadev.cpp" isdevice="yes" runnable="no">
+		<description>ATA Connector</description>
+	</machine>
+	<machine name="auto3a_terminal" sourcefile="devices/bus/rs232/auto3a.cpp" isdevice="yes" runnable="no">
+		<description>Auto-baud ADM-3A Terminal</description>
+		<device_ref tag=":_tmp:terminal_screen" name="screen"/>
+		<device_ref tag=":_tmp:keyboard" name="generic_keyboard"/>
+		<device_ref tag=":_tmp:bell" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<chip type="audio" tag=":bell" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="2000"/>
+		<display tag=":terminal_screen" type="raster" rotate="0" width="640" height="240" refresh="50.000000" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="73"/>
+		</input>
+		<configuration name="Data Bits (until lock)" tag=":RS232_DATABITS" mask="255">
+			<confsetting name="5" value="0"/>
+			<confsetting name="6" value="1"/>
+			<confsetting name="7" value="2"/>
+			<confsetting name="8" value="3" default="yes"/>
+		</configuration>
+		<configuration name="Parity" tag=":RS232_PARITY" mask="255">
+			<confsetting name="None" value="0" default="yes"/>
+			<confsetting name="Odd" value="1"/>
+			<confsetting name="Even" value="2"/>
+			<confsetting name="Mark" value="3"/>
+			<confsetting name="Space" value="4"/>
+		</configuration>
+		<configuration name="Stop Bits (until lock)" tag=":RS232_STOPBITS" mask="255">
+			<confsetting name="0" value="0"/>
+			<confsetting name="1" value="1" default="yes"/>
+			<confsetting name="1.5" value="2"/>
+			<confsetting name="2" value="3"/>
+		</configuration>
+		<configuration name="TX Baud (until lock)" tag=":RS232_TXBAUD" mask="255">
+			<confsetting name="50" value="14"/>
+			<confsetting name="75" value="15"/>
+			<confsetting name="110" value="0"/>
+			<confsetting name="134.5" value="16"/>
+			<confsetting name="150" value="1"/>
+			<confsetting name="200" value="17"/>
+			<confsetting name="300" value="2"/>
+			<confsetting name="600" value="3"/>
+			<confsetting name="1200" value="4"/>
+			<confsetting name="1800" value="18"/>
+			<confsetting name="2000" value="19"/>
+			<confsetting name="2400" value="5"/>
+			<confsetting name="3600" value="20"/>
+			<confsetting name="4800" value="6"/>
+			<confsetting name="7200" value="21"/>
+			<confsetting name="9600" value="7" default="yes"/>
+			<confsetting name="14400" value="8"/>
+			<confsetting name="19200" value="9"/>
+			<confsetting name="28800" value="10"/>
+			<confsetting name="38400" value="11"/>
+			<confsetting name="57600" value="12"/>
+			<confsetting name="76800" value="23"/>
+			<confsetting name="78125" value="24"/>
+			<confsetting name="111900" value="22"/>
+			<confsetting name="115200" value="13"/>
+		</configuration>
+		<configuration name="Cursor" tag=":TERM_CONF" mask="1">
+			<confsetting name="No" value="0"/>
+			<confsetting name="Yes" value="1" default="yes"/>
+		</configuration>
+		<configuration name="Type" tag=":TERM_CONF" mask="2">
+			<confsetting name="Underline" value="0"/>
+			<confsetting name="Block" value="2" default="yes"/>
+		</configuration>
+		<configuration name="Blinking" tag=":TERM_CONF" mask="4">
+			<confsetting name="No" value="0"/>
+			<confsetting name="Yes" value="4" default="yes"/>
+		</configuration>
+		<configuration name="Invert" tag=":TERM_CONF" mask="8">
+			<confsetting name="No" value="0"/>
+			<confsetting name="Yes" value="8" default="yes"/>
+		</configuration>
+		<configuration name="Color" tag=":TERM_CONF" mask="48">
+			<confsetting name="Green" value="0" default="yes"/>
+			<confsetting name="Amber" value="16"/>
+			<confsetting name="White" value="32"/>
+		</configuration>
+		<configuration name="Auto CR on LF" tag=":TERM_CONF" mask="64">
+			<confsetting name="No" value="0"/>
+			<confsetting name="Yes" value="64" default="yes"/>
+		</configuration>
+		<configuration name="Auto LF on CR" tag=":TERM_CONF" mask="128">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="128"/>
+		</configuration>
+		<configuration name="Local echo" tag=":TERM_CONF" mask="256">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="256"/>
+		</configuration>
+		<configuration name="Layout" tag=":keyboard:GENKBD_CFG" mask="1">
+			<confsetting name="ANSI" value="0" default="yes"/>
+			<confsetting name="JIS" value="1"/>
+		</configuration>
+		<configuration name="Typematic Delay" tag=":keyboard:GENKBD_CFG" mask="6">
+			<confsetting name="0.25s" value="0"/>
+			<confsetting name="0.5s" value="2"/>
+			<confsetting name="0.75s" value="4" default="yes"/>
+			<confsetting name="1.0s" value="6"/>
+		</configuration>
+		<configuration name="Typematic Rate" tag=":keyboard:GENKBD_CFG" mask="248">
+			<confsetting name="2.0cps" value="0"/>
+			<confsetting name="2.1cps" value="8"/>
+			<confsetting name="2.5cps" value="16"/>
+			<confsetting name="2.7cps" value="24"/>
+			<confsetting name="2.0cps" value="32"/>
+			<confsetting name="2.1cps" value="40"/>
+			<confsetting name="2.5cps" value="48"/>
+			<confsetting name="2.7cps" value="56"/>
+			<confsetting name="3.3cps" value="64"/>
+			<confsetting name="3.8cps" value="72"/>
+			<confsetting name="4.0cps" value="80"/>
+			<confsetting name="4.3cps" value="88"/>
+			<confsetting name="4.6cps" value="96"/>
+			<confsetting name="5.0cps" value="104"/>
+			<confsetting name="5.5cps" value="112"/>
+			<confsetting name="6.0cps" value="120"/>
+			<confsetting name="8.0cps" value="128"/>
+			<confsetting name="8.6cps" value="136"/>
+			<confsetting name="9.2cps" value="144"/>
+			<confsetting name="10.0cps" value="152" default="yes"/>
+			<confsetting name="10.9cps" value="160"/>
+			<confsetting name="12.0cps" value="168"/>
+			<confsetting name="13.3cps" value="176"/>
+			<confsetting name="15.0cps" value="184"/>
+			<confsetting name="16.0cps" value="192"/>
+			<confsetting name="17.1cps" value="200"/>
+			<confsetting name="18.5cps" value="208"/>
+			<confsetting name="20.0cps" value="216"/>
+			<confsetting name="21.8cps" value="224"/>
+			<confsetting name="24.0cps" value="232"/>
+			<confsetting name="26.7cps" value="240"/>
+			<confsetting name="30.0cps" value="248"/>
+		</configuration>
+	</machine>
+	<machine name="ay8913" sourcefile="devices/sound/ay8910.cpp" isdevice="yes" runnable="no">
+		<description>AY-3-8913 PSG</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="bbc_1mhzbus_slot" sourcefile="devices/bus/bbc/1mhzbus/1mhzbus.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro 1MHz Bus port</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="bbc_24bbc" sourcefile="devices/bus/bbc/1mhzbus/24bbc.cpp" isdevice="yes" runnable="no">
+		<description>Sprow 24bBC/RAM Disc Board</description>
+		<rom name="ramfs120.rom" size="16384" crc="782e6386" sha1="65493cc1f6ae31cf39298d67dad42ea23be4cae6" region="exp_rom" offset="0"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="0"/>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+	</machine>
+	<machine name="bbc_2ndserial" sourcefile="devices/bus/bbc/1mhzbus/2ndserial.cpp" isdevice="yes" runnable="no">
+		<description>Sprow 2nd Serial Port</description>
+		<rom name="2ndserial.rom" size="8192" crc="e58cdb76" sha1="9ebbe845734d77ebf1730ea622ce2db43f18b1c2" region="exp_rom" offset="0"/>
+		<device_ref tag=":_tmp:acia6850" name="acia6850"/>
+		<device_ref tag=":_tmp:rs232" name="rs232"/>
+		<device_ref tag=":_tmp:acia_clock_tx" name="clock"/>
+		<device_ref tag=":_tmp:acia_clock_rx" name="clock"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="0"/>
+		<configuration name="Base Address" tag=":LINKS" mask="3">
+			<confsetting name="&amp;FC60" value="0" default="yes"/>
+			<confsetting name="&amp;FC64" value="1"/>
+			<confsetting name="&amp;FC68" value="2"/>
+			<confsetting name="&amp;FC6C" value="3"/>
+		</configuration>
+		<slot name=":rs232">
+			<slotoption name="terminal" devname="serial_terminal"/>
+			<slotoption name="sunkbd" devname="sunkbd_adaptor"/>
+			<slotoption name="votraxtnt" devname="serial_votraxtnt"/>
+			<slotoption name="s97801" devname="s97801_terminal"/>
+			<slotoption name="rs_printer" devname="rs_serial_printer"/>
+			<slotoption name="rs232_sync_io" devname="rs232_sync_io"/>
+			<slotoption name="auto3a" devname="auto3a_terminal"/>
+			<slotoption name="dec_loopback" devname="dec_rs232_loopback"/>
+			<slotoption name="h19" devname="serial_heath_h19"/>
+			<slotoption name="ie15" devname="ie15_terminal"/>
+			<slotoption name="null_modem" devname="null_modem"/>
+			<slotoption name="keyboard" devname="serial_keyboard"/>
+			<slotoption name="patch" devname="rs232_patch_box"/>
+			<slotoption name="swtpc8212" devname="swtpc8212_terminal"/>
+			<slotoption name="printer" devname="serial_printer"/>
+			<slotoption name="scorpion" devname="scorpion_ic"/>
+			<slotoption name="loopback" devname="rs232_loopback"/>
+			<slotoption name="mockingboard" devname="mockingboardd"/>
+			<slotoption name="msystems_mouse" devname="rs232_mouse_hle_msystems"/>
+			<slotoption name="nss_tvi" devname="nss_tvinterface"/>
+			<slotoption name="pty" devname="pseudo_terminal"/>
+		</slot>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+	</machine>
+	<machine name="bbc_acornjoy" sourcefile="devices/bus/bbc/analogue/joystick.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Analogue Joysticks</description>
+		<input players="2">
+			<control type="stick" player="1" buttons="1" minimum="0" maximum="4095" sensitivity="100" keydelta="50" reverse="yes"/>
+			<control type="stick" player="2" buttons="1" minimum="0" maximum="4095" sensitivity="100" keydelta="50" reverse="yes"/>
+		</input>
+	</machine>
+	<machine name="bbc_amxmouse" sourcefile="devices/bus/bbc/userport/pointer.cpp" isdevice="yes" runnable="no">
+		<description>AMX Mouse (BBC Micro)</description>
+		<input players="1">
+			<control type="mouse" buttons="3" minimum="0" maximum="255" sensitivity="100"/>
+		</input>
+	</machine>
+	<machine name="bbc_analogue_slot" sourcefile="devices/bus/bbc/analogue/analogue.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro Analogue port</description>
+	</machine>
+	<machine name="bbc_awhd" sourcefile="devices/bus/bbc/1mhzbus/scsi.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Winchester Disc</description>
+		<device_ref tag=":_tmp:scsi" name="nscsi_bus"/>
+		<device_ref tag=":_tmp:scsi:0" name="nscsi_connector"/>
+		<device_ref tag=":_tmp:scsi:1" name="nscsi_connector"/>
+		<device_ref tag=":_tmp:scsi:7" name="nscsi_connector"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="0"/>
+		<feature type="disk" status="imperfect"/>
+		<slot name=":scsi:1">
+			<slotoption name="pc98_hd" devname="scsi_pc98_hd"/>
+			<slotoption name="cfp1080s" devname="cfp1080s"/>
+			<slotoption name="aplcdsc_ext" devname="scsi_cdrom_apple_ext"/>
+			<slotoption name="aplcdsc" devname="scsi_cdrom_apple"/>
+			<slotoption name="aplcd150" devname="aplcd150"/>
+			<slotoption name="crd254sh" devname="crd254sh"/>
+			<slotoption name="sa1403d" devname="nscsi_sa1403d"/>
+			<slotoption name="tape" devname="scsi_tape"/>
+			<slotoption name="s1410" devname="scsi_s1410"/>
+			<slotoption name="dtc510" devname="scsi_dtc510"/>
+			<slotoption name="harddisk" devname="scsi_harddisk"/>
+			<slotoption name="cw7501" devname="cw7501"/>
+			<slotoption name="cdr4210" devname="cdr4210"/>
+			<slotoption name="cdu561_25" devname="cdu561_25"/>
+			<slotoption name="cdrom" devname="scsi_cdrom"/>
+			<slotoption name="cdu415" devname="cdu415"/>
+			<slotoption name="smoc501" devname="smoc501"/>
+			<slotoption name="cdd2000" devname="cdd2000"/>
+			<slotoption name="cdrom_2x" devname="scsi_cdrom2x"/>
+			<slotoption name="cdrn820s" devname="cdrn820s"/>
+			<slotoption name="cdu75s" devname="cdu75s"/>
+		</slot>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+	</machine>
+	<machine name="bbc_b488" sourcefile="devices/bus/bbc/1mhzbus/ieee488.cpp" isdevice="yes" runnable="no">
+		<description>Aries-B488</description>
+		<device_ref tag=":_tmp:hpib" name="tms9914"/>
+		<device_ref tag=":_tmp:ieee_bus" name="ieee488"/>
+		<device_ref tag=":_tmp:ieee_dev" name="ieee488_slot"/>
+		<slot name=":ieee_dev">
+			<slotoption name="c2040" devname="c2040"/>
+			<slotoption name="d9090" devname="d9090"/>
+			<slotoption name="c4023" devname="c4023"/>
+			<slotoption name="hardbox" devname="gpib_hardbox"/>
+			<slotoption name="c3040" devname="c3040"/>
+			<slotoption name="c4040" devname="c4040"/>
+			<slotoption name="c8050" devname="c8050"/>
+			<slotoption name="c8250" devname="c8250"/>
+			<slotoption name="shark" devname="gpib_mshark"/>
+			<slotoption name="softbox" devname="gpib_softbox"/>
+			<slotoption name="sfd1001" devname="sfd1001"/>
+			<slotoption name="c2031" devname="c2031"/>
+			<slotoption name="c8280" devname="c8280"/>
+			<slotoption name="d9060" devname="d9060"/>
+		</slot>
+	</machine>
+	<machine name="bbc_barrybox" sourcefile="devices/bus/bbc/1mhzbus/barrybox.cpp" isdevice="yes" runnable="no">
+		<description>The Barry-Box</description>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:dac" name="zn428e"/>
+		<device_ref tag=":_tmp:mic" name="microphone"/>
+		<device_ref tag=":_tmp:adc" name="zn449"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":dac" name="ZN428E-8 DAC"/>
+		<chip type="audio" tag=":mic" name="Microphone"/>
+		<chip type="audio" tag=":adc" name="ZN449 ADC"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="bbc_beebex" sourcefile="devices/bus/bbc/1mhzbus/beebex.cpp" isdevice="yes" runnable="no">
+		<description>BEEBEX Extender for BBC Micro</description>
+		<device_ref tag=":_tmp:bus0" name="acorn_bus"/>
+		<device_ref tag=":_tmp:slot1" name="acorn_bus_slot"/>
+		<device_ref tag=":_tmp:bus1" name="acorn_bus"/>
+		<device_ref tag=":_tmp:slot2" name="acorn_bus_slot"/>
+		<device_ref tag=":_tmp:bus2" name="acorn_bus"/>
+		<device_ref tag=":_tmp:slot3" name="acorn_bus_slot"/>
+		<device_ref tag=":_tmp:bus3" name="acorn_bus"/>
+		<device_ref tag=":_tmp:slot4" name="acorn_bus_slot"/>
+		<slot name=":slot1">
+			<slotoption name="cugraphm" devname="cu_graphm"/>
+			<slotoption name="cugraphc" devname="cu_graphc"/>
+			<slotoption name="teletext" devname="cu_teletext"/>
+			<slotoption name="cubio_r" devname="cu_cubio_race" default="yes"/>
+		</slot>
+		<slot name=":slot2">
+			<slotoption name="cugraphm" devname="cu_graphm"/>
+			<slotoption name="cugraphc" devname="cu_graphc"/>
+			<slotoption name="teletext" devname="cu_teletext"/>
+			<slotoption name="cubio_r" devname="cu_cubio_race"/>
+		</slot>
+		<slot name=":slot3">
+			<slotoption name="cugraphm" devname="cu_graphm"/>
+			<slotoption name="cugraphc" devname="cu_graphc"/>
+			<slotoption name="teletext" devname="cu_teletext"/>
+			<slotoption name="cubio_r" devname="cu_cubio_race"/>
+		</slot>
+		<slot name=":slot4">
+			<slotoption name="cugraphm" devname="cu_graphm"/>
+			<slotoption name="cugraphc" devname="cu_graphc"/>
+			<slotoption name="teletext" devname="cu_teletext"/>
+			<slotoption name="cubio_r" devname="cu_cubio_race"/>
+		</slot>
+	</machine>
+	<machine name="bbc_beebide" sourcefile="devices/bus/bbc/1mhzbus/ide.cpp" isdevice="yes" runnable="no">
+		<description>Sprow BeebIDE 16-bit IDE Interface</description>
+		<device_ref tag=":_tmp:ide" name="ata_interface"/>
+		<device_ref tag=":_tmp:ide:0" name="ata_slot"/>
+		<device_ref tag=":_tmp:ide:1" name="ata_slot"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="0"/>
+		<configuration name="Interrupt Enable" tag=":LINKS" mask="1">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="1"/>
+		</configuration>
+		<configuration name="Address Selection" tag=":LINKS" mask="16">
+			<confsetting name="&amp;FC40-&amp;FC4F" value="0" default="yes"/>
+			<confsetting name="&amp;FC50-&amp;FC5F" value="16"/>
+		</configuration>
+		<slot name=":ide:0">
+			<slotoption name="px320a" devname="px320a"/>
+			<slotoption name="zip100" devname="zip100_ide"/>
+			<slotoption name="cr589" devname="cr589"/>
+			<slotoption name="cp2024" devname="cp2024"/>
+			<slotoption name="xm3301" devname="xm3301"/>
+			<slotoption name="cf" devname="atacf"/>
+			<slotoption name="cdrom" devname="cdrom"/>
+			<slotoption name="hdd" devname="idehd" default="yes"/>
+		</slot>
+		<slot name=":ide:1">
+			<slotoption name="px320a" devname="px320a"/>
+			<slotoption name="zip100" devname="zip100_ide"/>
+			<slotoption name="cr589" devname="cr589"/>
+			<slotoption name="cp2024" devname="cp2024"/>
+			<slotoption name="xm3301" devname="xm3301"/>
+			<slotoption name="cf" devname="atacf"/>
+			<slotoption name="cdrom" devname="cdrom"/>
+			<slotoption name="hdd" devname="idehd"/>
+		</slot>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+	</machine>
+	<machine name="bbc_beebspch" sourcefile="devices/bus/bbc/userport/beebspch.cpp" isdevice="yes" runnable="no">
+		<description>Beeb Speech Synthesiser</description>
+		<rom name="watford_speech.rom" size="8192" crc="731642a8" sha1="1bd31345af6043f394bc9d8e65180c93b2356905" region="exp_rom" offset="0"/>
+		<rom name="sp0256a-al2.bin" size="2048" crc="b504ac15" sha1="e60fcb5fa16ff3f3b69d36c7a6e955744d3feafc" region="sp0256" offset="1000"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:sp0256" name="sp0256"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":sp0256" name="GI SP0256 Narrator Speech Processor" clock="3120000"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="bbc_bitstik1" sourcefile="devices/bus/bbc/analogue/bitstik.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Bitstik</description>
+		<rom name="bitstik1.rom" size="8192" crc="a3c539f8" sha1="c6f2cf2f6d1e48819a8381c6a1c97ca8fa5ab117" region="exp_rom" offset="0"/>
+		<input players="1">
+			<control type="stick" buttons="3" minimum="0" maximum="4095" sensitivity="100" keydelta="50"/>
+		</input>
+	</machine>
+	<machine name="bbc_bitstik2" sourcefile="devices/bus/bbc/analogue/bitstik.cpp" isdevice="yes" runnable="no">
+		<description>Robo Bitstik 2</description>
+		<rom name="bitstik2.rom" size="8192" crc="a2b5a743" sha1="4d0040af6bdc6a587e42d4aa36d528b768cf9549" region="exp_rom" offset="0"/>
+		<input players="1">
+			<control type="stick" buttons="3" minimum="0" maximum="4095" sensitivity="100" keydelta="50"/>
+		</input>
+	</machine>
+	<machine name="bbc_cc500" sourcefile="devices/bus/bbc/1mhzbus/cc500.cpp" isdevice="yes" runnable="no">
+		<description>CTS Colour Card 500</description>
+		<rom name="cts_palette_1.10.rom" size="8192" crc="93533144" sha1="e645afdc5c7574a487ff484b79ea21a3b476f847" region="exp_rom" offset="0"/>
+		<device_ref tag=":_tmp:via" name="mos6522"/>
+		<device_ref tag=":_tmp:userport" name="bbc_userport_slot"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="0"/>
+		<slot name=":userport">
+			<slotoption name="amxmouse" devname="bbc_amxmouse"/>
+			<slotoption name="beebspch" devname="bbc_beebspch"/>
+			<slotoption name="chameleon" devname="bbc_chameleon"/>
+			<slotoption name="sdcard" devname="bbc_sdcard"/>
+			<slotoption name="lcd" devname="bbc_lcd"/>
+			<slotoption name="cpalette" devname="bbc_cpalette"/>
+			<slotoption name="m4000" devname="bbc_m4000"/>
+			<slotoption name="m512mouse" devname="bbc_m512mouse"/>
+			<slotoption name="usersplit" devname="bbc_usersplit"/>
+			<slotoption name="sdcardt" devname="bbc_sdcardt"/>
+			<slotoption name="lvlecho" devname="bbc_lvlecho"/>
+			<slotoption name="tracker" devname="bbc_tracker"/>
+			<slotoption name="voicebox" devname="bbc_voicebox"/>
+		</slot>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+	</machine>
+	<machine name="bbc_ccibase" sourcefile="devices/bus/bbc/rom/pal.cpp" isdevice="yes" runnable="no">
+		<description>Computer Concepts 64K ROM Carrier (Inter-Base)</description>
+	</machine>
+	<machine name="bbc_ccispell" sourcefile="devices/bus/bbc/rom/pal.cpp" isdevice="yes" runnable="no">
+		<description>Computer Concepts 128K ROM Carrier (SpellMaster)</description>
+	</machine>
+	<machine name="bbc_cciword" sourcefile="devices/bus/bbc/rom/pal.cpp" isdevice="yes" runnable="no">
+		<description>Computer Concepts 32K ROM Carrier (Inter-Word)</description>
+	</machine>
+	<machine name="bbc_chameleon" sourcefile="devices/bus/bbc/userport/palext.cpp" isdevice="yes" runnable="no">
+		<description>Micro User Chameleon (DIY)</description>
+		<rom name="chameleon.rom" size="8192" crc="e0ea0252" sha1="72cf334cdb866ba3dd2353fc7da0dfdb6abf63a7" region="exp_rom" offset="0"/>
+	</machine>
+	<machine name="bbc_click" sourcefile="devices/bus/bbc/cart/click.cpp" isdevice="yes" runnable="no">
+		<description>Slogger Click (Master 128) cartridge</description>
+		<input players="1">
+			<control type="only_buttons" buttons="1"/>
+		</input>
+	</machine>
+	<machine name="bbc_cpalette" sourcefile="devices/bus/bbc/userport/palext.cpp" isdevice="yes" runnable="no">
+		<description>Clwyd Technics Colour Palette</description>
+		<feature type="palette" status="imperfect"/>
+	</machine>
+	<machine name="bbc_datacentre" sourcefile="devices/bus/bbc/1mhzbus/datacentre.cpp" isdevice="yes" runnable="no">
+		<description>RetroClinic DataCentre</description>
+		<rom name="ramfs104.rom" size="16384" crc="2e52e331" sha1="d3c501fb29d35c2d144b164fa3ceb5a3b65d2850" region="exp_rom" offset="0"/>
+		<rom name="eeprom.bin" size="65536" crc="eb22a606" sha1="7d791234216c63a32b7181ff09c2f5fbdfc7f1a0" region="nvram" offset="0"/>
+		<rom name="nvrest_1.01.ssd" size="204800" crc="54b49e63" sha1="524826112e436728ba54e73f3f6b25c7b43abd69" region="nvrest" offset="0"/>
+		<device_ref tag=":_tmp:ide" name="ata_interface"/>
+		<device_ref tag=":_tmp:ide:0" name="ata_slot"/>
+		<device_ref tag=":_tmp:ide:1" name="ata_slot"/>
+		<device_ref tag=":_tmp:nvram" name="24c512"/>
+		<device_ref tag=":_tmp:import0" name="quickload"/>
+		<device_ref tag=":_tmp:import1" name="quickload"/>
+		<device_ref tag=":_tmp:import2" name="quickload"/>
+		<device_ref tag=":_tmp:import3" name="quickload"/>
+		<configuration name="JP1: IDE Power" tag=":LINKS" mask="1">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="1"/>
+		</configuration>
+		<configuration name="JP2: IDE Interrupt Enable" tag=":LINKS" mask="2">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="2"/>
+		</configuration>
+		<configuration name="JP3: NVRAM Write Protect" tag=":LINKS" mask="4">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="4"/>
+		</configuration>
+		<configuration name="Import NVRAM Restore Utility" tag=":NVREST" mask="1">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="1"/>
+		</configuration>
+		<device type="quickload" tag=":import0">
+			<instance name="quickload1" briefname="quik1"/>
+			<extension name="ssd"/>
+			<extension name="dsd"/>
+			<extension name="img"/>
+		</device>
+		<device type="quickload" tag=":import1">
+			<instance name="quickload2" briefname="quik2"/>
+			<extension name="ssd"/>
+			<extension name="dsd"/>
+			<extension name="img"/>
+		</device>
+		<device type="quickload" tag=":import2">
+			<instance name="quickload3" briefname="quik3"/>
+			<extension name="ssd"/>
+			<extension name="dsd"/>
+			<extension name="img"/>
+		</device>
+		<device type="quickload" tag=":import3">
+			<instance name="quickload4" briefname="quik4"/>
+			<extension name="ssd"/>
+			<extension name="dsd"/>
+			<extension name="img"/>
+		</device>
+		<slot name=":ide:0">
+			<slotoption name="px320a" devname="px320a"/>
+			<slotoption name="zip100" devname="zip100_ide"/>
+			<slotoption name="cr589" devname="cr589"/>
+			<slotoption name="cp2024" devname="cp2024"/>
+			<slotoption name="xm3301" devname="xm3301"/>
+			<slotoption name="cf" devname="atacf"/>
+			<slotoption name="cdrom" devname="cdrom"/>
+			<slotoption name="hdd" devname="idehd" default="yes"/>
+		</slot>
+		<slot name=":ide:1">
+			<slotoption name="px320a" devname="px320a"/>
+			<slotoption name="zip100" devname="zip100_ide"/>
+			<slotoption name="cr589" devname="cr589"/>
+			<slotoption name="cp2024" devname="cp2024"/>
+			<slotoption name="xm3301" devname="xm3301"/>
+			<slotoption name="cf" devname="atacf"/>
+			<slotoption name="cdrom" devname="cdrom"/>
+			<slotoption name="hdd" devname="idehd" default="yes"/>
+		</slot>
+	</machine>
+	<machine name="bbc_datagem" sourcefile="devices/bus/bbc/rom/datagem.cpp" isdevice="yes" runnable="no">
+		<description>Gemini DataGem ROM Carrier</description>
+	</machine>
+	<machine name="bbc_detalker" sourcefile="devices/bus/bbc/rom/detalker.cpp" isdevice="yes" runnable="no">
+		<description>D.E.Talker Speech Synthesizer</description>
+		<rom name="sp0256a-al2.bin" size="2048" crc="b504ac15" sha1="e60fcb5fa16ff3f3b69d36c7a6e955744d3feafc" region="sp0256" offset="1000"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:sp0256" name="sp0256"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":sp0256" name="GI SP0256 Narrator Speech Processor" clock="3276800"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="bbc_dfse00" sourcefile="devices/bus/bbc/rom/dfs.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro E00 DFS</description>
+	</machine>
+	<machine name="bbc_emrmidi" sourcefile="devices/bus/bbc/1mhzbus/emrmidi.cpp" isdevice="yes" runnable="no">
+		<description>EMR BBC MIDI Interface</description>
+		<device_ref tag=":_tmp:acia1" name="acia6850"/>
+		<device_ref tag=":_tmp:acia_clock" name="clock"/>
+		<device_ref tag=":_tmp:mdout1" name="midi_port"/>
+		<device_ref tag=":_tmp:mdout2" name="midi_port"/>
+		<device_ref tag=":_tmp:mdin" name="midi_port"/>
+		<slot name=":mdout1">
+			<slotoption name="midiout" devname="midiout_port" default="yes"/>
+		</slot>
+		<slot name=":mdout2">
+			<slotoption name="midiout" devname="midiout_port" default="yes"/>
+		</slot>
+		<slot name=":mdin">
+			<slotoption name="midiin" devname="midiin_port" default="yes"/>
+		</slot>
+	</machine>
+	<machine name="bbc_ide8" sourcefile="devices/bus/bbc/1mhzbus/ide.cpp" isdevice="yes" runnable="no">
+		<description>RetroClinic BBC 8-bit IDE Interface</description>
+		<device_ref tag=":_tmp:ide" name="ata_interface"/>
+		<device_ref tag=":_tmp:ide:0" name="ata_slot"/>
+		<device_ref tag=":_tmp:ide:1" name="ata_slot"/>
+		<slot name=":ide:0">
+			<slotoption name="px320a" devname="px320a"/>
+			<slotoption name="zip100" devname="zip100_ide"/>
+			<slotoption name="cr589" devname="cr589"/>
+			<slotoption name="cp2024" devname="cp2024"/>
+			<slotoption name="xm3301" devname="xm3301"/>
+			<slotoption name="cf" devname="atacf"/>
+			<slotoption name="cdrom" devname="cdrom"/>
+			<slotoption name="hdd" devname="idehd" default="yes"/>
+		</slot>
+		<slot name=":ide:1">
+			<slotoption name="px320a" devname="px320a"/>
+			<slotoption name="zip100" devname="zip100_ide"/>
+			<slotoption name="cr589" devname="cr589"/>
+			<slotoption name="cp2024" devname="cp2024"/>
+			<slotoption name="xm3301" devname="xm3301"/>
+			<slotoption name="cf" devname="atacf"/>
+			<slotoption name="cdrom" devname="cdrom"/>
+			<slotoption name="hdd" devname="idehd"/>
+		</slot>
+	</machine>
+	<machine name="bbc_ieee488" sourcefile="devices/bus/bbc/1mhzbus/ieee488.cpp" isdevice="yes" runnable="no">
+		<description>Acorn IEEE-488 Interface</description>
+		<biosset name="ieee05" description="IEEEFS 0.05" default="yes"/>
+		<biosset name="ieee02" description="IEEEFS 0.02"/>
+		<biosset name="ieee01" description="IEEEFS 0.01"/>
+		<rom name="ieeefs-0.5.rom" bios="ieee05" size="8192" crc="4c2e80ee" sha1="0bf33f0378657cf35a49f4f74be40c26ebcb9de5" region="exp_rom" offset="0"/>
+		<rom name="ieeefs-0.2.rom" bios="ieee02" size="8192" crc="73a7960c" sha1="86828db58e6d1d0a9aade9e73fb1fafd5b6aedff" region="exp_rom" offset="0"/>
+		<rom name="ieeefs-0.1.rom" bios="ieee01" size="8192" crc="69dfc98d" sha1="0d3fcb79e70cfa42eff8cc78bf29c2493898d6eb" region="exp_rom" offset="0"/>
+		<device_ref tag=":_tmp:hpib" name="tms9914"/>
+		<device_ref tag=":_tmp:ieee_bus" name="ieee488"/>
+		<device_ref tag=":_tmp:ieee_dev" name="ieee488_slot"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="0"/>
+		<slot name=":ieee_dev">
+			<slotoption name="c2040" devname="c2040"/>
+			<slotoption name="d9090" devname="d9090"/>
+			<slotoption name="c4023" devname="c4023"/>
+			<slotoption name="hardbox" devname="gpib_hardbox"/>
+			<slotoption name="c3040" devname="c3040"/>
+			<slotoption name="c4040" devname="c4040"/>
+			<slotoption name="c8050" devname="c8050"/>
+			<slotoption name="c8250" devname="c8250"/>
+			<slotoption name="shark" devname="gpib_mshark"/>
+			<slotoption name="softbox" devname="gpib_softbox"/>
+			<slotoption name="sfd1001" devname="sfd1001"/>
+			<slotoption name="c2031" devname="c2031"/>
+			<slotoption name="c8280" devname="c8280"/>
+			<slotoption name="d9060" devname="d9060"/>
+		</slot>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+	</machine>
+	<machine name="bbc_internal_slot" sourcefile="devices/bus/bbc/internal/internal.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro internal boards</description>
+	</machine>
+	<machine name="bbc_lcd" sourcefile="devices/bus/bbc/userport/lcd.cpp" isdevice="yes" runnable="no">
+		<description>Sprow LCD Display</description>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<device_ref tag=":_tmp:lcdc" name="hd44780"/>
+		<display tag=":screen" type="lcd" rotate="0" width="120" height="36" refresh="50.000000" />
+	</machine>
+	<machine name="bbc_lvlecho" sourcefile="devices/bus/bbc/userport/lvlecho.cpp" isdevice="yes" runnable="no">
+		<description>LVL Echo Keyboard</description>
+		<input players="1">
+			<control type="keyboard" buttons="61"/>
+		</input>
+	</machine>
+	<machine name="bbc_m2000" sourcefile="devices/bus/bbc/1mhzbus/m2000.cpp" isdevice="yes" runnable="no">
+		<description>Hybrid Music 2000 Interface</description>
+		<device_ref tag=":_tmp:irqs" name="ipt_merge_any_hi"/>
+		<device_ref tag=":_tmp:acia1" name="acia6850"/>
+		<device_ref tag=":_tmp:acia2" name="acia6850"/>
+		<device_ref tag=":_tmp:acia3" name="acia6850"/>
+		<device_ref tag=":_tmp:acia_clock" name="clock"/>
+		<device_ref tag=":_tmp:mdout1" name="midi_port"/>
+		<device_ref tag=":_tmp:mdout2" name="midi_port"/>
+		<device_ref tag=":_tmp:mdout3" name="midi_port"/>
+		<device_ref tag=":_tmp:mdin" name="midi_port"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="0"/>
+		<slot name=":mdout1">
+			<slotoption name="midiout" devname="midiout_port" default="yes"/>
+		</slot>
+		<slot name=":mdout2">
+			<slotoption name="midiout" devname="midiout_port" default="yes"/>
+		</slot>
+		<slot name=":mdout3">
+			<slotoption name="midiout" devname="midiout_port" default="yes"/>
+		</slot>
+		<slot name=":mdin">
+			<slotoption name="midiin" devname="midiin_port" default="yes"/>
+		</slot>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+	</machine>
+	<machine name="bbc_m3000" sourcefile="devices/bus/bbc/1mhzbus/m5000.cpp" isdevice="yes" runnable="no">
+		<description>Hybrid Music 3000 Expander</description>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:hybrid" name="htmusic"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":hybrid" name="Hybrid Technology Music System" clock="6000000"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="1"/>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+	</machine>
+	<machine name="bbc_m4000" sourcefile="devices/bus/bbc/userport/m4000.cpp" isdevice="yes" runnable="no">
+		<description>Hybrid Music 4000 Keyboard</description>
+		<input players="1">
+			<control type="keyboard" buttons="50"/>
+		</input>
+	</machine>
+	<machine name="bbc_m5000" sourcefile="devices/bus/bbc/1mhzbus/m5000.cpp" isdevice="yes" runnable="no">
+		<description>Hybrid Music 5000 Synthesiser</description>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:hybrid" name="htmusic"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<device_ref tag=":_tmp:flop_ls_hybrid" name="software_list"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":hybrid" name="Hybrid Technology Music System" clock="6000000"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="1"/>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+		<softwarelist tag=":flop_ls_hybrid" name="bbc_flop_hybrid" status="original" filter="M5000"/>
+	</machine>
+	<machine name="bbc_m512mouse" sourcefile="devices/bus/bbc/userport/pointer.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Master 512 Mouse</description>
+		<input players="1">
+			<control type="mouse" buttons="2" minimum="0" maximum="255" sensitivity="100"/>
+		</input>
+	</machine>
+	<machine name="bbc_m87" sourcefile="devices/bus/bbc/1mhzbus/m5000.cpp" isdevice="yes" runnable="no">
+		<description>Peartree Music 87 Synthesiser</description>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:hybrid" name="htmusic"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<device_ref tag=":_tmp:flop_ls_hybrid" name="software_list"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":hybrid" name="Hybrid Technology Music System" clock="6000000"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="1"/>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+		<softwarelist tag=":flop_ls_hybrid" name="bbc_flop_hybrid" status="original" filter="M87"/>
+	</machine>
+	<machine name="bbc_mastersd" sourcefile="devices/bus/bbc/cart/mastersd.cpp" isdevice="yes" runnable="no">
+		<description>MasterSD BBC Master SD Cartridge</description>
+		<device_ref tag=":_tmp:sdcard" name="spi_sdcard"/>
+		<device_ref tag=":_tmp:sdcard:image" name="harddisk_image"/>
+		<device type="harddisk" tag=":sdcard:image" interface="sdcard">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="bbc_mastersdr2" sourcefile="devices/bus/bbc/cart/mastersd.cpp" isdevice="yes" runnable="no">
+		<description>MasterSD R2 BBC Master SD Cartridge</description>
+		<device_ref tag=":_tmp:sdcard" name="spi_sdcard"/>
+		<device_ref tag=":_tmp:sdcard:image" name="harddisk_image"/>
+		<device type="harddisk" tag=":sdcard:image" interface="sdcard">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="bbc_mega256" sourcefile="devices/bus/bbc/cart/mega256.cpp" isdevice="yes" runnable="no">
+		<description>Solidisk Mega 256 cartridge</description>
+	</machine>
+	<machine name="bbc_meup" sourcefile="devices/bus/bbc/modem/meup.cpp" isdevice="yes" runnable="no">
+		<description>Master Extra User Port</description>
+		<device_ref tag=":_tmp:via" name="mos6522"/>
+		<device_ref tag=":_tmp:userport2" name="bbc_userport_slot"/>
+		<slot name=":userport2">
+			<slotoption name="amxmouse" devname="bbc_amxmouse"/>
+			<slotoption name="beebspch" devname="bbc_beebspch"/>
+			<slotoption name="chameleon" devname="bbc_chameleon"/>
+			<slotoption name="sdcard" devname="bbc_sdcard"/>
+			<slotoption name="lcd" devname="bbc_lcd"/>
+			<slotoption name="cpalette" devname="bbc_cpalette"/>
+			<slotoption name="m4000" devname="bbc_m4000"/>
+			<slotoption name="m512mouse" devname="bbc_m512mouse"/>
+			<slotoption name="usersplit" devname="bbc_usersplit"/>
+			<slotoption name="sdcardt" devname="bbc_sdcardt"/>
+			<slotoption name="lvlecho" devname="bbc_lvlecho"/>
+			<slotoption name="tracker" devname="bbc_tracker"/>
+			<slotoption name="voicebox" devname="bbc_voicebox"/>
+		</slot>
+	</machine>
+	<machine name="bbc_modem_slot" sourcefile="devices/bus/bbc/modem/modem.cpp" isdevice="yes" runnable="no">
+		<description>BBC Master Internal Modem port</description>
+	</machine>
+	<machine name="bbc_morleyaa" sourcefile="devices/bus/bbc/internal/morleyaa.cpp" isdevice="yes" runnable="no">
+		<description>Morley Electronics 'AA' Master ROM Expansion Board</description>
+		<rom name="masterboard_200.rom" size="16384" crc="d93738ec" sha1="c80f47e3f661b1636d21ff542c7a39a586008098" region="aa_rom" offset="0"/>
+		<device_ref tag=":_tmp:romslot0" name="bbc_romslot16"/>
+		<device_ref tag=":_tmp:romslot1" name="bbc_romslot16"/>
+		<device_ref tag=":_tmp:romslot2" name="bbc_romslot16"/>
+		<device_ref tag=":_tmp:romslot3" name="bbc_romslot16"/>
+		<device_ref tag=":_tmp:romslot4" name="bbc_romslot16"/>
+		<device_ref tag=":_tmp:romslot5" name="bbc_romslot16"/>
+		<device_ref tag=":_tmp:romslot6" name="bbc_romslot16"/>
+		<device_ref tag=":_tmp:romslot7" name="bbc_romslot16"/>
+		<device_ref tag=":_tmp:romslot8" name="bbc_romslot32"/>
+		<device_ref tag=":_tmp:romslot9" name="bbc_romslot32"/>
+		<device_ref tag=":_tmp:romslot10" name="bbc_romslot32"/>
+		<device_ref tag=":_tmp:romslot11" name="bbc_romslot32"/>
+		<device type="romimage" tag=":romslot0" interface="bbc_rom">
+			<instance name="romimage1" briefname="rom1"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot1" interface="bbc_rom">
+			<instance name="romimage2" briefname="rom2"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot2" interface="bbc_rom">
+			<instance name="romimage3" briefname="rom3"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot3" interface="bbc_rom">
+			<instance name="romimage4" briefname="rom4"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot4" interface="bbc_rom">
+			<instance name="romimage5" briefname="rom5"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot5" interface="bbc_rom">
+			<instance name="romimage6" briefname="rom6"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot6" interface="bbc_rom">
+			<instance name="romimage7" briefname="rom7"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot7" interface="bbc_rom">
+			<instance name="romimage8" briefname="rom8"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot8" interface="bbc_rom">
+			<instance name="romimage9" briefname="rom9"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot9" interface="bbc_rom">
+			<instance name="romimage10" briefname="rom10"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot10" interface="bbc_rom">
+			<instance name="romimage11" briefname="rom11"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot11" interface="bbc_rom">
+			<instance name="romimage12" briefname="rom12"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<slot name=":romslot0">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot1">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot2">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot3">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot4">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot5">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot6">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot7">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot8">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot9">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot10">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot11">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+	</machine>
+	<machine name="bbc_mr8000" sourcefile="devices/bus/bbc/cart/mr8000.cpp" isdevice="yes" runnable="no">
+		<description>MR8000 Master RAM Cartridge</description>
+		<configuration name="ROM Choice" tag=":SWITCH" mask="3">
+			<confsetting name="A (lower banks)" value="0" default="yes"/>
+			<confsetting name="B (upper banks)" value="1"/>
+			<confsetting name="Off (disabled)" value="2"/>
+		</configuration>
+		<configuration name="Write Protect" tag=":SWITCH" mask="4">
+			<confsetting name="On (read only" value="0" default="yes"/>
+			<confsetting name="Off (read and write)" value="4"/>
+		</configuration>
+	</machine>
+	<machine name="bbc_msc" sourcefile="devices/bus/bbc/cart/msc.cpp" isdevice="yes" runnable="no">
+		<description>Master Smart Cartridge</description>
+		<input players="1">
+			<control type="only_buttons" buttons="1"/>
+		</input>
+	</machine>
+	<machine name="bbc_multiform" sourcefile="devices/bus/bbc/1mhzbus/multiform.cpp" isdevice="yes" runnable="no">
+		<description>PEDL Multiform Z80</description>
+		<rom name="osmv200.rom" size="8192" crc="67ce1713" sha1="314ee6211a7af6cab659640fbdd11f1078460f08" region="osm" offset="0"/>
+		<rom name="osmz80v137.rom" size="16384" crc="79a8de8f" sha1="0bc06ce54ab9a2242294bbbe9ce8f07e464bb674" region="exp_rom" offset="0"/>
+		<device_ref tag=":_tmp:z80" name="z80"/>
+		<device_ref tag=":_tmp:host_latch0" name="generic_latch_8"/>
+		<device_ref tag=":_tmp:host_latch1" name="generic_latch_8"/>
+		<device_ref tag=":_tmp:parasite_latch0" name="generic_latch_8"/>
+		<device_ref tag=":_tmp:parasite_latch1" name="generic_latch_8"/>
+		<device_ref tag=":_tmp:flop_ls_z80" name="software_list"/>
+		<chip type="cpu" tag=":z80" name="Zilog Z80" clock="4000000"/>
+		<softwarelist tag=":flop_ls_z80" name="bbc_flop_z80" status="original"/>
+	</machine>
+	<machine name="bbc_nvram" sourcefile="devices/bus/bbc/rom/nvram.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro Sideways RAM (Battery Backup)</description>
+	</machine>
+	<machine name="bbc_opusa" sourcefile="devices/bus/bbc/1mhzbus/opus3.cpp" isdevice="yes" runnable="no">
+		<description>Opus Challenger ADFS</description>
+		<biosset name="ch200" description="Challenger ADFS" default="yes"/>
+		<rom name="challenger adfs_dfs.rom" bios="ch200" size="32768" crc="e922c19a" sha1="b9f5c749412528e4f8e9cda9f13e10f8405bb195" region="exp_rom" offset="0"/>
+		<device_ref tag=":_tmp:wd1770" name="wd1770"/>
+		<device_ref tag=":_tmp:wd1770:0" name="floppy_connector"/>
+		<device_ref tag=":_tmp:wd1770:1" name="floppy_connector"/>
+		<device_ref tag=":_tmp:ramdisk" name="ram"/>
+		<slot name=":wd1770:0">
+			<slotoption name="525qd" devname="floppy_525_qd" default="yes"/>
+		</slot>
+		<slot name=":wd1770:1">
+			<slotoption name="525qd" devname="floppy_525_qd"/>
+		</slot>
+	</machine>
+	<machine name="bbc_overlay" sourcefile="devices/bus/bbc/internal/overlay.cpp" isdevice="yes" runnable="no">
+		<description>Vine Micros Romboard '3' (Master OS Overlay)</description>
+		<device_ref tag=":_tmp:romslot0" name="bbc_romslot16"/>
+		<device_ref tag=":_tmp:romslot1" name="bbc_romslot16"/>
+		<device_ref tag=":_tmp:romslot2" name="bbc_romslot16"/>
+		<configuration name="ROM 1" tag=":link_rom1" mask="31">
+			<confsetting name="Operating System (reserved)" value="16"/>
+			<confsetting name="1770 DFS" value="9"/>
+			<confsetting name="Viewsheet" value="10" default="yes"/>
+			<confsetting name="Edit" value="11"/>
+			<confsetting name="BASIC" value="12"/>
+			<confsetting name="ADFS" value="13"/>
+			<confsetting name="View (and some GXR)" value="14"/>
+			<confsetting name="Terminal and Operating System (reserved)" value="15"/>
+		</configuration>
+		<configuration name="ROM 2" tag=":link_rom2" mask="31">
+			<confsetting name="Operating System (reserved)" value="16"/>
+			<confsetting name="1770 DFS" value="9"/>
+			<confsetting name="Viewsheet" value="10"/>
+			<confsetting name="Edit" value="11" default="yes"/>
+			<confsetting name="BASIC" value="12"/>
+			<confsetting name="ADFS" value="13"/>
+			<confsetting name="View (and some GXR)" value="14"/>
+			<confsetting name="Terminal and Operating System (reserved)" value="15"/>
+		</configuration>
+		<configuration name="ROM 3" tag=":link_rom3" mask="31">
+			<confsetting name="Operating System (reserved)" value="16"/>
+			<confsetting name="1770 DFS" value="9"/>
+			<confsetting name="Viewsheet" value="10"/>
+			<confsetting name="Edit" value="11"/>
+			<confsetting name="BASIC" value="12"/>
+			<confsetting name="ADFS" value="13"/>
+			<confsetting name="View (and some GXR)" value="14" default="yes"/>
+			<confsetting name="Terminal and Operating System (reserved)" value="15"/>
+		</configuration>
+		<device type="romimage" tag=":romslot0" interface="bbc_rom">
+			<instance name="romimage1" briefname="rom1"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot1" interface="bbc_rom">
+			<instance name="romimage2" briefname="rom2"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<device type="romimage" tag=":romslot2" interface="bbc_rom">
+			<instance name="romimage3" briefname="rom3"/>
+			<extension name="rom"/>
+			<extension name="bin"/>
+		</device>
+		<slot name=":romslot0">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot1">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+		<slot name=":romslot2">
+			<slotoption name="ram" devname="bbc_ram"/>
+		</slot>
+	</machine>
+	<machine name="bbc_palabe" sourcefile="devices/bus/bbc/rom/pal.cpp" isdevice="yes" runnable="no">
+		<description>P.R.E.S. 32K ROM Carrier (ABE)</description>
+	</machine>
+	<machine name="bbc_palabep" sourcefile="devices/bus/bbc/rom/pal.cpp" isdevice="yes" runnable="no">
+		<description>P.R.E.S. 32K ROM Carrier (ABE+)</description>
+	</machine>
+	<machine name="bbc_palmo2" sourcefile="devices/bus/bbc/rom/pal.cpp" isdevice="yes" runnable="no">
+		<description>Instant Mini Office 2 ROM Carrier</description>
+	</machine>
+	<machine name="bbc_palqst" sourcefile="devices/bus/bbc/rom/pal.cpp" isdevice="yes" runnable="no">
+		<description>Watford Electronics ROM Carrier (Quest Paint)</description>
+	</machine>
+	<machine name="bbc_palted" sourcefile="devices/bus/bbc/rom/pal.cpp" isdevice="yes" runnable="no">
+		<description>Watford Electronics ROM Carrier (TED)</description>
+	</machine>
+	<machine name="bbc_palwap" sourcefile="devices/bus/bbc/rom/pal.cpp" isdevice="yes" runnable="no">
+		<description>Watford Electronics ROM Carrier (Wapping Editor)</description>
+	</machine>
+	<machine name="bbc_pdram" sourcefile="devices/bus/bbc/1mhzbus/pdram.cpp" isdevice="yes" runnable="no">
+		<description>Micro User Pull Down RAM (DIY)</description>
+		<rom name="ramdvr.rom" size="8192" crc="56f61728" sha1="265359d1fb9c0adca53912aa6a42a995b8225a3e" region="exp_rom" offset="0"/>
+	</machine>
+	<machine name="bbc_pms64k" sourcefile="devices/bus/bbc/1mhzbus/pms64k.cpp" isdevice="yes" runnable="no">
+		<description>PMS 64K Non-Volatile Ram Module</description>
+		<rom name="pms_utility_12d.rom" size="16384" crc="c630990e" sha1="da9abe3b1b0bf34ee5d6ed7ee032686403436289" region="exp_rom" offset="0"/>
+		<device_ref tag=":_tmp:nvram" name="nvram"/>
+	</machine>
+	<machine name="bbc_pmsgenie" sourcefile="devices/bus/bbc/rom/genie.cpp" isdevice="yes" runnable="no">
+		<description>PMS Genie ROM Board</description>
+	</machine>
+	<machine name="bbc_pmsrtc" sourcefile="devices/bus/bbc/rom/rtc.cpp" isdevice="yes" runnable="no">
+		<description>PMS Genie Real Time Clock</description>
+		<device_ref tag=":_tmp:rtc" name="ds1216e"/>
+	</machine>
+	<machine name="bbc_quinkey_intf" sourcefile="devices/bus/bbc/analogue/quinkey.cpp" isdevice="yes" runnable="no">
+		<description>Microwriter Quinkey Interface</description>
+		<device_ref tag=":_tmp:1" name="bbc_quinkey_slot"/>
+		<device_ref tag=":_tmp:2" name="bbc_quinkey_slot"/>
+		<device_ref tag=":_tmp:3" name="bbc_quinkey_slot"/>
+		<device_ref tag=":_tmp:4" name="bbc_quinkey_slot"/>
+		<slot name=":1">
+			<slotoption name="quinkey" devname="bbc_quinkey" default="yes"/>
+		</slot>
+		<slot name=":2">
+			<slotoption name="quinkey" devname="bbc_quinkey"/>
+		</slot>
+		<slot name=":3">
+			<slotoption name="quinkey" devname="bbc_quinkey"/>
+		</slot>
+		<slot name=":4">
+			<slotoption name="quinkey" devname="bbc_quinkey"/>
+		</slot>
+	</machine>
+	<machine name="bbc_quinkey_slot" sourcefile="devices/bus/bbc/analogue/quinkey.cpp" isdevice="yes" runnable="no">
+		<description>Microwriter Quinkey slot</description>
+	</machine>
+	<machine name="bbc_ram" sourcefile="devices/bus/bbc/rom/ram.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro Sideways RAM</description>
+	</machine>
+	<machine name="bbc_ramdisc" sourcefile="devices/bus/bbc/1mhzbus/ramdisc.cpp" isdevice="yes" runnable="no">
+		<description>Morley Electronics RAM Disc</description>
+		<rom name="ramdisc101.rom" size="16384" crc="627568c2" sha1="17e727998756fe35ff451fd2ce1d4b5977be24fc" region="exp_rom" offset="0"/>
+		<device_ref tag=":_tmp:nvram" name="nvram"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="0"/>
+		<configuration name="Power" tag=":POWER" mask="1">
+			<confsetting name="Off" value="0"/>
+			<confsetting name="On" value="1" default="yes"/>
+		</configuration>
+		<configuration name="RAM Disk Capacity" tag=":SIZE" mask="3">
+			<confsetting name="1MB" value="1"/>
+			<confsetting name="2MB" value="2" default="yes"/>
+		</configuration>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+	</machine>
+	<machine name="bbc_rom" sourcefile="devices/bus/bbc/rom/rom.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro Sideways ROM</description>
+	</machine>
+	<machine name="bbc_romslot16" sourcefile="devices/bus/bbc/rom/slot.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro 16K ROM Slot</description>
+	</machine>
+	<machine name="bbc_romslot32" sourcefile="devices/bus/bbc/rom/slot.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro 32K ROM Slot</description>
+	</machine>
+	<machine name="bbc_scsiaiv" sourcefile="devices/bus/bbc/modem/scsiaiv.cpp" isdevice="yes" runnable="no">
+		<description>Acorn AIV SCSI Host Adaptor</description>
+		<device_ref tag=":_tmp:scsi" name="nscsi_bus"/>
+		<device_ref tag=":_tmp:scsi:0" name="nscsi_connector"/>
+		<device_ref tag=":_tmp:scsi:7" name="nscsi_connector"/>
+		<slot name=":scsi:0">
+			<slotoption name="pc98_hd" devname="scsi_pc98_hd"/>
+			<slotoption name="cfp1080s" devname="cfp1080s"/>
+			<slotoption name="aplcdsc_ext" devname="scsi_cdrom_apple_ext"/>
+			<slotoption name="aplcdsc" devname="scsi_cdrom_apple"/>
+			<slotoption name="aplcd150" devname="aplcd150"/>
+			<slotoption name="crd254sh" devname="crd254sh"/>
+			<slotoption name="sa1403d" devname="nscsi_sa1403d"/>
+			<slotoption name="tape" devname="scsi_tape"/>
+			<slotoption name="s1410" devname="scsi_s1410"/>
+			<slotoption name="dtc510" devname="scsi_dtc510"/>
+			<slotoption name="harddisk" devname="scsi_harddisk"/>
+			<slotoption name="cw7501" devname="cw7501"/>
+			<slotoption name="cdr4210" devname="cdr4210"/>
+			<slotoption name="cdu561_25" devname="cdu561_25"/>
+			<slotoption name="cdrom" devname="scsi_cdrom"/>
+			<slotoption name="cdu415" devname="cdu415"/>
+			<slotoption name="smoc501" devname="smoc501"/>
+			<slotoption name="cdd2000" devname="cdd2000"/>
+			<slotoption name="cdrom_2x" devname="scsi_cdrom2x"/>
+			<slotoption name="cdrn820s" devname="cdrn820s"/>
+			<slotoption name="cdu75s" devname="cdu75s"/>
+		</slot>
+	</machine>
+	<machine name="bbc_sdcard" sourcefile="devices/bus/bbc/userport/sdcard.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro SD Card</description>
+		<device_ref tag=":_tmp:sdcard" name="spi_sdcard"/>
+		<device_ref tag=":_tmp:sdcard:image" name="harddisk_image"/>
+		<device type="harddisk" tag=":sdcard:image" interface="sdcard">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="bbc_sdcardt" sourcefile="devices/bus/bbc/userport/sdcard.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro Turbo SD Card</description>
+		<device_ref tag=":_tmp:sdcard" name="spi_sdcard"/>
+		<device_ref tag=":_tmp:sdcard:image" name="harddisk_image"/>
+		<device type="harddisk" tag=":sdcard:image" interface="sdcard">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="bbc_sprite" sourcefile="devices/bus/bbc/1mhzbus/sprite.cpp" isdevice="yes" runnable="no">
+		<description>Logotron Sprite Board</description>
+		<device_ref tag=":_tmp:vdp" name="tms9129"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<display tag=":screen" type="raster" rotate="0" width="280" height="216" refresh="50.158969" pixclock="5369317" htotal="342" hbend="25" hbstart="305" vtotal="313" vbend="52" vbstart="268" />
+	</machine>
+	<machine name="bbc_stlrtc" sourcefile="devices/bus/bbc/rom/rtc.cpp" isdevice="yes" runnable="no">
+		<description>Solidisk Real Time Clock</description>
+		<device_ref tag=":_tmp:rtc" name="mc146818"/>
+	</machine>
+	<machine name="bbc_torchhd" sourcefile="devices/bus/bbc/1mhzbus/sasi.cpp" isdevice="yes" runnable="no">
+		<description>Torch Hard Disc Pack</description>
+		<device_ref tag=":_tmp:sasi" name="nscsi_bus"/>
+		<device_ref tag=":_tmp:sasi:0" name="nscsi_connector"/>
+		<device_ref tag=":_tmp:sasi:7" name="nscsi_connector"/>
+	</machine>
+	<machine name="bbc_tracker" sourcefile="devices/bus/bbc/userport/pointer.cpp" isdevice="yes" runnable="no">
+		<description>Marconi RB2 Tracker Ball</description>
+		<input players="1">
+			<control type="trackball" buttons="3" minimum="0" maximum="255" sensitivity="100"/>
+		</input>
+	</machine>
+	<machine name="bbc_trilogy" sourcefile="devices/bus/bbc/rom/pal.cpp" isdevice="yes" runnable="no">
+		<description>Acornsoft Trilogy Emulator</description>
+	</machine>
+	<machine name="bbc_tube_32016" sourcefile="devices/bus/bbc/tube/tube_32016.cpp" isdevice="yes" runnable="no">
+		<description>Acorn 32016 2nd processor</description>
+		<biosset name="200" description="Pandora v2.00"/>
+		<biosset name="100" description="Pandora v1.00"/>
+		<biosset name="061" description="Pandora v0.61"/>
+		<rom name="pan200lo.rom" bios="200" size="16384" crc="b1980fd0" sha1="8084f8896cd22953abefbd43c51e1a422b30e28d" region="rom" offset="0"/>
+		<rom name="pan200hi.rom" bios="200" size="16384" crc="cab98d6b" sha1="dfad1f4180c50757a74fcfe3a0ee7d7b48eb1bee" region="rom" offset="1"/>
+		<rom name="pan100lo.rom" bios="100" size="8192" crc="101e8aca" sha1="4998e64afe98b2f227df6daa7ae0af512ce8907a" region="rom" offset="0"/>
+		<rom name="pan100hi.rom" bios="100" size="8192" crc="139de9ed" sha1="1871e65c9ebd3eac835b0317b0ad8272ff207c4b" region="rom" offset="1"/>
+		<rom name="pan061lo.rom" bios="061" size="16384" crc="6f801b35" sha1="ce31f7c10603f3d15a06a8e32bde40df0639e446" region="rom" offset="0"/>
+		<rom name="pan061hi.rom" bios="061" size="16384" crc="c00b1ab0" sha1="e6a705232278c518340ddc69ea51af91965fa332" region="rom" offset="1"/>
+		<device_ref tag=":_tmp:maincpu" name="ns32016"/>
+		<device_ref tag=":_tmp:ns32081" name="ns32081"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:flop_ls_32016" name="software_list"/>
+		<chip type="cpu" tag=":maincpu" name="National Semiconductor NS32016" clock="6000000"/>
+		<dipswitch name="H" tag=":CONFIG" mask="1">
+			<diplocation name="LKS" number="1"/>
+			<dipvalue name="FPU" value="1" default="yes"/>
+			<dipvalue name="No FPU" value="0"/>
+		</dipswitch>
+		<dipswitch name="G" tag=":CONFIG" mask="2">
+			<diplocation name="LKS" number="2"/>
+			<dipvalue name="MMU" value="2"/>
+			<dipvalue name="No MMU" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="F" tag=":CONFIG" mask="4">
+			<diplocation name="LKS" number="3"/>
+			<dipvalue name="Reserved" value="4"/>
+			<dipvalue name="Reserved" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="E" tag=":CONFIG" mask="8">
+			<diplocation name="LKS" number="4"/>
+			<dipvalue name="Reserved" value="8"/>
+			<dipvalue name="Reserved" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="D" tag=":CONFIG" mask="16">
+			<diplocation name="LKS" number="5"/>
+			<dipvalue name="Reserved" value="16"/>
+			<dipvalue name="Reserved" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="C" tag=":CONFIG" mask="32">
+			<diplocation name="LKS" number="6"/>
+			<dipvalue name="Reserved" value="32"/>
+			<dipvalue name="Reserved" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="B" tag=":CONFIG" mask="64">
+			<diplocation name="LKS" number="7"/>
+			<dipvalue name="Reserved" value="64"/>
+			<dipvalue name="Reserved" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="A" tag=":CONFIG" mask="128">
+			<diplocation name="LKS" number="8"/>
+			<dipvalue name="Reserved" value="128"/>
+			<dipvalue name="Reserved" value="0" default="yes"/>
+		</dipswitch>
+		<softwarelist tag=":flop_ls_32016" name="bbc_flop_32016" status="original"/>
+	</machine>
+	<machine name="bbc_tube_32016l" sourcefile="devices/bus/bbc/tube/tube_32016.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Large 32016 2nd processor</description>
+		<biosset name="200" description="Pandora v2.00"/>
+		<rom name="pan200lo.rom" bios="200" size="16384" crc="b1980fd0" sha1="8084f8896cd22953abefbd43c51e1a422b30e28d" region="rom" offset="0"/>
+		<rom name="pan200hi.rom" bios="200" size="16384" crc="cab98d6b" sha1="dfad1f4180c50757a74fcfe3a0ee7d7b48eb1bee" region="rom" offset="1"/>
+		<device_ref tag=":_tmp:maincpu" name="ns32016"/>
+		<device_ref tag=":_tmp:ns32081" name="ns32081"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:flop_ls_32016" name="software_list"/>
+		<chip type="cpu" tag=":maincpu" name="National Semiconductor NS32016" clock="8000000"/>
+		<dipswitch name="H" tag=":CONFIG" mask="1">
+			<diplocation name="LKS" number="1"/>
+			<dipvalue name="FPU" value="1" default="yes"/>
+			<dipvalue name="No FPU" value="0"/>
+		</dipswitch>
+		<dipswitch name="G" tag=":CONFIG" mask="2">
+			<diplocation name="LKS" number="2"/>
+			<dipvalue name="MMU" value="2"/>
+			<dipvalue name="No MMU" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="F" tag=":CONFIG" mask="4">
+			<diplocation name="LKS" number="3"/>
+			<dipvalue name="Reserved" value="4"/>
+			<dipvalue name="Reserved" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="E" tag=":CONFIG" mask="8">
+			<diplocation name="LKS" number="4"/>
+			<dipvalue name="Reserved" value="8"/>
+			<dipvalue name="Reserved" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="D" tag=":CONFIG" mask="16">
+			<diplocation name="LKS" number="5"/>
+			<dipvalue name="Reserved" value="16"/>
+			<dipvalue name="Reserved" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="C" tag=":CONFIG" mask="32">
+			<diplocation name="LKS" number="6"/>
+			<dipvalue name="Reserved" value="32"/>
+			<dipvalue name="Reserved" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="B" tag=":CONFIG" mask="64">
+			<diplocation name="LKS" number="7"/>
+			<dipvalue name="Reserved" value="64"/>
+			<dipvalue name="Reserved" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="A" tag=":CONFIG" mask="128">
+			<diplocation name="LKS" number="8"/>
+			<dipvalue name="Reserved" value="128"/>
+			<dipvalue name="Reserved" value="0" default="yes"/>
+		</dipswitch>
+		<softwarelist tag=":flop_ls_32016" name="bbc_flop_32016" status="original"/>
+	</machine>
+	<machine name="bbc_tube_6502" sourcefile="devices/bus/bbc/tube/tube_6502.cpp" isdevice="yes" runnable="no">
+		<description>Acorn 6502 2nd Processor</description>
+		<biosset name="110" description="Tube 1.10" default="yes"/>
+		<biosset name="120" description="Tube 1.20"/>
+		<biosset name="121" description="Tube 1.21 (ReCo6502)"/>
+		<rom name="6502tube_110.rom" bios="110" size="4096" crc="98b5fe42" sha1="338269d03cf6bfa28e09d1651c273ea53394323b" region="rom" offset="0"/>
+		<rom name="6502tube_120.rom" bios="120" size="4096" crc="50c36da5" sha1="80e5f1c03a00cf728917242522befc17b264413f" region="rom" offset="0"/>
+		<rom name="reco6502tube.rom" bios="121" size="4096" crc="75b2a466" sha1="9ecef24de58a48c3fbe01b12888c3f6a5d24f57f" region="rom" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="g65sc02"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:flop_ls_6502" name="software_list"/>
+		<chip type="cpu" tag=":maincpu" name="GTE G65SC02" clock="3000000"/>
+		<softwarelist tag=":flop_ls_6502" name="bbc_flop_6502" status="original"/>
+	</machine>
+	<machine name="bbc_tube_6502e" sourcefile="devices/bus/bbc/tube/tube_6502.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Extended 6502 2nd Processor</description>
+		<biosset name="120" description="Tube 1.20" default="yes"/>
+		<rom name="6502tube256_120.rom" bios="120" size="4096" crc="967ee712" sha1="ebca4bb471cd18608882668edda811ed88b4cee5" status="baddump" region="rom" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="g65sc02"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:flop_ls_6502" name="software_list"/>
+		<chip type="cpu" tag=":maincpu" name="GTE G65SC02" clock="3000000"/>
+		<softwarelist tag=":flop_ls_6502" name="bbc_flop_6502" status="original"/>
+	</machine>
+	<machine name="bbc_tube_65c102" sourcefile="devices/bus/bbc/tube/tube_6502.cpp" isdevice="yes" runnable="no">
+		<description>Acorn 65C102 Co-Processor</description>
+		<biosset name="110" description="Tube 1.10" default="yes"/>
+		<biosset name="120" description="Tube 1.20"/>
+		<biosset name="121" description="Tube 1.21 (ReCo6502)"/>
+		<rom name="65c102_boot_110.rom" bios="110" size="4096" crc="ad5b70cc" sha1="0ac9a1c70e55a79e2c81e102afae1d016af229fa" region="rom" offset="0"/>
+		<rom name="65c102_boot_120.rom" bios="120" size="4096" crc="1462f0f7" sha1="7dc03d3c4862159baefebf1662de7e05987ddf7b" region="rom" offset="0"/>
+		<rom name="reco6502tube.rom" bios="121" size="4096" crc="75b2a466" sha1="9ecef24de58a48c3fbe01b12888c3f6a5d24f57f" region="rom" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="r65c102"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:flop_ls_6502" name="software_list"/>
+		<chip type="cpu" tag=":maincpu" name="Rockwell R65C102" clock="16000000"/>
+		<softwarelist tag=":flop_ls_6502" name="bbc_flop_6502" status="original"/>
+	</machine>
+	<machine name="bbc_tube_80186" sourcefile="devices/bus/bbc/tube/tube_80186.cpp" isdevice="yes" runnable="no">
+		<description>Acorn 80186 Co-Processor</description>
+		<rom name="m512_lo_ic31.rom" size="8192" crc="c0df8707" sha1="7f6d843d5aea6bdb36cbd4623ae942b16b96069d" region="bootstrap" offset="0"/>
+		<rom name="m512_hi_ic32.rom" size="8192" crc="e47f10b2" sha1="45dc8d7e7936afbec6de423569d9005a1c350316" region="bootstrap" offset="1"/>
+		<device_ref tag=":_tmp:i80186" name="i80186"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:flop_ls_80186" name="software_list"/>
+		<device_ref tag=":_tmp:pc_disk_list" name="software_list"/>
+		<chip type="cpu" tag=":i80186" name="Intel 80186" clock="20000000"/>
+		<softwarelist tag=":flop_ls_80186" name="bbc_flop_80186" status="original"/>
+		<softwarelist tag=":pc_disk_list" name="ibm5150" status="compatible"/>
+	</machine>
+	<machine name="bbc_tube_80286" sourcefile="devices/bus/bbc/tube/tube_80286.cpp" isdevice="yes" runnable="no">
+		<description>Acorn 80286 2nd Processor</description>
+		<rom name="m512_lo.ic31" size="8192" crc="c0df8707" sha1="7f6d843d5aea6bdb36cbd4623ae942b16b96069d" region="bootstrap" offset="0"/>
+		<rom name="m512_hi.ic32" size="8192" crc="e47f10b2" sha1="45dc8d7e7936afbec6de423569d9005a1c350316" region="bootstrap" offset="1"/>
+		<device_ref tag=":_tmp:i80286" name="i80286"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:flop_ls_80186" name="software_list"/>
+		<device_ref tag=":_tmp:pc_disk_list" name="software_list"/>
+		<chip type="cpu" tag=":i80286" name="Intel 80286" clock="6000000"/>
+		<softwarelist tag=":flop_ls_80186" name="bbc_flop_80186" status="original"/>
+		<softwarelist tag=":pc_disk_list" name="ibm5150" status="compatible"/>
+	</machine>
+	<machine name="bbc_tube_a500" sourcefile="devices/bus/bbc/tube/tube_a500.cpp" isdevice="yes" runnable="no">
+		<description>Acorn A500 2nd Processor</description>
+		<rom name="0.bin" size="16384" crc="7ecfeb0e" sha1="f9cd49f86e4b210cde6b14752cdbc2962e86551f" region="maincpu" offset="0"/>
+		<rom name="1.bin" size="16384" crc="f3bf6c3b" sha1="e66496a1bf7a7f7bf300e8baebc40a4b37c19c1e" region="maincpu" offset="1"/>
+		<rom name="2.bin" size="16384" crc="6b73d4af" sha1="7ebc8c7268cda6c8bd4dcbf3b63a7ffff4d2c43c" region="maincpu" offset="2"/>
+		<rom name="3.bin" size="16384" crc="607f2f49" sha1="c46448435b86d1397c7cb144bece87e73a9220aa" region="maincpu" offset="3"/>
+		<device_ref tag=":_tmp:maincpu" name="arm_cpu"/>
+		<device_ref tag=":_tmp:fiqs" name="ipt_merge_any_hi"/>
+		<device_ref tag=":_tmp:irqs" name="ipt_merge_any_hi"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:memc" name="memc"/>
+		<device_ref tag=":_tmp:ioc" name="ioc"/>
+		<device_ref tag=":_tmp:keyboard" name="archimedes_keyboard"/>
+		<device_ref tag=":_tmp:keyboard:mcu" name="i8051"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:vidc" name="acorn_vidc1"/>
+		<device_ref tag=":_tmp:vidc:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:vidc:dac0" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac1" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac2" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac3" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac4" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac5" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac6" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac7" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:flop_list" name="software_list"/>
+		<chip type="cpu" tag=":maincpu" name="ARM" clock="8000000"/>
+		<chip type="cpu" tag=":keyboard:mcu" name="Intel 8051" clock="12000000"/>
+		<chip type="audio" tag=":vidc:speaker" name="Speaker"/>
+		<chip type="audio" tag=":vidc:dac0" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac1" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac2" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac3" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac4" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac5" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac6" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac7" name="16-Bit R-2R Twos Complement DAC"/>
+		<display tag=":screen" type="raster" rotate="0" width="735" height="292" refresh="50.080128" pixclock="16000000" htotal="1024" hbend="0" hbstart="735" vtotal="312" vbend="0" vbstart="292" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="mouse" minimum="0" maximum="65535" sensitivity="100"/>
+			<control type="keyboard" buttons="106"/>
+		</input>
+		<softwarelist tag=":flop_list" name="bbc_flop_arm" status="original" filter="A500"/>
+	</machine>
+	<machine name="bbc_tube_a500d" sourcefile="devices/bus/bbc/tube/tube_a500.cpp" isdevice="yes" runnable="no">
+		<description>Acorn A500 (Dual MEMC) 2nd Processor</description>
+		<rom name="m4_brazil_8mbaddr_rom0.bin" size="16384" crc="f01fb7a6" sha1="840a15882797572db4764f37b725cf9c5a07a8cb" region="maincpu" offset="0"/>
+		<rom name="m4_brazil_8mbaddr_rom1.bin" size="16384" crc="924e4181" sha1="4f1903ef83cb6e0cef130005b0442a6548915b8a" region="maincpu" offset="1"/>
+		<rom name="m4_brazil_8mbaddr_rom2.bin" size="16384" crc="c210e9a5" sha1="ee09b8bac275153467ec31f7a16c366a0f97b550" region="maincpu" offset="2"/>
+		<rom name="m4_brazil_8mbaddr_rom3.bin" size="16384" crc="1e520555" sha1="9b6bdeef8d7fb22ef0203c2f531a4e0a55e22c6f" region="maincpu" offset="3"/>
+		<device_ref tag=":_tmp:maincpu" name="arm_cpu"/>
+		<device_ref tag=":_tmp:fiqs" name="ipt_merge_any_hi"/>
+		<device_ref tag=":_tmp:irqs" name="ipt_merge_any_hi"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:memc" name="memc"/>
+		<device_ref tag=":_tmp:ioc" name="ioc"/>
+		<device_ref tag=":_tmp:keyboard" name="archimedes_keyboard"/>
+		<device_ref tag=":_tmp:keyboard:mcu" name="i8051"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:vidc" name="acorn_vidc1"/>
+		<device_ref tag=":_tmp:vidc:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:vidc:dac0" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac1" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac2" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac3" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac4" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac5" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac6" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:vidc:dac7" name="dac_16bit_r2r_tc"/>
+		<device_ref tag=":_tmp:flop_list" name="software_list"/>
+		<chip type="cpu" tag=":maincpu" name="ARM" clock="8000000"/>
+		<chip type="cpu" tag=":keyboard:mcu" name="Intel 8051" clock="12000000"/>
+		<chip type="audio" tag=":vidc:speaker" name="Speaker"/>
+		<chip type="audio" tag=":vidc:dac0" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac1" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac2" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac3" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac4" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac5" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac6" name="16-Bit R-2R Twos Complement DAC"/>
+		<chip type="audio" tag=":vidc:dac7" name="16-Bit R-2R Twos Complement DAC"/>
+		<display tag=":screen" type="raster" rotate="0" width="735" height="292" refresh="50.080128" pixclock="16000000" htotal="1024" hbend="0" hbstart="735" vtotal="312" vbend="0" vbstart="292" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="mouse" minimum="0" maximum="65535" sensitivity="100"/>
+			<control type="keyboard" buttons="106"/>
+		</input>
+		<softwarelist tag=":flop_list" name="bbc_flop_arm" status="original" filter="A500"/>
+	</machine>
+	<machine name="bbc_tube_arm" sourcefile="devices/bus/bbc/tube/tube_arm.cpp" isdevice="yes" runnable="no">
+		<description>ARM Evaluation System</description>
+		<biosset name="101" description="Executive v1.00 (14th August 1986)" default="yes"/>
+		<biosset name="100" description="Executive v1.00 (6th June 1986)"/>
+		<biosset name="006" description="Brazil v-.006 (11th July 1986)"/>
+		<biosset name="005" description="Brazil v-.005 (8th August 1986)"/>
+		<rom name="armeval_101.rom" bios="101" size="16384" crc="cab85473" sha1="f86bbc4894e62725b8ef22d44e7f44d37c98ac14" region="bootstrap" offset="0"/>
+		<rom name="armeval_100.rom" bios="100" size="16384" crc="ed80462a" sha1="ba33eaf1a23cfef6fc1b88aa516ca2b3693e69d9" region="bootstrap" offset="0"/>
+		<rom name="brazil_006.rom" bios="006" size="16384" crc="9bafcc1c" sha1="bfa252de2af0d20db87af554fff99f158e267ace" region="bootstrap" offset="0"/>
+		<rom name="brazil_005.rom" bios="005" size="16384" crc="7c27c098" sha1="abcc71cbc43489e89a87aac64e67b17daef5895a" region="bootstrap" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="arm_cpu"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:flop_list" name="software_list"/>
+		<chip type="cpu" tag=":maincpu" name="ARM" clock="6666666"/>
+		<softwarelist tag=":flop_list" name="bbc_flop_arm" status="original" filter="ARM"/>
+	</machine>
+	<machine name="bbc_tube_arm7" sourcefile="devices/bus/bbc/tube/tube_arm7.cpp" isdevice="yes" runnable="no">
+		<description>Sprow ARM7TDMI Co-Processor</description>
+		<biosset name="045" description="ARM Tube OS 0.45"/>
+		<biosset name="040" description="ARM Tube OS 0.40"/>
+		<rom name="atos045.rom" bios="045" size="524288" crc="984c594e" sha1="1909886361c2a143c02a3977f6ce1a529dfc8779" region="flash" offset="0"/>
+		<rom name="atos040.rom" bios="040" size="524288" crc="b34b5011" sha1="babfb5bdb8265cf3ac7feff254146cb2d2773da1" region="flash" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="arm7_le"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:flop_ls_arm" name="software_list"/>
+		<chip type="cpu" tag=":maincpu" name="ARM7 (little)" clock="64000000"/>
+		<softwarelist tag=":flop_ls_arm" name="bbc_flop_arm" status="original" filter="ARM7"/>
+	</machine>
+	<machine name="bbc_tube_matchbox" sourcefile="devices/bus/bbc/tube/tube_matchbox.cpp" isdevice="yes" runnable="no">
+		<description>Matchbox Co-Processor</description>
+		<rom name="client65v2.bin" size="2048" crc="866a5b7b" sha1="40e2de0443e3447483fe6ee43fe66bac87fed1c4" region="r65c102_rom" offset="0"/>
+		<rom name="tuberom_z80.rom" size="4096" crc="229a764c" sha1="9702f9a821e5beddd04f7f71c4a07ab660fcc962" region="z80_rom" offset="0"/>
+		<rom name="client86_101.bin" size="16384" crc="6da326ce" sha1="8acaf42a4a6b5f62f6be5e62df5fcffbf48890dd" region="i80286_rom" offset="0"/>
+		<rom name="client09_106.bin" size="2048" crc="5f499c5b" sha1="5c615d16f579b4b6fb42f8ff1188b1f3404425fa" region="m6809_rom" offset="0"/>
+		<rom name="tuberom_68000.bin" size="32768" crc="906d6733" sha1="c376a6741e40d5b37a2e1fa7c2d766b9a575c57c" region="m68000_rom" offset="0"/>
+		<rom name="client11_040.bin" size="2048" crc="ab409e78" sha1="3756c0b78f94c6a79d077c25c5c74c55cfacf65c" region="pdp11_rom" offset="0"/>
+		<rom name="armeval_101.rom" size="16384" crc="cabd6a1b" sha1="9f451f53a5cb6f649fa8a2946e22f1ee49199a93" region="arm2_rom" offset="0"/>
+		<rom name="tuberom_32016.bin" size="32768" crc="11dfca39" sha1="80343cb198b03ea91c8790d765f7d3869ba9bb32" region="ns32016_rom" offset="0"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:r65c102" name="r65c102"/>
+		<device_ref tag=":_tmp:flop_ls_6502" name="software_list"/>
+		<device_ref tag=":_tmp:z80" name="z80"/>
+		<device_ref tag=":_tmp:flop_ls_z80" name="software_list"/>
+		<device_ref tag=":_tmp:i80286" name="i80286"/>
+		<device_ref tag=":_tmp:flop_ls_80186" name="software_list"/>
+		<device_ref tag=":_tmp:pc_disk_list" name="software_list"/>
+		<device_ref tag=":_tmp:m6809" name="mc6809"/>
+		<device_ref tag=":_tmp:m68000" name="m68000"/>
+		<device_ref tag=":_tmp:flop_ls_68000" name="software_list"/>
+		<device_ref tag=":_tmp:pdp11" name="t11"/>
+		<device_ref tag=":_tmp:arm2" name="arm_cpu"/>
+		<device_ref tag=":_tmp:flop_ls_arm" name="software_list"/>
+		<device_ref tag=":_tmp:ns32016" name="ns32016"/>
+		<device_ref tag=":_tmp:flop_ls_32016" name="software_list"/>
+		<chip type="cpu" tag=":r65c102" name="Rockwell R65C102" clock="32000000"/>
+		<chip type="cpu" tag=":z80" name="Zilog Z80" clock="32000000"/>
+		<chip type="cpu" tag=":i80286" name="Intel 80286" clock="12000000"/>
+		<chip type="cpu" tag=":m6809" name="Motorola MC6809" clock="16000000"/>
+		<chip type="cpu" tag=":m68000" name="Motorola MC68000" clock="8000000"/>
+		<chip type="cpu" tag=":pdp11" name="DEC T11" clock="32000000"/>
+		<chip type="cpu" tag=":arm2" name="ARM" clock="32000000"/>
+		<chip type="cpu" tag=":ns32016" name="National Semiconductor NS32016" clock="32000000"/>
+		<dipswitch name="Co-Processor" tag=":DIPSW" mask="15">
+			<dipvalue name="65C102 3 MHz" value="0" default="yes"/>
+			<dipvalue name="65C102 4 MHz" value="1"/>
+			<dipvalue name="65C102 16 MHz" value="2"/>
+			<dipvalue name="65C102 64 MHz" value="3"/>
+			<dipvalue name="Z80 8 MHz" value="4"/>
+			<dipvalue name="Z80 32 MHz" value="5"/>
+			<dipvalue name="Z80 56 MHz" value="6"/>
+			<dipvalue name="Z80 112 MHz" value="7"/>
+			<dipvalue name="80286 12 MHz" value="8"/>
+			<dipvalue name="6809 4 MHz" value="9"/>
+			<dipvalue name="68000 16 MHz" value="10"/>
+			<dipvalue name="PDP-11 32 MHz" value="11"/>
+			<dipvalue name="ARM2 32 MHz" value="12"/>
+			<dipvalue name="32016 32 MHz" value="13"/>
+			<dipvalue name="Null / SPI" value="14"/>
+			<dipvalue name="BIST" value="15"/>
+		</dipswitch>
+		<softwarelist tag=":flop_ls_6502" name="bbc_flop_6502" status="original"/>
+		<softwarelist tag=":flop_ls_z80" name="bbc_flop_z80" status="original"/>
+		<softwarelist tag=":flop_ls_80186" name="bbc_flop_80186" status="original"/>
+		<softwarelist tag=":pc_disk_list" name="ibm5150" status="compatible"/>
+		<softwarelist tag=":flop_ls_68000" name="bbc_flop_68000" status="original"/>
+		<softwarelist tag=":flop_ls_arm" name="bbc_flop_arm" status="original" filter="ARM"/>
+		<softwarelist tag=":flop_ls_32016" name="bbc_flop_32016" status="original"/>
+	</machine>
+	<machine name="bbc_tube_pcplus" sourcefile="devices/bus/bbc/tube/tube_80186.cpp" isdevice="yes" runnable="no">
+		<description>Solidisk PC-Plus Co-Processor</description>
+		<rom name="pcplus_ic31.rom" size="8192" crc="5149417b" sha1="a905c8570d70597bb2b2fca47a1a47783956af9c" region="bootstrap" offset="0"/>
+		<rom name="pcplus_ic32.rom" size="8192" crc="e47f10b2" sha1="45dc8d7e7936afbec6de423569d9005a1c350316" region="bootstrap" offset="1"/>
+		<device_ref tag=":_tmp:i80186" name="i80186"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:flop_ls_80186" name="software_list"/>
+		<device_ref tag=":_tmp:pc_disk_list" name="software_list"/>
+		<chip type="cpu" tag=":i80186" name="Intel 80186" clock="20000000"/>
+		<softwarelist tag=":flop_ls_80186" name="bbc_flop_80186" status="original"/>
+		<softwarelist tag=":pc_disk_list" name="ibm5150" status="compatible"/>
+	</machine>
+	<machine name="bbc_tube_rc6502" sourcefile="devices/bus/bbc/tube/tube_rc6502.cpp" isdevice="yes" runnable="no">
+		<description>ReCo6502 (65C02)</description>
+		<biosset name="hb84" description="HiBASIC '84'" default="yes"/>
+		<biosset name="hb02" description="HiBASIC 4r32 65C02"/>
+		<rom name="reco6502tube.rom" bios="hb84" size="32768" crc="6bf531b5" sha1="83f51b7e1120e14807ed4e24a2fe69c2a3efa416" region="maincpu" offset="0"/>
+		<rom name="reco6502tube_02.rom" bios="hb02" size="32768" crc="5ce3d04f" sha1="70b190e251e8807c4120c2ec7b930e62c19e3ea1" region="maincpu" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="w65c02s"/>
+		<device_ref tag=":_tmp:bankdev" name="address_map_bank"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:flop_ls_6502" name="software_list"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<chip type="cpu" tag=":maincpu" name="WDC W65C02S" clock="44236800"/>
+		<configuration name="Link 3: Soft config" tag=":config" mask="1">
+			<confsetting name="Disable" value="0"/>
+			<confsetting name="Enable" value="1" default="yes"/>
+		</configuration>
+		<configuration name="Link 2: Auto-load HiBASIC" tag=":config" mask="2">
+			<confsetting name="Disable" value="0" default="yes"/>
+			<confsetting name="Enable" value="2"/>
+		</configuration>
+		<configuration name="Link 1: Processor clock frequency" tag=":config" mask="4">
+			<confsetting name="3.15 MHz" value="0"/>
+			<confsetting name="14.7 MHz" value="4" default="yes"/>
+		</configuration>
+		<softwarelist tag=":flop_ls_6502" name="bbc_flop_6502" status="original"/>
+	</machine>
+	<machine name="bbc_tube_rc65816" sourcefile="devices/bus/bbc/tube/tube_rc6502.cpp" isdevice="yes" runnable="no">
+		<description>ReCo6502 (65C816)</description>
+		<biosset name="hb84" description="HiBASIC '84" default="yes"/>
+		<biosset name="hb816" description="HiBASIC 4r32 65C816"/>
+		<rom name="reco6502tube.rom" bios="hb84" size="32768" crc="6bf531b5" sha1="83f51b7e1120e14807ed4e24a2fe69c2a3efa416" region="maincpu" offset="0"/>
+		<rom name="reco6502tube_816.rom" bios="hb816" size="32768" crc="169a2b8c" sha1="b9943843f753470b636ee17ad820fa3ccad68249" region="maincpu" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="w65c816"/>
+		<device_ref tag=":_tmp:bankdev" name="address_map_bank"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<device_ref tag=":_tmp:flop_ls_6502" name="software_list"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<chip type="cpu" tag=":maincpu" name="WDC W65C816" clock="44236800"/>
+		<configuration name="Link 3: Soft config" tag=":config" mask="1">
+			<confsetting name="Disable" value="0"/>
+			<confsetting name="Enable" value="1" default="yes"/>
+		</configuration>
+		<configuration name="Link 2: Auto-load HiBASIC" tag=":config" mask="2">
+			<confsetting name="Disable" value="0" default="yes"/>
+			<confsetting name="Enable" value="2"/>
+		</configuration>
+		<configuration name="Link 1: Processor clock frequency" tag=":config" mask="4">
+			<confsetting name="3.15 MHz" value="0"/>
+			<confsetting name="14.7 MHz" value="4" default="yes"/>
+		</configuration>
+		<softwarelist tag=":flop_ls_6502" name="bbc_flop_6502" status="original"/>
+	</machine>
+	<machine name="bbc_tube_slot" sourcefile="devices/bus/bbc/tube/tube.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro Tube port</description>
+	</machine>
+	<machine name="bbc_tube_z80" sourcefile="devices/bus/bbc/tube/tube_z80.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Z80 2nd Processor</description>
+		<biosset name="120" description="Z80 v1.20"/>
+		<rom name="z80_120.rom" bios="120" size="4096" crc="315bfc20" sha1="069077df498599a9c880d4ec9f4bc53fcc602d82" region="rom" offset="0"/>
+		<device_ref tag=":_tmp:z80" name="z80"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:flop_ls_z80" name="software_list"/>
+		<chip type="cpu" tag=":z80" name="Zilog Z80" clock="6000000"/>
+		<softwarelist tag=":flop_ls_z80" name="bbc_flop_z80" status="original"/>
+	</machine>
+	<machine name="bbc_tube_z80w" sourcefile="devices/bus/bbc/tube/tube_z80.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Z80 2nd Processor (Winchester)</description>
+		<biosset name="200" description="Z80 v2.00"/>
+		<rom name="z80_200.rom" bios="200" size="4096" crc="84672c3d" sha1="47211cead3a1b0f9830dcdef8e54e29522c69bf8" region="rom" offset="0"/>
+		<device_ref tag=":_tmp:z80" name="z80"/>
+		<device_ref tag=":_tmp:ula" name="tube"/>
+		<device_ref tag=":_tmp:flop_ls_z80" name="software_list"/>
+		<chip type="cpu" tag=":z80" name="Zilog Z80" clock="6000000"/>
+		<softwarelist tag=":flop_ls_z80" name="bbc_flop_z80" status="original"/>
+	</machine>
+	<machine name="bbc_tube_zep100m" sourcefile="devices/bus/bbc/tube/tube_zep100.cpp" isdevice="yes" runnable="no">
+		<description>Torch Z80 Communicator (Master)</description>
+		<biosset name="mcp202" description="MCP v2.02 (CBM)"/>
+		<biosset name="mcp122" description="MCP v1.22 (ABM)"/>
+		<rom name="mcp202cbm.rom" bios="mcp202" size="16384" crc="237bd2d0" sha1="064203ce44c764b189465fa93b71bcc6f0c66e3b" region="exp_rom" offset="0"/>
+		<rom name="mcp122abm.rom" bios="mcp122" size="16384" crc="596be795" sha1="35843ace281494ab40463a69a263244d0cb0ecd6" region="exp_rom" offset="0"/>
+		<rom name="cccp102.rom" size="8192" crc="2eb40a21" sha1="e6ee738e5f2f8556002b79d18caa8ef21f14e08d" region="rom" offset="0"/>
+		<device_ref tag=":_tmp:z80" name="z80"/>
+		<device_ref tag=":_tmp:via" name="mos6522"/>
+		<device_ref tag=":_tmp:ppi" name="i8255"/>
+		<device_ref tag=":_tmp:flop_ls_torch" name="software_list"/>
+		<chip type="cpu" tag=":z80" name="Zilog Z80" clock="4000000"/>
+		<softwarelist tag=":flop_ls_torch" name="bbc_flop_torch" status="original" filter="Z80"/>
+	</machine>
+	<machine name="bbc_userport_slot" sourcefile="devices/bus/bbc/userport/userport.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro User port</description>
+	</machine>
+	<machine name="bbc_usersplit" sourcefile="devices/bus/bbc/userport/usersplit.cpp" isdevice="yes" runnable="no">
+		<description>BBC Micro User Port Splitter</description>
+		<device_ref tag=":_tmp:userport1" name="bbc_userport_slot"/>
+		<device_ref tag=":_tmp:userport2" name="bbc_userport_slot"/>
+		<configuration name="User Port" tag=":SELECT" mask="1">
+			<confsetting name="A" value="0" default="yes"/>
+			<confsetting name="B" value="1"/>
+		</configuration>
+		<slot name=":userport1">
+			<slotoption name="amxmouse" devname="bbc_amxmouse"/>
+			<slotoption name="beebspch" devname="bbc_beebspch"/>
+			<slotoption name="chameleon" devname="bbc_chameleon"/>
+			<slotoption name="sdcard" devname="bbc_sdcard"/>
+			<slotoption name="lcd" devname="bbc_lcd"/>
+			<slotoption name="cpalette" devname="bbc_cpalette"/>
+			<slotoption name="m4000" devname="bbc_m4000"/>
+			<slotoption name="m512mouse" devname="bbc_m512mouse"/>
+			<slotoption name="usersplit" devname="bbc_usersplit"/>
+			<slotoption name="sdcardt" devname="bbc_sdcardt"/>
+			<slotoption name="lvlecho" devname="bbc_lvlecho"/>
+			<slotoption name="tracker" devname="bbc_tracker"/>
+			<slotoption name="voicebox" devname="bbc_voicebox"/>
+		</slot>
+		<slot name=":userport2">
+			<slotoption name="amxmouse" devname="bbc_amxmouse"/>
+			<slotoption name="beebspch" devname="bbc_beebspch"/>
+			<slotoption name="chameleon" devname="bbc_chameleon"/>
+			<slotoption name="sdcard" devname="bbc_sdcard"/>
+			<slotoption name="lcd" devname="bbc_lcd"/>
+			<slotoption name="cpalette" devname="bbc_cpalette"/>
+			<slotoption name="m4000" devname="bbc_m4000"/>
+			<slotoption name="m512mouse" devname="bbc_m512mouse"/>
+			<slotoption name="usersplit" devname="bbc_usersplit"/>
+			<slotoption name="sdcardt" devname="bbc_sdcardt"/>
+			<slotoption name="lvlecho" devname="bbc_lvlecho"/>
+			<slotoption name="tracker" devname="bbc_tracker"/>
+			<slotoption name="voicebox" devname="bbc_voicebox"/>
+		</slot>
+	</machine>
+	<machine name="bbc_voicebox" sourcefile="devices/bus/bbc/userport/voicebox.cpp" isdevice="yes" runnable="no">
+		<description>Robin Voice Box</description>
+		<rom name="sp0256a-al2.bin" size="2048" crc="b504ac15" sha1="e60fcb5fa16ff3f3b69d36c7a6e955744d3feafc" region="sp0256" offset="1000"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:sp0256" name="sp0256"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":sp0256" name="GI SP0256 Narrator Speech Processor" clock="3120000"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="bbc_voltmace3b" sourcefile="devices/bus/bbc/analogue/joystick.cpp" isdevice="yes" runnable="no">
+		<description>Voltmace Delta 3b Twin Joysticks</description>
+		<input players="2">
+			<control type="stick" player="1" buttons="1" minimum="0" maximum="4095" sensitivity="100" keydelta="50" reverse="yes"/>
+			<control type="stick" player="2" buttons="1" minimum="0" maximum="4095" sensitivity="100" keydelta="50" reverse="yes"/>
+		</input>
+	</machine>
+	<machine name="bbcm_kbd" sourcefile="acorn/bbc_kbd.cpp" isdevice="yes" runnable="no">
+		<description>BBC Master Keyboard</description>
+		<input players="1">
+			<control type="keyboard" buttons="92"/>
+		</input>
+	</machine>
+	<machine name="beebopl" sourcefile="devices/bus/bbc/1mhzbus/beebopl.cpp" isdevice="yes" runnable="no">
+		<description>BeebOPL FM Synthesiser</description>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:ym3812" name="ym3812"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":ym3812" name="YM3812 OPL2" clock="3579000"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="1"/>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+	</machine>
+	<machine name="beebsid" sourcefile="devices/bus/bbc/1mhzbus/beebsid.cpp" isdevice="yes" runnable="no">
+		<description>BeebSID</description>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:mos8580" name="mos8580"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":mos8580" name="MOS 8580 SID"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="1"/>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+	</machine>
+	<machine name="beep" sourcefile="devices/sound/beep.cpp" isdevice="yes" runnable="no">
+		<description>Beep</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="bitbanger" sourcefile="devices/imagedev/bitbngr.cpp" isdevice="yes" runnable="no">
+		<description>Bitbanger</description>
+	</machine>
+	<machine name="bitmap_printer" sourcefile="devices/machine/bitmap_printer.cpp" isdevice="yes" runnable="no">
+		<description>Bitmap Printer Device</description>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:pf_stepper" name="stepper"/>
+		<device_ref tag=":_tmp:cr_stepper" name="stepper"/>
+		<display tag=":screen" type="raster" rotate="0" width="0" height="384" refresh="60.000000" />
+		<input players="1">
+		</input>
+		<configuration name="Draw Inch Marks" tag=":DRAWMARKS" mask="3">
+			<confsetting name="Off" value="0"/>
+			<confsetting name="with marks" value="1"/>
+			<confsetting name="with numbers" value="2" default="yes"/>
+		</configuration>
+		<adjuster name="Printer Bottom Margin" default="18"/>
+		<adjuster name="Printer Top Margin" default="18"/>
+	</machine>
+	<machine name="cassette_image" sourcefile="devices/imagedev/cassette.cpp" isdevice="yes" runnable="no">
+		<description>Cassette</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="centronics" sourcefile="devices/bus/centronics/ctronics.cpp" isdevice="yes" runnable="no">
+		<description>Centronics</description>
+	</machine>
+	<machine name="centronics_chessmec" sourcefile="devices/bus/centronics/chessmec.cpp" isdevice="yes" runnable="no">
+		<description>Tasc ChessMachine EC Interface</description>
+		<device_ref tag=":_tmp:chessm" name="chessmachine"/>
+		<device_ref tag=":_tmp:chessm:maincpu" name="arm_cpu"/>
+		<chip type="cpu" tag=":chessm:maincpu" name="ARM" clock="15000000"/>
+	</machine>
+	<machine name="centronics_printer" sourcefile="devices/bus/centronics/printer.cpp" isdevice="yes" runnable="no">
+		<description>Centronics Printer</description>
+		<device_ref tag=":_tmp:printer" name="printer_image"/>
+		<device type="printout" tag=":printer">
+			<instance name="printout" briefname="prin"/>
+			<extension name="prn"/>
+		</device>
+	</machine>
+	<machine name="centronics_samdac" sourcefile="devices/bus/centronics/samdac.cpp" isdevice="yes" runnable="no">
+		<description>SAMDAC</description>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:dac0" name="dac_8bit_r2r"/>
+		<device_ref tag=":_tmp:dac1" name="dac_8bit_r2r"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":dac0" name="8-Bit R-2R DAC"/>
+		<chip type="audio" tag=":dac1" name="8-Bit R-2R DAC"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="centronics_smartboard" sourcefile="devices/bus/centronics/smartboard.cpp" isdevice="yes" runnable="no">
+		<description>Tasc SmartBoard SB30 Interface</description>
+		<device_ref tag=":_tmp:smartboard" name="tasc_sb30"/>
+		<device_ref tag=":_tmp:smartboard:board" name="sensorboard"/>
+		<configuration name="Duplicate Piece IDs" tag=":smartboard:CONF" mask="1">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="1"/>
+		</configuration>
+		<configuration name="Remember Position" tag=":smartboard:board:CONF" mask="3">
+			<condition tag="UI_CHECK" mask="4" relation="ne" value="0"/>
+			<confsetting name="No" value="1"/>
+			<confsetting name="Yes" value="2"/>
+			<confsetting name="Auto" value="0" default="yes"/>
+		</configuration>
+		<configuration name="Show Pieces" tag=":smartboard:board:CONF" mask="4">
+			<condition tag="UI_CHECK" mask="4" relation="ne" value="0"/>
+			<confsetting name="No" value="4"/>
+			<confsetting name="Yes" value="0" default="yes"/>
+		</configuration>
+	</machine>
+	<machine name="cfa3000a" sourcefile="devices/bus/bbc/analogue/cfa3000a.cpp" isdevice="yes" runnable="no">
+		<description>Henson CFA 3000 Analogue</description>
+		<input players="1">
+			<control type="paddle" minimum="0" maximum="4095" sensitivity="25" keydelta="5"/>
+		</input>
+	</machine>
+	<machine name="cfa3000kbd" sourcefile="devices/bus/bbc/userport/cfa3000kbd.cpp" isdevice="yes" runnable="no">
+		<description>Henson CFA 3000 Keyboard</description>
+		<input players="1">
+			<control type="keyboard" buttons="16"/>
+		</input>
+	</machine>
+	<machine name="cfa3000opt" sourcefile="devices/bus/bbc/1mhzbus/cfa3000opt.cpp" isdevice="yes" runnable="no">
+		<description>Henson CFA 3000 Option Board</description>
+		<dipswitch name="Switch 8" tag=":OPT" mask="1">
+			<diplocation name="Option" number="8"/>
+			<dipvalue name="2nd level" value="1"/>
+			<dipvalue name="1st level" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Switch 7" tag=":OPT" mask="2">
+			<diplocation name="Option" number="7"/>
+			<dipvalue name="db" value="2"/>
+			<dipvalue name="log units" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Switch 6" tag=":OPT" mask="4">
+			<diplocation name="Option" number="6"/>
+			<dipvalue name="Full Threshold" value="4"/>
+			<dipvalue name="Supra Threshold" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Switch 5" tag=":OPT" mask="8">
+			<diplocation name="Option" number="5"/>
+			<dipvalue name="est. fluct." value="8"/>
+			<dipvalue name="do not est. fluct." value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Switch 4" tag=":OPT" mask="16">
+			<diplocation name="Option" number="4"/>
+			<dipvalue name="repeat &gt;4db" value="16"/>
+			<dipvalue name="do not repeat &gt;4db" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Switch 3" tag=":OPT" mask="32">
+			<diplocation name="Option" number="3"/>
+			<dipvalue name="Auto Send" value="32"/>
+			<dipvalue name="Request Send" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Switch 2" tag=":OPT" mask="64">
+			<diplocation name="Option" number="2"/>
+			<dipvalue name="not used" value="64"/>
+			<dipvalue name="not used" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Switch 1" tag=":OPT" mask="128">
+			<diplocation name="Option" number="1"/>
+			<dipvalue name="not used" value="128"/>
+			<dipvalue name="not used" value="0" default="yes"/>
+		</dipswitch>
+	</machine>
+	<machine name="chessmachine" sourcefile="devices/machine/chessmachine.cpp" isdevice="yes" runnable="no">
+		<description>Tasc ChessMachine</description>
+		<rom name="74s288.1" size="32" crc="284114e2" sha1="df4037536d505d7240bb1d70dc58f59a34ab77b4" region="bootrom" offset="0"/>
+		<rom name="74s288.2" size="32" crc="9f239c75" sha1="aafaf30dac90f36b01f9ee89903649fc4ea0480d" region="bootrom" offset="1"/>
+		<rom name="74s288.3" size="32" crc="0455360b" sha1="f1486142330f2c39a4d6c479646030d31443d1c8" region="bootrom" offset="2"/>
+		<rom name="74s288.4" size="32" crc="c7c9aba8" sha1="cbb5b12b5917e36679d45bcbc36ea9285223a75d" region="bootrom" offset="3"/>
+		<device_ref tag=":_tmp:maincpu" name="arm_cpu"/>
+		<chip type="cpu" tag=":maincpu" name="ARM" clock="0"/>
+	</machine>
+	<machine name="clock" sourcefile="devices/machine/clock.cpp" isdevice="yes" runnable="no">
+		<description>Clock</description>
+	</machine>
+	<machine name="comx_pl80" sourcefile="devices/bus/centronics/comxpl80.cpp" isdevice="yes" runnable="no">
+		<description>COMX PL-80</description>
+		<rom name="pl80.pt6" size="3584" crc="ae059e5b" sha1="f25812606b0082d32eb603d0a702a2187089d332" region="cx005" offset="80"/>
+		<rom name="it.em.ou.bin" size="8192" crc="1b4a3198" sha1="138ff6666a31c2d18cd63e609dd94d9cd1529931" region="gfx1" offset="2000"/>
+		<rom name="tiny.bin" size="1024" crc="940ec1ed" sha1="ad83a3b57e2f0fbaa1e40644cd999b3f239635e8" region="gfx1" offset="4000"/>
+		<configuration name="COMX PL-80 Font Pack" tag=":FONT" mask="3">
+			<confsetting name="None" value="0" default="yes"/>
+			<confsetting name="Italic, Emphasized and Outline" value="1"/>
+			<confsetting name="Tiny" value="2"/>
+		</configuration>
+	</machine>
+	<machine name="covox" sourcefile="devices/bus/centronics/covox.cpp" isdevice="yes" runnable="no">
+		<description>Covox Speech Thing</description>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:dac" name="dac_8bit_r2r"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":dac" name="8-Bit R-2R DAC"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="covox_stereo" sourcefile="devices/bus/centronics/covox.cpp" isdevice="yes" runnable="no">
+		<description>Covox (Stereo-in-1)</description>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:ldac" name="dac_8bit_r2r"/>
+		<device_ref tag=":_tmp:rdac" name="dac_8bit_r2r"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":ldac" name="8-Bit R-2R DAC"/>
+		<chip type="audio" tag=":rdac" name="8-Bit R-2R DAC"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="cpcdigiblst" sourcefile="devices/bus/centronics/digiblst.cpp" isdevice="yes" runnable="no">
+		<description>Digiblaster (DIY)</description>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:dac" name="dac_8bit_r2r"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":dac" name="8-Bit R-2R DAC"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="dac" sourcefile="devices/sound/dac.h" isdevice="yes" runnable="no">
+		<description>1-Bit DAC</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="dac_16bit_r2r_tc" sourcefile="devices/sound/dac.h" isdevice="yes" runnable="no">
+		<description>16-Bit R-2R Twos Complement DAC</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="dac_8bit_r2r" sourcefile="devices/sound/dac.h" isdevice="yes" runnable="no">
+		<description>8-Bit R-2R DAC</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="datapen" sourcefile="devices/bus/bbc/analogue/lightpen.cpp" isdevice="yes" runnable="no">
+		<description>Datapen Light Pen (BBC Micro)</description>
+		<input players="1">
+			<control type="lightgun" buttons="1" minimum="0" maximum="1023" sensitivity="50" keydelta="10"/>
+		</input>
+	</machine>
+	<machine name="dec_rs232_loopback" sourcefile="devices/bus/rs232/loopback.cpp" isdevice="yes" runnable="no">
+		<description>RS-232 Loopback (DEC 12-15336-00)</description>
+	</machine>
+	<machine name="ds1216e" sourcefile="devices/machine/ds1215.cpp" isdevice="yes" runnable="no">
+		<description>Dallas Semiconductor DS1216E SmartWatch/ROM</description>
+	</machine>
+	<machine name="e05a03" sourcefile="devices/machine/e05a03.cpp" isdevice="yes" runnable="no">
+		<description>Epson E05A03 Gate Array</description>
+	</machine>
+	<machine name="e05a30" sourcefile="devices/machine/e05a30.cpp" isdevice="yes" runnable="no">
+		<description>Epson E05A30 Gate Array</description>
+	</machine>
+	<machine name="econet" sourcefile="devices/bus/econet/econet.cpp" isdevice="yes" runnable="no">
+		<description>Econet</description>
+	</machine>
+	<machine name="econet_e01" sourcefile="devices/bus/econet/e01.cpp" isdevice="yes" runnable="no">
+		<description>Acorn FileStore E01</description>
+		<rom name="0254,205-04 e01 fs" size="32768" crc="ae666c76" sha1="0954119eb5cd09cdbadf76d60d812aa845838d5a" region="r65c102" offset="0"/>
+		<rom name="0254,205-03 e01 mos" size="32768" crc="a13e8014" sha1="6f44a1a48108c60a64a1774cb30c1a59c4a6a199" region="r65c102" offset="8000"/>
+		<device_ref tag=":_tmp:r65c102" name="r65c102"/>
+		<device_ref tag=":_tmp:hd146818" name="mc146818"/>
+		<device_ref tag=":_tmp:ic21" name="r65c22"/>
+		<device_ref tag=":_tmp:mc6854" name="mc6854"/>
+		<device_ref tag=":_tmp:ic20" name="wd2793"/>
+		<device_ref tag=":_tmp:ic20:0" name="floppy_connector"/>
+		<device_ref tag=":_tmp:ic20:1" name="floppy_connector"/>
+		<device_ref tag=":_tmp:flop_ls_e01" name="software_list"/>
+		<device_ref tag=":_tmp:centronics" name="centronics"/>
+		<device_ref tag=":_tmp:cent_data_out" name="output_latch"/>
+		<device_ref tag=":_tmp:scsi" name="scsi"/>
+		<device_ref tag=":_tmp:scsi:1" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi:2" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi:3" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi:4" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi:5" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi:6" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi:7" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi_data_out" name="output_latch"/>
+		<device_ref tag=":_tmp:scsi_data_in" name="input_buffer"/>
+		<device_ref tag=":_tmp:scsi_ctrl_in" name="input_buffer"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<chip type="cpu" tag=":r65c102" name="Rockwell R65C102" clock="8000000"/>
+		<dipswitch name="SW3" tag=":FLAP" mask="128">
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="128"/>
+		</dipswitch>
+		<configuration name="Front Flap" tag=":FLAP" mask="64">
+			<confsetting name="Closed" value="0" default="yes"/>
+			<confsetting name="Open" value="64"/>
+		</configuration>
+		<slot name=":ic20:0">
+			<slotoption name="35dd" devname="floppy_35_dd" default="yes"/>
+		</slot>
+		<slot name=":ic20:1">
+			<slotoption name="35dd" devname="floppy_35_dd" default="yes"/>
+		</slot>
+		<slot name=":centronics">
+			<slotoption name="neomania" devname="neomania_adapter"/>
+			<slotoption name="pc6022" devname="pc6022"/>
+			<slotoption name="nlq401" devname="nlq401"/>
+			<slotoption name="smartboard" devname="centronics_smartboard"/>
+			<slotoption name="chessmec" devname="centronics_chessmec"/>
+			<slotoption name="samdac" devname="centronics_samdac"/>
+			<slotoption name="covox_stereo" devname="covox_stereo"/>
+			<slotoption name="adaptator" devname="adaptator_multitap"/>
+			<slotoption name="digiblst" devname="cpcdigiblst"/>
+			<slotoption name="lx800" devname="lx800"/>
+			<slotoption name="jx80" devname="epson_jx80"/>
+			<slotoption name="ap2000" devname="ap2000"/>
+			<slotoption name="ex800" devname="ex800"/>
+			<slotoption name="fx80" devname="epson_fx80"/>
+			<slotoption name="rx80" devname="epson_rx80"/>
+			<slotoption name="mz1p16" devname="mz1p16"/>
+			<slotoption name="covox" devname="covox"/>
+			<slotoption name="pl80" devname="comx_pl80"/>
+			<slotoption name="lx810l" devname="lx810l"/>
+			<slotoption name="p72" devname="p72"/>
+			<slotoption name="printer" devname="centronics_printer" default="yes"/>
+		</slot>
+		<slot name=":scsi:1">
+			<slotoption name="harddisk" devname="scsihd" default="yes"/>
+		</slot>
+		<slot name=":scsi:2">
+		</slot>
+		<slot name=":scsi:3">
+		</slot>
+		<slot name=":scsi:4">
+		</slot>
+		<slot name=":scsi:5">
+		</slot>
+		<slot name=":scsi:6">
+		</slot>
+		<slot name=":scsi:7">
+		</slot>
+		<softwarelist tag=":flop_ls_e01" name="e01_flop" status="original"/>
+	</machine>
+	<machine name="econet_e01s" sourcefile="devices/bus/econet/e01.cpp" isdevice="yes" runnable="no">
+		<description>Acorn FileStore E01S</description>
+		<rom name="e01sv133.rom" size="65536" crc="2a4a0032" sha1="54ad68ceae44992293ccdd64ec88ad8520deec22" region="r65c102" offset="0"/>
+		<rom name="e01sv140.rom" size="65536" crc="5068fe86" sha1="9b8740face15b5541e2375b3054988af00757931" region="r65c102" offset="0"/>
+		<device_ref tag=":_tmp:r65c102" name="r65c102"/>
+		<device_ref tag=":_tmp:hd146818" name="mc146818"/>
+		<device_ref tag=":_tmp:ic21" name="r65c22"/>
+		<device_ref tag=":_tmp:mc6854" name="mc6854"/>
+		<device_ref tag=":_tmp:ic20" name="wd2793"/>
+		<device_ref tag=":_tmp:ic20:0" name="floppy_connector"/>
+		<device_ref tag=":_tmp:ic20:1" name="floppy_connector"/>
+		<device_ref tag=":_tmp:flop_ls_e01" name="software_list"/>
+		<device_ref tag=":_tmp:centronics" name="centronics"/>
+		<device_ref tag=":_tmp:cent_data_out" name="output_latch"/>
+		<device_ref tag=":_tmp:scsi" name="scsi"/>
+		<device_ref tag=":_tmp:scsi:1" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi:2" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi:3" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi:4" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi:5" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi:6" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi:7" name="scsi_slot"/>
+		<device_ref tag=":_tmp:scsi_data_out" name="output_latch"/>
+		<device_ref tag=":_tmp:scsi_data_in" name="input_buffer"/>
+		<device_ref tag=":_tmp:scsi_ctrl_in" name="input_buffer"/>
+		<device_ref tag=":_tmp:ram" name="ram"/>
+		<chip type="cpu" tag=":r65c102" name="Rockwell R65C102" clock="8000000"/>
+		<dipswitch name="SW3" tag=":FLAP" mask="128">
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="128"/>
+		</dipswitch>
+		<configuration name="Front Flap" tag=":FLAP" mask="64">
+			<confsetting name="Closed" value="0" default="yes"/>
+			<confsetting name="Open" value="64"/>
+		</configuration>
+		<slot name=":ic20:0">
+			<slotoption name="35dd" devname="floppy_35_dd" default="yes"/>
+		</slot>
+		<slot name=":ic20:1">
+			<slotoption name="35dd" devname="floppy_35_dd" default="yes"/>
+		</slot>
+		<slot name=":centronics">
+			<slotoption name="neomania" devname="neomania_adapter"/>
+			<slotoption name="pc6022" devname="pc6022"/>
+			<slotoption name="nlq401" devname="nlq401"/>
+			<slotoption name="smartboard" devname="centronics_smartboard"/>
+			<slotoption name="chessmec" devname="centronics_chessmec"/>
+			<slotoption name="samdac" devname="centronics_samdac"/>
+			<slotoption name="covox_stereo" devname="covox_stereo"/>
+			<slotoption name="adaptator" devname="adaptator_multitap"/>
+			<slotoption name="digiblst" devname="cpcdigiblst"/>
+			<slotoption name="lx800" devname="lx800"/>
+			<slotoption name="jx80" devname="epson_jx80"/>
+			<slotoption name="ap2000" devname="ap2000"/>
+			<slotoption name="ex800" devname="ex800"/>
+			<slotoption name="fx80" devname="epson_fx80"/>
+			<slotoption name="rx80" devname="epson_rx80"/>
+			<slotoption name="mz1p16" devname="mz1p16"/>
+			<slotoption name="covox" devname="covox"/>
+			<slotoption name="pl80" devname="comx_pl80"/>
+			<slotoption name="lx810l" devname="lx810l"/>
+			<slotoption name="p72" devname="p72"/>
+			<slotoption name="printer" devname="centronics_printer" default="yes"/>
+		</slot>
+		<slot name=":scsi:1">
+			<slotoption name="harddisk" devname="scsihd" default="yes"/>
+		</slot>
+		<slot name=":scsi:2">
+		</slot>
+		<slot name=":scsi:3">
+		</slot>
+		<slot name=":scsi:4">
+		</slot>
+		<slot name=":scsi:5">
+		</slot>
+		<slot name=":scsi:6">
+		</slot>
+		<slot name=":scsi:7">
+		</slot>
+		<softwarelist tag=":flop_ls_e01" name="e01_flop" status="original"/>
+	</machine>
+	<machine name="econet_slot" sourcefile="devices/bus/econet/econet.cpp" isdevice="yes" runnable="no">
+		<description>Econet station</description>
+	</machine>
+	<machine name="electron_abr" sourcefile="devices/bus/electron/cart/abr.cpp" isdevice="yes" runnable="no">
+		<description>Electron Advanced Battery-Backed RAM cartridge</description>
+	</machine>
+	<machine name="electron_aqr" sourcefile="devices/bus/electron/cart/aqr.cpp" isdevice="yes" runnable="no">
+		<description>Electron Advanced Quarter Meg Ram cartridge</description>
+	</machine>
+	<machine name="electron_cartslot" sourcefile="devices/bus/electron/cart/slot.cpp" isdevice="yes" runnable="no">
+		<description>Electron Cartridge Slot</description>
+	</machine>
+	<machine name="electron_stdcart" sourcefile="devices/bus/electron/cart/std.cpp" isdevice="yes" runnable="no">
+		<description>Electron standard cartridge</description>
+	</machine>
+	<machine name="epson_fx80" sourcefile="devices/bus/centronics/epson_fx80.cpp" isdevice="yes" runnable="no">
+		<description>Epson FX-80</description>
+		<rom name="epson_8426k9_m1206ba029_read_as_27c128.bin" size="16384" crc="ff5c2b1e" sha1="e1e38c3e4864e60f701939e23331360b76603a24" region="maincpu" offset="0"/>
+		<rom name="epson_fx_c42040kb_8042ah.bin" size="2048" crc="3e9d08c1" sha1="d5074f60497cc75d40996e6cef63231d3a3697f1" region="slavecpu" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="upd7810"/>
+		<device_ref tag=":_tmp:slavecpu" name="i8042ah"/>
+		<chip type="cpu" tag=":maincpu" name="NEC uPD7810" clock="10000000"/>
+		<chip type="cpu" tag=":slavecpu" name="Intel 8042AH" clock="11000000"/>
+		<feature type="printer" status="unemulated"/>
+	</machine>
+	<machine name="epson_jx80" sourcefile="devices/bus/centronics/epson_fx80.cpp" isdevice="yes" runnable="no">
+		<description>Epson JX-80</description>
+		<rom name="jx80_a4_fs5_27128.bin" size="16384" crc="2925a47b" sha1="1864d3561491d7dca78ac2cd13a023460f551184" region="maincpu" offset="0"/>
+		<rom name="epson_fx_c42040kb_8042ah.bin" size="2048" crc="3e9d08c1" sha1="d5074f60497cc75d40996e6cef63231d3a3697f1" region="slavecpu" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="upd7810"/>
+		<device_ref tag=":_tmp:slavecpu" name="i8042ah"/>
+		<chip type="cpu" tag=":maincpu" name="NEC uPD7810" clock="10000000"/>
+		<chip type="cpu" tag=":slavecpu" name="Intel 8042AH" clock="11000000"/>
+		<feature type="printer" status="unemulated"/>
+	</machine>
+	<machine name="epson_rx80" sourcefile="devices/bus/centronics/epson_rx80.cpp" isdevice="yes" runnable="no">
+		<description>Epson RX-80</description>
+		<rom name="rx80_2764.bin" size="8192" crc="5206104a" sha1="3e304f5331181aedb321d3db23a9387e3cfacf0c" region="maincpu" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="upd7810"/>
+		<chip type="cpu" tag=":maincpu" name="NEC uPD7810" clock="11000000"/>
+		<feature type="printer" status="unemulated"/>
+	</machine>
+	<machine name="ex800" sourcefile="devices/bus/centronics/epson_ex800.cpp" isdevice="yes" runnable="no">
+		<description>Epson EX-800</description>
+		<rom name="w8_pe9.9b" size="32768" crc="6dd41e9b" sha1="8e30ead727b9317154742efd881206e9f9bbf95b" region="maincpu" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="upd7810"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<chip type="cpu" tag=":maincpu" name="NEC uPD7810" clock="12000000"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="4000"/>
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="11"/>
+		</input>
+		<dipswitch name="Condensed characters" tag=":DSW_1" mask="1">
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="1"/>
+		</dipswitch>
+		<dipswitch name="Slashed zero" tag=":DSW_1" mask="2">
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="2"/>
+		</dipswitch>
+		<dipswitch name="Character table" tag=":DSW_1" mask="4">
+			<dipvalue name="Italics" value="0" default="yes"/>
+			<dipvalue name="Graphics" value="4"/>
+		</dipswitch>
+		<dipswitch name="Printer commands" tag=":DSW_1" mask="8">
+			<dipvalue name="ESC/P" value="0" default="yes"/>
+			<dipvalue name="IBM printer emulation" value="8"/>
+		</dipswitch>
+		<dipswitch name="Print quality" tag=":DSW_1" mask="16">
+			<dipvalue name="Draft" value="0" default="yes"/>
+			<dipvalue name="NLQ" value="16"/>
+		</dipswitch>
+		<dipswitch name="Int. character set" tag=":DSW_1" mask="224">
+			<dipvalue name="USA" value="0" default="yes"/>
+			<dipvalue name="French" value="32"/>
+			<dipvalue name="German" value="32"/>
+			<dipvalue name="UK" value="64"/>
+			<dipvalue name="Danish" value="64"/>
+			<dipvalue name="Swedish" value="96"/>
+			<dipvalue name="Italian" value="96"/>
+			<dipvalue name="Spanish" value="128"/>
+		</dipswitch>
+		<dipswitch name="Page length" tag=":DSW_2" mask="1">
+			<dipvalue name="11 inch" value="0" default="yes"/>
+			<dipvalue name="12 inch" value="1"/>
+		</dipswitch>
+		<dipswitch name="Auto. sheet feeder" tag=":DSW_2" mask="2">
+			<dipvalue name="Canceled" value="0" default="yes"/>
+			<dipvalue name="Selected" value="2"/>
+		</dipswitch>
+		<dipswitch name="Skip-over-perforation" tag=":DSW_2" mask="4">
+			<dipvalue name="None" value="0" default="yes"/>
+			<dipvalue name="1 inch" value="4"/>
+		</dipswitch>
+		<dipswitch name="Add LF after CR" tag=":DSW_2" mask="8">
+			<dipvalue name="CR only" value="0" default="yes"/>
+			<dipvalue name="CR + LF" value="8"/>
+		</dipswitch>
+		<dipswitch name="Interface type" tag=":DSW_2" mask="48">
+			<dipvalue name="Parallel" value="0" default="yes"/>
+			<dipvalue name="Serial (odd parity)" value="16"/>
+			<dipvalue name="Serial (even parity)" value="32"/>
+			<dipvalue name="Serial (no parity)" value="48"/>
+		</dipswitch>
+		<dipswitch name="Baud rate" tag=":DSW_2" mask="192">
+			<dipvalue name="9600" value="0" default="yes"/>
+			<dipvalue name="4800" value="64"/>
+			<dipvalue name="1200" value="128"/>
+			<dipvalue name="300" value="192"/>
+		</dipswitch>
+	</machine>
+	<machine name="floppy_35_dd" sourcefile="devices/imagedev/floppy.cpp" isdevice="yes" runnable="no">
+		<description>3.5&quot; double density floppy drive</description>
+		<device_ref tag=":_tmp:flopsndout" name="speaker"/>
+		<device_ref tag=":_tmp:flopsnd" name="flopsnd"/>
+		<chip type="audio" tag=":flopsndout" name="Speaker"/>
+		<chip type="audio" tag=":flopsnd" name="Floppy sound" clock="44100"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="floppy_525_qd" sourcefile="devices/imagedev/floppy.cpp" isdevice="yes" runnable="no">
+		<description>5.25&quot; quad density floppy drive</description>
+		<device_ref tag=":_tmp:flopsndout" name="speaker"/>
+		<device_ref tag=":_tmp:flopsnd" name="flopsnd"/>
+		<chip type="audio" tag=":flopsndout" name="Speaker"/>
+		<chip type="audio" tag=":flopsnd" name="Floppy sound" clock="44100"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="floppy_525_sd" sourcefile="devices/imagedev/floppy.cpp" isdevice="yes" runnable="no">
+		<description>5.25&quot; single density floppy drive</description>
+		<device_ref tag=":_tmp:flopsndout" name="speaker"/>
+		<device_ref tag=":_tmp:flopsnd" name="flopsnd"/>
+		<chip type="audio" tag=":flopsndout" name="Speaker"/>
+		<chip type="audio" tag=":flopsnd" name="Floppy sound" clock="44100"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="floppy_525_sssd" sourcefile="devices/imagedev/floppy.cpp" isdevice="yes" runnable="no">
+		<description>5.25&quot; single-sided single density floppy drive</description>
+		<device_ref tag=":_tmp:flopsndout" name="speaker"/>
+		<device_ref tag=":_tmp:flopsnd" name="flopsnd"/>
+		<chip type="audio" tag=":flopsndout" name="Speaker"/>
+		<chip type="audio" tag=":flopsnd" name="Floppy sound" clock="44100"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="floppy_connector" sourcefile="devices/imagedev/floppy.cpp" isdevice="yes" runnable="no">
+		<description>Floppy drive connector abstraction</description>
+	</machine>
+	<machine name="flopsnd" sourcefile="devices/imagedev/floppy.cpp" isdevice="yes" runnable="no">
+		<description>Floppy sound</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="g65sc02" sourcefile="devices/cpu/m6502/g65sc02.cpp" isdevice="yes" runnable="no">
+		<description>GTE G65SC02</description>
+	</machine>
+	<machine name="g65sc12" sourcefile="devices/cpu/m6502/g65sc02.cpp" isdevice="yes" runnable="no">
+		<description>GTE G65SC12</description>
+	</machine>
+	<machine name="generic_keyboard" sourcefile="devices/machine/keyboard.cpp" isdevice="yes" runnable="no">
+		<description>Generic Keyboard</description>
+		<input players="1">
+			<control type="keyboard" buttons="73"/>
+		</input>
+		<configuration name="Layout" tag=":GENKBD_CFG" mask="1">
+			<confsetting name="ANSI" value="0" default="yes"/>
+			<confsetting name="JIS" value="1"/>
+		</configuration>
+		<configuration name="Typematic Delay" tag=":GENKBD_CFG" mask="6">
+			<confsetting name="0.25s" value="0"/>
+			<confsetting name="0.5s" value="2"/>
+			<confsetting name="0.75s" value="4" default="yes"/>
+			<confsetting name="1.0s" value="6"/>
+		</configuration>
+		<configuration name="Typematic Rate" tag=":GENKBD_CFG" mask="248">
+			<confsetting name="2.0cps" value="0"/>
+			<confsetting name="2.1cps" value="8"/>
+			<confsetting name="2.5cps" value="16"/>
+			<confsetting name="2.7cps" value="24"/>
+			<confsetting name="2.0cps" value="32"/>
+			<confsetting name="2.1cps" value="40"/>
+			<confsetting name="2.5cps" value="48"/>
+			<confsetting name="2.7cps" value="56"/>
+			<confsetting name="3.3cps" value="64"/>
+			<confsetting name="3.8cps" value="72"/>
+			<confsetting name="4.0cps" value="80"/>
+			<confsetting name="4.3cps" value="88"/>
+			<confsetting name="4.6cps" value="96"/>
+			<confsetting name="5.0cps" value="104"/>
+			<confsetting name="5.5cps" value="112"/>
+			<confsetting name="6.0cps" value="120"/>
+			<confsetting name="8.0cps" value="128"/>
+			<confsetting name="8.6cps" value="136"/>
+			<confsetting name="9.2cps" value="144"/>
+			<confsetting name="10.0cps" value="152" default="yes"/>
+			<confsetting name="10.9cps" value="160"/>
+			<confsetting name="12.0cps" value="168"/>
+			<confsetting name="13.3cps" value="176"/>
+			<confsetting name="15.0cps" value="184"/>
+			<confsetting name="16.0cps" value="192"/>
+			<confsetting name="17.1cps" value="200"/>
+			<confsetting name="18.5cps" value="208"/>
+			<confsetting name="20.0cps" value="216"/>
+			<confsetting name="21.8cps" value="224"/>
+			<confsetting name="24.0cps" value="232"/>
+			<confsetting name="26.7cps" value="240"/>
+			<confsetting name="30.0cps" value="248"/>
+		</configuration>
+	</machine>
+	<machine name="generic_latch_8" sourcefile="devices/machine/gen_latch.cpp" isdevice="yes" runnable="no">
+		<description>Generic 8-bit latch</description>
+	</machine>
+	<machine name="gfxdecode" sourcefile="emu/drawgfx.cpp" isdevice="yes" runnable="no">
+		<description>gfxdecode</description>
+	</machine>
+	<machine name="harddisk_image" sourcefile="devices/imagedev/harddriv.cpp" isdevice="yes" runnable="no">
+		<description>Hard disk</description>
+	</machine>
+	<machine name="hasp_savquest" sourcefile="devices/bus/centronics/hasp_savquest.cpp" isdevice="yes" runnable="no">
+		<description>Alladin HASP dongle for Savage Quest</description>
+	</machine>
+	<machine name="hd44780" sourcefile="devices/video/hd44780.cpp" isdevice="yes" runnable="no">
+		<description>Hitachi HD44780 LCD Controller</description>
+		<biosset name="a00" description="A00" default="yes"/>
+		<rom name="hd44780_a00.bin" bios="a00" size="4096" crc="e459877c" sha1="65cf075a988cdcbb316b9afdd0529b374a1a65ec" status="baddump" region="cgrom" offset="0"/>
+	</machine>
+	<machine name="hd6303r" sourcefile="devices/cpu/m6800/m6801.cpp" isdevice="yes" runnable="no">
+		<description>Hitachi HD6303R</description>
+	</machine>
+	<machine name="hd6303x" sourcefile="devices/cpu/m6800/m6801.cpp" isdevice="yes" runnable="no">
+		<description>Hitachi HD6303X</description>
+	</machine>
+	<machine name="hd6845s" sourcefile="devices/video/mc6845.cpp" isdevice="yes" runnable="no">
+		<description>Hitachi HD6845S CRTC</description>
+	</machine>
+	<machine name="heath_tlb_connector" sourcefile="devices/bus/heathzenith/h19/tlb.cpp" isdevice="yes" runnable="no">
+		<description>Heath Terminal Logic board connector abstraction</description>
+	</machine>
+	<machine name="htmusic" sourcefile="devices/bus/bbc/1mhzbus/m5000.cpp" isdevice="yes" runnable="no">
+		<description>Hybrid Technology Music System</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="i80186" sourcefile="devices/cpu/i86/i186.cpp" isdevice="yes" runnable="no">
+		<description>Intel 80186</description>
+	</machine>
+	<machine name="i80286" sourcefile="devices/cpu/i86/i286.cpp" isdevice="yes" runnable="no">
+		<description>Intel 80286</description>
+	</machine>
+	<machine name="i8031" sourcefile="devices/cpu/mcs51/i8051.cpp" isdevice="yes" runnable="no">
+		<description>Intel 8031</description>
+	</machine>
+	<machine name="i8035" sourcefile="devices/cpu/mcs48/mcs48.cpp" isdevice="yes" runnable="no">
+		<description>Intel 8035</description>
+	</machine>
+	<machine name="i8042ah" sourcefile="devices/cpu/mcs48/mcs48.cpp" isdevice="yes" runnable="no">
+		<description>Intel 8042AH</description>
+	</machine>
+	<machine name="i8050" sourcefile="devices/cpu/mcs48/mcs48.cpp" isdevice="yes" runnable="no">
+		<description>Intel 8050</description>
+	</machine>
+	<machine name="i8051" sourcefile="devices/cpu/mcs51/i8051.cpp" isdevice="yes" runnable="no">
+		<description>Intel 8051</description>
+	</machine>
+	<machine name="i8255" sourcefile="devices/machine/i8255.cpp" isdevice="yes" runnable="no">
+		<description>Intel 8255 PPI</description>
+	</machine>
+	<machine name="ie15_cpu" sourcefile="devices/cpu/ie15/ie15.cpp" isdevice="yes" runnable="no">
+		<description>ie15 CPU</description>
+	</machine>
+	<machine name="ie15_device" sourcefile="devices/machine/ie15.cpp" isdevice="yes" runnable="no">
+		<description>IE15</description>
+		<biosset name="5chip" description="5-chip firmware (newer)" default="yes"/>
+		<biosset name="6chip" description="6-chip firmware (older)"/>
+		<rom name="dump1.bin" bios="5chip" size="4096" crc="14b82284" sha1="5ac4159fbb1c3b81445605e26cd97a713ae12b5f" region="maincpu" offset="0"/>
+		<rom name="dump5.bin" bios="6chip" size="4096" crc="01f2e065" sha1="2b72dc0594e38a528400cd25aed0c47e0c432895" region="maincpu" offset="0"/>
+		<rom name="chargen-15ie.bin" size="2048" crc="ed16bf6b" sha1="6af9fb75f5375943d5c0ce9ed408e0fb4621b17e" region="chargen" offset="0"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:maincpu" name="ie15_cpu"/>
+		<device_ref tag=":_tmp:keyboard" name="ie15kbd"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<device_ref tag=":_tmp:gfxdecode" name="gfxdecode"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<chip type="cpu" tag=":maincpu" name="ie15 CPU" clock="3080000"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="2400"/>
+		<display tag=":screen" type="raster" rotate="0" width="800" height="275" refresh="50.000000" pixclock="15400000" htotal="1000" hbend="200" hbstart="1000" vtotal="308" vbend="22" vbstart="297" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="91"/>
+		</input>
+		<dipswitch name="RED (Interpret controls)" tag=":io_keyboard" mask="1">
+			<dipvalue name="Off" value="0"/>
+			<dipvalue name="On" value="1" default="yes"/>
+		</dipswitch>
+		<dipswitch name="DUP (Full duplex)" tag=":io_keyboard" mask="8">
+			<dipvalue name="Off" value="0"/>
+			<dipvalue name="On" value="8" default="yes"/>
+		</dipswitch>
+		<dipswitch name="LIN (Online)" tag=":io_keyboard" mask="16">
+			<dipvalue name="Off" value="0"/>
+			<dipvalue name="On" value="16" default="yes"/>
+		</dipswitch>
+		<configuration name="Data Bits" tag=":RS232_DATABITS" mask="15">
+			<confsetting name="7" value="7"/>
+			<confsetting name="8" value="8" default="yes"/>
+		</configuration>
+		<configuration name="Parity" tag=":RS232_PARITY" mask="7">
+			<confsetting name="None" value="0" default="yes"/>
+			<confsetting name="Odd" value="1"/>
+			<confsetting name="Even" value="2"/>
+			<confsetting name="Mark" value="3"/>
+			<confsetting name="Space" value="4"/>
+		</configuration>
+		<configuration name="RX Baud" tag=":RS232_RXBAUD" mask="65535">
+			<confsetting name="300" value="300"/>
+			<confsetting name="600" value="600"/>
+			<confsetting name="1200" value="1200"/>
+			<confsetting name="2400" value="2400"/>
+			<confsetting name="4800" value="4800"/>
+			<confsetting name="9600" value="9600" default="yes"/>
+			<confsetting name="19200" value="19200"/>
+		</configuration>
+		<configuration name="Stop Bits" tag=":RS232_STOPBITS" mask="3">
+			<confsetting name="1" value="1" default="yes"/>
+			<confsetting name="2" value="2"/>
+		</configuration>
+		<configuration name="TX Baud" tag=":RS232_TXBAUD" mask="65535">
+			<confsetting name="300" value="300"/>
+			<confsetting name="600" value="600"/>
+			<confsetting name="1200" value="1200"/>
+			<confsetting name="2400" value="2400"/>
+			<confsetting name="4800" value="4800"/>
+			<confsetting name="9600" value="9600" default="yes"/>
+			<confsetting name="19200" value="19200"/>
+		</configuration>
+	</machine>
+	<machine name="ie15_terminal" sourcefile="devices/bus/rs232/ie15.cpp" isdevice="yes" runnable="no">
+		<description>IE15 Terminal</description>
+		<device_ref tag=":_tmp:ie15" name="ie15_device"/>
+		<device_ref tag=":_tmp:ie15:screen" name="screen"/>
+		<device_ref tag=":_tmp:ie15:maincpu" name="ie15_cpu"/>
+		<device_ref tag=":_tmp:ie15:keyboard" name="ie15kbd"/>
+		<device_ref tag=":_tmp:ie15:mono" name="speaker"/>
+		<device_ref tag=":_tmp:ie15:beeper" name="beep"/>
+		<device_ref tag=":_tmp:ie15:gfxdecode" name="gfxdecode"/>
+		<device_ref tag=":_tmp:ie15:palette" name="palette"/>
+		<chip type="cpu" tag=":ie15:maincpu" name="ie15 CPU" clock="3080000"/>
+		<chip type="audio" tag=":ie15:mono" name="Speaker"/>
+		<chip type="audio" tag=":ie15:beeper" name="Beep" clock="2400"/>
+		<display tag=":ie15:screen" type="raster" rotate="0" width="800" height="275" refresh="50.000000" pixclock="15400000" htotal="1000" hbend="200" hbstart="1000" vtotal="308" vbend="22" vbstart="297" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="91"/>
+		</input>
+		<dipswitch name="RED (Interpret controls)" tag=":ie15:io_keyboard" mask="1">
+			<dipvalue name="Off" value="0"/>
+			<dipvalue name="On" value="1" default="yes"/>
+		</dipswitch>
+		<dipswitch name="DUP (Full duplex)" tag=":ie15:io_keyboard" mask="8">
+			<dipvalue name="Off" value="0"/>
+			<dipvalue name="On" value="8" default="yes"/>
+		</dipswitch>
+		<dipswitch name="LIN (Online)" tag=":ie15:io_keyboard" mask="16">
+			<dipvalue name="Off" value="0"/>
+			<dipvalue name="On" value="16" default="yes"/>
+		</dipswitch>
+		<configuration name="Data Bits" tag=":ie15:RS232_DATABITS" mask="15">
+			<confsetting name="7" value="7"/>
+			<confsetting name="8" value="8" default="yes"/>
+		</configuration>
+		<configuration name="Parity" tag=":ie15:RS232_PARITY" mask="7">
+			<confsetting name="None" value="0" default="yes"/>
+			<confsetting name="Odd" value="1"/>
+			<confsetting name="Even" value="2"/>
+			<confsetting name="Mark" value="3"/>
+			<confsetting name="Space" value="4"/>
+		</configuration>
+		<configuration name="RX Baud" tag=":ie15:RS232_RXBAUD" mask="65535">
+			<confsetting name="300" value="300"/>
+			<confsetting name="600" value="600"/>
+			<confsetting name="1200" value="1200"/>
+			<confsetting name="2400" value="2400"/>
+			<confsetting name="4800" value="4800"/>
+			<confsetting name="9600" value="9600" default="yes"/>
+			<confsetting name="19200" value="19200"/>
+		</configuration>
+		<configuration name="Stop Bits" tag=":ie15:RS232_STOPBITS" mask="3">
+			<confsetting name="1" value="1" default="yes"/>
+			<confsetting name="2" value="2"/>
+		</configuration>
+		<configuration name="TX Baud" tag=":ie15:RS232_TXBAUD" mask="65535">
+			<confsetting name="300" value="300"/>
+			<confsetting name="600" value="600"/>
+			<confsetting name="1200" value="1200"/>
+			<confsetting name="2400" value="2400"/>
+			<confsetting name="4800" value="4800"/>
+			<confsetting name="9600" value="9600" default="yes"/>
+			<confsetting name="19200" value="19200"/>
+		</configuration>
+	</machine>
+	<machine name="ie15kbd" sourcefile="devices/machine/ie15_kbd.cpp" isdevice="yes" runnable="no">
+		<description>15WWW-97-006 Keyboard</description>
+		<rom name="15bbb.rt5" size="512" crc="e6a4226e" sha1="0ee46f5be1b01fa917a6d483bb51463106ae441f" region="ie15kbd" offset="0"/>
+		<input players="1">
+			<control type="keyboard" buttons="91"/>
+		</input>
+	</machine>
+	<machine name="ieee488" sourcefile="devices/bus/ieee488/ieee488.cpp" isdevice="yes" runnable="no">
+		<description>IEEE-488 bus</description>
+	</machine>
+	<machine name="ieee488_slot" sourcefile="devices/bus/ieee488/ieee488.cpp" isdevice="yes" runnable="no">
+		<description>IEEE-488 slot</description>
+	</machine>
+	<machine name="input_buffer" sourcefile="devices/machine/buffer.cpp" isdevice="yes" runnable="no">
+		<description>Input Buffer</description>
+	</machine>
+	<machine name="ins8250" sourcefile="devices/machine/ins8250.cpp" isdevice="yes" runnable="no">
+		<description>National Semiconductor INS8250 UART</description>
+	</machine>
+	<machine name="ioc" sourcefile="devices/machine/acorn_ioc.cpp" isdevice="yes" runnable="no">
+		<description>Acorn IOC</description>
+	</machine>
+	<machine name="ipt_merge_any_hi" sourcefile="devices/machine/input_merger.cpp" isdevice="yes" runnable="no">
+		<description>Input Merger (any high)</description>
+	</machine>
+	<machine name="ls259" sourcefile="devices/machine/74259.cpp" isdevice="yes" runnable="no">
+		<description>74LS259 Addressable Latch</description>
+	</machine>
+	<machine name="lx800" sourcefile="devices/bus/centronics/epson_lx800.cpp" isdevice="yes" runnable="no">
+		<description>Epson LX-800</description>
+		<rom name="lx800.ic3c" size="32768" crc="da06c45b" sha1="9618c940dd10d5b43cd1edd5763b90e6447de667" region="maincpu" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="upd7810"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<device_ref tag=":_tmp:ic3b" name="e05a03"/>
+		<chip type="cpu" tag=":maincpu" name="NEC uPD7810" clock="14745600"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="4000"/>
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="3"/>
+		</input>
+		<dipswitch name="Typeface" tag=":DIPSW1" mask="1">
+			<diplocation name="SW 1" number="1" inverted="yes"/>
+			<dipvalue name="Normal" value="0" default="yes"/>
+			<dipvalue name="Condensed" value="1"/>
+		</dipswitch>
+		<dipswitch name="Shape of zero" tag=":DIPSW1" mask="2">
+			<diplocation name="SW 1" number="2" inverted="yes"/>
+			<dipvalue name="Not slashed" value="0" default="yes"/>
+			<dipvalue name="Slashed" value="2"/>
+		</dipswitch>
+		<dipswitch name="Character table" tag=":DIPSW1" mask="4">
+			<diplocation name="SW 1" number="3" inverted="yes"/>
+			<dipvalue name="Italics" value="0" default="yes"/>
+			<dipvalue name="Graphics" value="4"/>
+		</dipswitch>
+		<dipswitch name="Paper-out detection" tag=":DIPSW1" mask="8">
+			<diplocation name="SW 1" number="4" inverted="yes"/>
+			<dipvalue name="Invalid" value="0" default="yes"/>
+			<dipvalue name="Valid" value="8"/>
+		</dipswitch>
+		<dipswitch name="Printing quality" tag=":DIPSW1" mask="16">
+			<diplocation name="SW 1" number="5" inverted="yes"/>
+			<dipvalue name="Draft" value="0" default="yes"/>
+			<dipvalue name="NLQ" value="16"/>
+		</dipswitch>
+		<dipswitch name="International character set" tag=":DIPSW1" mask="224">
+			<diplocation name="SW 1" number="6" inverted="yes"/>
+			<diplocation name="SW 1" number="7" inverted="yes"/>
+			<diplocation name="SW 1" number="8" inverted="yes"/>
+			<dipvalue name="USA" value="224" default="yes"/>
+			<dipvalue name="France" value="96"/>
+			<dipvalue name="Germany" value="160"/>
+			<dipvalue name="UK" value="32"/>
+			<dipvalue name="Denmark" value="192"/>
+			<dipvalue name="Sweden" value="64"/>
+			<dipvalue name="Italy" value="128"/>
+			<dipvalue name="Spain" value="0"/>
+		</dipswitch>
+		<dipswitch name="Page length" tag=":DIPSW2" mask="1">
+			<diplocation name="SW 2" number="1" inverted="yes"/>
+			<dipvalue name="11&quot;" value="0" default="yes"/>
+			<dipvalue name="12&quot;" value="1"/>
+		</dipswitch>
+		<dipswitch name="Cut-sheet feeder mode" tag=":DIPSW2" mask="2">
+			<diplocation name="SW 2" number="2" inverted="yes"/>
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="2"/>
+		</dipswitch>
+		<dipswitch name="Skip over perforation" tag=":DIPSW2" mask="4">
+			<diplocation name="SW 2" number="3" inverted="yes"/>
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="1&quot;" value="4"/>
+		</dipswitch>
+		<dipswitch name="Auto line feed" tag=":DIPSW2" mask="8">
+			<diplocation name="SW 2" number="4" inverted="yes"/>
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="8"/>
+		</dipswitch>
+	</machine>
+	<machine name="lx810l" sourcefile="devices/bus/centronics/epson_lx810l.cpp" isdevice="yes" runnable="no">
+		<description>Epson LX-810L</description>
+		<rom name="lx810l.ic3c" size="32768" crc="a66454e1" sha1="8e6f2f98abcbd8af6e34b9ba746edf0d18aef843" region="maincpu" offset="0"/>
+		<rom name="at93c06" size="32" status="nodump" region="eeprom" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="upd7810"/>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:dac" name="dac"/>
+		<device_ref tag=":_tmp:e05a30" name="e05a30"/>
+		<device_ref tag=":_tmp:eeprom" name="93c06_16"/>
+		<device_ref tag=":_tmp:bitmap_printer" name="bitmap_printer"/>
+		<device_ref tag=":_tmp:bitmap_printer:screen" name="screen"/>
+		<device_ref tag=":_tmp:bitmap_printer:pf_stepper" name="stepper"/>
+		<device_ref tag=":_tmp:bitmap_printer:cr_stepper" name="stepper"/>
+		<chip type="cpu" tag=":maincpu" name="NEC uPD7810" clock="14745600"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":dac" name="1-Bit DAC"/>
+		<display tag=":bitmap_printer:screen" type="raster" rotate="0" width="1024" height="384" refresh="60.000000" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="6"/>
+		</input>
+		<dipswitch name="Character spacing" tag=":DIPSW1" mask="1">
+			<diplocation name="SW 1" number="1" inverted="yes"/>
+			<dipvalue name="10 cpi" value="0" default="yes"/>
+			<dipvalue name="12 cpi" value="1"/>
+		</dipswitch>
+		<dipswitch name="Shape of zero" tag=":DIPSW1" mask="2">
+			<diplocation name="SW 1" number="2" inverted="yes"/>
+			<dipvalue name="Not slashed" value="0" default="yes"/>
+			<dipvalue name="Slashed" value="2"/>
+		</dipswitch>
+		<dipswitch name="Page length" tag=":DIPSW1" mask="12">
+			<diplocation name="SW 1" number="3" inverted="yes"/>
+			<diplocation name="SW 1" number="4" inverted="yes"/>
+			<dipvalue name="8.5&quot;" value="8"/>
+			<dipvalue name="11&quot;" value="0" default="yes"/>
+			<dipvalue name="11.7&quot; (A4)" value="12"/>
+			<dipvalue name="12&quot;" value="4"/>
+		</dipswitch>
+		<dipswitch name="Character table" tag=":DIPSW1" mask="16">
+			<diplocation name="SW 1" number="5" inverted="yes"/>
+			<dipvalue name="Italics" value="0" default="yes"/>
+			<dipvalue name="Graphics" value="16"/>
+		</dipswitch>
+		<dipswitch name="International character set" tag=":DIPSW1" mask="224">
+			<diplocation name="SW 1" number="6" inverted="yes"/>
+			<diplocation name="SW 1" number="7" inverted="yes"/>
+			<diplocation name="SW 1" number="8" inverted="yes"/>
+			<dipvalue name="USA (PC 437)" value="224" default="yes"/>
+			<dipvalue name="France (PC 850)" value="96"/>
+			<dipvalue name="Germany (PC 860)" value="160"/>
+			<dipvalue name="UK (PC 863)" value="32"/>
+			<dipvalue name="Denmark (PC 865)" value="192"/>
+			<dipvalue name="Sweden (PC 437)" value="64"/>
+			<dipvalue name="Italy (PC 437)" value="128"/>
+			<dipvalue name="Spain (PC 437)" value="0"/>
+		</dipswitch>
+		<dipswitch name="Short tear-off" tag=":DIPSW2" mask="1">
+			<diplocation name="SW 2" number="1" inverted="yes"/>
+			<dipvalue name="Invalid" value="1" default="yes"/>
+			<dipvalue name="Valid" value="0"/>
+		</dipswitch>
+		<dipswitch name="Cut-sheet feeder mode" tag=":DIPSW2" mask="2">
+			<diplocation name="SW 2" number="2" inverted="yes"/>
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="2"/>
+		</dipswitch>
+		<dipswitch name="Skip over perforation" tag=":DIPSW2" mask="4">
+			<diplocation name="SW 2" number="3" inverted="yes"/>
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="1&quot;" value="4"/>
+		</dipswitch>
+		<dipswitch name="Auto line feed" tag=":DIPSW2" mask="8">
+			<diplocation name="SW 2" number="4" inverted="yes"/>
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="8"/>
+		</dipswitch>
+		<configuration name="Draw Inch Marks" tag=":bitmap_printer:DRAWMARKS" mask="3">
+			<confsetting name="Off" value="0"/>
+			<confsetting name="with marks" value="1"/>
+			<confsetting name="with numbers" value="2" default="yes"/>
+		</configuration>
+		<adjuster name="Printer Bottom Margin" default="18"/>
+		<adjuster name="Printer Top Margin" default="18"/>
+	</machine>
+	<machine name="m68000" sourcefile="devices/cpu/m68000/m68000.cpp" isdevice="yes" runnable="no">
+		<description>Motorola MC68000</description>
+	</machine>
+	<machine name="m6802" sourcefile="devices/cpu/m6800/m6800.cpp" isdevice="yes" runnable="no">
+		<description>Motorola MC6802</description>
+	</machine>
+	<machine name="m6803" sourcefile="devices/cpu/m6800/m6801.cpp" isdevice="yes" runnable="no">
+		<description>Motorola MC6803</description>
+	</machine>
+	<machine name="mc146818" sourcefile="devices/machine/mc146818.cpp" isdevice="yes" runnable="no">
+		<description>MC146818 RTC</description>
+	</machine>
+	<machine name="mc6809" sourcefile="devices/cpu/m6809/m6809.cpp" isdevice="yes" runnable="no">
+		<description>Motorola MC6809</description>
+	</machine>
+	<machine name="mc6845" sourcefile="devices/video/mc6845.cpp" isdevice="yes" runnable="no">
+		<description>Motorola MC6845 CRTC</description>
+	</machine>
+	<machine name="mc6854" sourcefile="devices/machine/mc6854.cpp" isdevice="yes" runnable="no">
+		<description>Motorola MC6854 ADLC</description>
+	</machine>
+	<machine name="memc" sourcefile="devices/machine/acorn_memc.cpp" isdevice="yes" runnable="no">
+		<description>Acorn MEMC</description>
+	</machine>
+	<machine name="micromike" sourcefile="devices/bus/bbc/analogue/micromike.cpp" isdevice="yes" runnable="no">
+		<description>Micro Mike</description>
+		<device_ref tag=":_tmp:mic" name="microphone"/>
+		<chip type="audio" tag=":mic" name="Microphone"/>
+		<sound channels="0"/>
+		<input players="1">
+			<control type="only_buttons" buttons="1"/>
+		</input>
+	</machine>
+	<machine name="microphone" sourcefile="emu/speaker.cpp" isdevice="yes" runnable="no">
+		<description>Microphone</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="midi_port" sourcefile="devices/bus/midi/midi.cpp" isdevice="yes" runnable="no">
+		<description>MIDI port</description>
+	</machine>
+	<machine name="mockingboardd" sourcefile="devices/bus/rs232/mboardd.cpp" isdevice="yes" runnable="no">
+		<description>Sweet Micro Systems Mockingboard D</description>
+		<rom name="mockingboard d rom.bin" size="2048" crc="277b1813" sha1="e8d20f4b59fe867ff76434d35a14d2cbdc8533e3" region="mbcpu" offset="0"/>
+		<device_ref tag=":_tmp:mbdcpu" name="m6803"/>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:ay1" name="ay8913"/>
+		<device_ref tag=":_tmp:ay2" name="ay8913"/>
+		<chip type="cpu" tag=":mbdcpu" name="Motorola MC6803" clock="4915200"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":ay1" name="AY-3-8913 PSG" clock="1022727"/>
+		<chip type="audio" tag=":ay2" name="AY-3-8913 PSG" clock="1022727"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="mos6522" sourcefile="devices/machine/6522via.cpp" isdevice="yes" runnable="no">
+		<description>MOS 6522 VIA</description>
+	</machine>
+	<machine name="mos8580" sourcefile="devices/sound/mos6581.cpp" isdevice="yes" runnable="no">
+		<description>MOS 8580 SID</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="mz1p16" sourcefile="devices/bus/centronics/mz1p16.cpp" isdevice="yes" runnable="no">
+		<description>Sharp MZ-1P16 Plotter Printer</description>
+		<rom name="m5m8050h-059p.ic1" size="4096" crc="beb12a84" sha1="2e059c2f7d653294c77fe8e1a37436b4c028e122" region="mcu" offset="0"/>
+		<device_ref tag=":_tmp:mcu" name="i8050"/>
+		<device_ref tag=":_tmp:buffer" name="input_buffer"/>
+		<chip type="cpu" tag=":mcu" name="Intel 8050" clock="6000000"/>
+		<feature type="printer" status="unemulated"/>
+	</machine>
+	<machine name="neomania_adapter" sourcefile="devices/bus/centronics/neomania_adapter.cpp" isdevice="yes" runnable="no">
+		<description>Neo Mania Adapter JAMMA board</description>
+		<input players="2" coins="2" service="yes">
+			<control type="joy" player="1" buttons="4" ways="8"/>
+			<control type="joy" player="2" buttons="4" ways="8"/>
+		</input>
+	</machine>
+	<machine name="nlq401" sourcefile="devices/bus/centronics/nlq401.cpp" isdevice="yes" runnable="no">
+		<description>Schneider NLQ 401 Matrix Printer</description>
+		<rom name="schneider_nlq401_rev004.bin" size="16384" crc="5c331aed" sha1="b6374abaebb8e484e573caa21b1cc87f1554c8d6" region="prom" offset="0"/>
+		<device_ref tag=":_tmp:mcu" name="upd7810"/>
+		<device_ref tag=":_tmp:inpexp" name="tms1025"/>
+		<device_ref tag=":_tmp:outexp" name="tms1025"/>
+		<chip type="cpu" tag=":mcu" name="NEC uPD7810" clock="11000000"/>
+		<dipswitch name="DIP28" tag=":P2" mask="2">
+			<diplocation name="SW2" number="8"/>
+			<dipvalue name="Off" value="2" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP27" tag=":P2" mask="4">
+			<diplocation name="SW2" number="7"/>
+			<dipvalue name="Off" value="4" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP16" tag=":P2" mask="8">
+			<diplocation name="SW1" number="3"/>
+			<dipvalue name="Off" value="8" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP17" tag=":P3" mask="1">
+			<diplocation name="SW1" number="2"/>
+			<dipvalue name="Off" value="1" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP18" tag=":P3" mask="2">
+			<diplocation name="SW1" number="1"/>
+			<dipvalue name="Off" value="2" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP26" tag=":P3" mask="4">
+			<diplocation name="SW2" number="6"/>
+			<dipvalue name="Off" value="4" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP25" tag=":P3" mask="8">
+			<diplocation name="SW2" number="5"/>
+			<dipvalue name="Off" value="8" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP24" tag=":P4" mask="1">
+			<diplocation name="SW2" number="4"/>
+			<dipvalue name="Off" value="1" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP23" tag=":P4" mask="2">
+			<diplocation name="SW2" number="3"/>
+			<dipvalue name="Off" value="2" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP22" tag=":P4" mask="4">
+			<diplocation name="SW2" number="2"/>
+			<dipvalue name="Off" value="4" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP21" tag=":P4" mask="8">
+			<diplocation name="SW2" number="1"/>
+			<dipvalue name="Off" value="8" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP11" tag=":SW1" mask="1">
+			<diplocation name="SW1" number="8"/>
+			<dipvalue name="Off" value="1" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP12" tag=":SW1" mask="2">
+			<diplocation name="SW1" number="7"/>
+			<dipvalue name="Off" value="2" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP13" tag=":SW1" mask="4">
+			<diplocation name="SW1" number="6"/>
+			<dipvalue name="Off" value="4" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP14" tag=":SW1" mask="8">
+			<diplocation name="SW1" number="5"/>
+			<dipvalue name="Off" value="8" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="DIP15" tag=":SW1" mask="16">
+			<diplocation name="SW1" number="4"/>
+			<dipvalue name="Off" value="16" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<feature type="printer" status="unemulated"/>
+	</machine>
+	<machine name="ns32016" sourcefile="devices/cpu/ns32000/ns32000.cpp" isdevice="yes" runnable="no">
+		<description>National Semiconductor NS32016</description>
+	</machine>
+	<machine name="ns32081" sourcefile="devices/machine/ns32081.cpp" isdevice="yes" runnable="no">
+		<description>National Semiconductor NS32081 Floating-Point Unit</description>
+	</machine>
+	<machine name="nscsi_bus" sourcefile="devices/machine/nscsi_bus.cpp" isdevice="yes" runnable="no">
+		<description>SCSI Bus (new)</description>
+	</machine>
+	<machine name="nscsi_connector" sourcefile="devices/machine/nscsi_bus.cpp" isdevice="yes" runnable="no">
+		<description>SCSI Connector Abstraction (new)</description>
+	</machine>
+	<machine name="nss_tvinterface" sourcefile="devices/bus/rs232/nss_tvinterface.cpp" isdevice="yes" runnable="no">
+		<description>Novag Super System TV Interface</description>
+		<biosset name="de" description="German" default="yes"/>
+		<biosset name="fr" description="French"/>
+		<rom name="tvgr_011091" bios="de" size="8192" crc="0ff64cec" sha1="d35881111cdf8e85a843e3b085447d07244d8d70" region="maincpu" offset="e000"/>
+		<rom name="white_27c64a" bios="fr" size="8192" crc="3eefa63d" sha1="2e6e0abb50f5722c81baedfd514d660f9c1c814e" region="maincpu" offset="e000"/>
+		<rom name="cg_930" size="8192" crc="98287b9d" sha1="b20d7856e4739bafcd66434adf9881824f8a611b" region="cg_rom" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="hd6303r"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:crtc" name="mc6845"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<chip type="cpu" tag=":maincpu" name="Hitachi HD6303R" clock="4915200"/>
+		<display tag=":screen" type="raster" rotate="0" width="320" height="200" refresh="58.336783" pixclock="7159090" htotal="472" hbend="0" hbstart="320" vtotal="260" vbend="0" vbstart="200" />
+		<input players="1">
+			<control type="only_buttons" buttons="2"/>
+		</input>
+		<configuration name="Serial TxD" tag=":CONF" mask="1">
+			<confsetting name="Off" value="1" default="yes"/>
+			<confsetting name="On" value="0"/>
+		</configuration>
+		<configuration name="Video Mode" tag=":IN" mask="8">
+			<confsetting name="NTSC" value="0" default="yes"/>
+			<confsetting name="PAL" value="8"/>
+		</configuration>
+	</machine>
+	<machine name="null_modem" sourcefile="devices/bus/rs232/null_modem.cpp" isdevice="yes" runnable="no">
+		<description>RS-232 Null Modem</description>
+		<device_ref tag=":_tmp:stream" name="bitbanger"/>
+		<configuration name="Flow Control" tag=":FLOW_CONTROL" mask="7">
+			<confsetting name="Off" value="0" default="yes"/>
+			<confsetting name="RTS" value="1"/>
+			<confsetting name="DTR" value="2"/>
+			<confsetting name="XON/XOFF" value="4"/>
+		</configuration>
+		<configuration name="CR/LF Input Conversion" tag=":FLOW_CONTROL" mask="24">
+			<confsetting name="Off" value="0" default="yes"/>
+			<confsetting name="LF to CR" value="8"/>
+			<confsetting name="CR/LF to CR" value="16"/>
+			<confsetting name="LF to CR/LF" value="24"/>
+		</configuration>
+		<configuration name="Delay After CR" tag=":FLOW_CONTROL" mask="224">
+			<confsetting name="None" value="0" default="yes"/>
+			<confsetting name="10 ms" value="32"/>
+			<confsetting name="20 ms" value="64"/>
+			<confsetting name="40 ms" value="96"/>
+			<confsetting name="80 ms" value="128"/>
+			<confsetting name="160 ms" value="160"/>
+			<confsetting name="320 ms" value="192"/>
+			<confsetting name="640 ms" value="224"/>
+		</configuration>
+		<configuration name="Data Bits" tag=":RS232_DATABITS" mask="255">
+			<confsetting name="5" value="0"/>
+			<confsetting name="6" value="1"/>
+			<confsetting name="7" value="2"/>
+			<confsetting name="8" value="3" default="yes"/>
+		</configuration>
+		<configuration name="Parity" tag=":RS232_PARITY" mask="255">
+			<confsetting name="None" value="0" default="yes"/>
+			<confsetting name="Odd" value="1"/>
+			<confsetting name="Even" value="2"/>
+			<confsetting name="Mark" value="3"/>
+			<confsetting name="Space" value="4"/>
+		</configuration>
+		<configuration name="RX Baud" tag=":RS232_RXBAUD" mask="255">
+			<confsetting name="50" value="14"/>
+			<confsetting name="75" value="15"/>
+			<confsetting name="110" value="0"/>
+			<confsetting name="134.5" value="16"/>
+			<confsetting name="150" value="1"/>
+			<confsetting name="200" value="17"/>
+			<confsetting name="300" value="2"/>
+			<confsetting name="600" value="3"/>
+			<confsetting name="1200" value="4"/>
+			<confsetting name="1800" value="18"/>
+			<confsetting name="2000" value="19"/>
+			<confsetting name="2400" value="5"/>
+			<confsetting name="3600" value="20"/>
+			<confsetting name="4800" value="6"/>
+			<confsetting name="7200" value="21"/>
+			<confsetting name="9600" value="7" default="yes"/>
+			<confsetting name="14400" value="8"/>
+			<confsetting name="19200" value="9"/>
+			<confsetting name="28800" value="10"/>
+			<confsetting name="38400" value="11"/>
+			<confsetting name="57600" value="12"/>
+			<confsetting name="76800" value="23"/>
+			<confsetting name="78125" value="24"/>
+			<confsetting name="111900" value="22"/>
+			<confsetting name="115200" value="13"/>
+		</configuration>
+		<configuration name="Stop Bits" tag=":RS232_STOPBITS" mask="255">
+			<confsetting name="0" value="0"/>
+			<confsetting name="1" value="1" default="yes"/>
+			<confsetting name="1.5" value="2"/>
+			<confsetting name="2" value="3"/>
+		</configuration>
+		<configuration name="TX Baud" tag=":RS232_TXBAUD" mask="255">
+			<confsetting name="50" value="14"/>
+			<confsetting name="75" value="15"/>
+			<confsetting name="110" value="0"/>
+			<confsetting name="134.5" value="16"/>
+			<confsetting name="150" value="1"/>
+			<confsetting name="200" value="17"/>
+			<confsetting name="300" value="2"/>
+			<confsetting name="600" value="3"/>
+			<confsetting name="1200" value="4"/>
+			<confsetting name="1800" value="18"/>
+			<confsetting name="2000" value="19"/>
+			<confsetting name="2400" value="5"/>
+			<confsetting name="3600" value="20"/>
+			<confsetting name="4800" value="6"/>
+			<confsetting name="7200" value="21"/>
+			<confsetting name="9600" value="7" default="yes"/>
+			<confsetting name="14400" value="8"/>
+			<confsetting name="19200" value="9"/>
+			<confsetting name="28800" value="10"/>
+			<confsetting name="38400" value="11"/>
+			<confsetting name="57600" value="12"/>
+			<confsetting name="76800" value="23"/>
+			<confsetting name="78125" value="24"/>
+			<confsetting name="111900" value="22"/>
+			<confsetting name="115200" value="13"/>
+		</configuration>
+		<device type="bitbanger" tag=":stream">
+			<instance name="bitbanger" briefname="bitb"/>
+			<extension name=""/>
+		</device>
+	</machine>
+	<machine name="nvram" sourcefile="devices/machine/nvram.cpp" isdevice="yes" runnable="no">
+		<description>NVRAM</description>
+	</machine>
+	<machine name="output_latch" sourcefile="devices/machine/output_latch.cpp" isdevice="yes" runnable="no">
+		<description>Output Latch</description>
+	</machine>
+	<machine name="p72" sourcefile="devices/bus/centronics/nec_p72.cpp" isdevice="yes" runnable="no">
+		<description>NEC PinWriter P72</description>
+		<rom name="p72.2c" size="1048576" crc="2bc6846f" sha1="10430f1d3b73ad413d77053515d9d53831a1341b" region="maincpu" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="v33"/>
+		<chip type="cpu" tag=":maincpu" name="NEC V33" clock="8000000"/>
+	</machine>
+	<machine name="palette" sourcefile="emu/emupal.cpp" isdevice="yes" runnable="no">
+		<description>palette</description>
+	</machine>
+	<machine name="pc6022" sourcefile="devices/bus/centronics/pc6022.cpp" isdevice="yes" runnable="no">
+		<description>NEC PC-6022 Color Plotter Printer</description>
+		<rom name="upd7801g-138.bin" size="4096" crc="0a294989" sha1="fab85e88566ffa10923dec3a1a6b0d8346bc69ec" region="cpu" offset="0"/>
+		<device_ref tag=":_tmp:cpu" name="upd7801"/>
+		<device_ref tag=":_tmp:busy" name="ipt_merge_any_hi"/>
+		<chip type="cpu" tag=":cpu" name="NEC uPD7801" clock="4000000"/>
+		<input players="1">
+			<control type="keypad" buttons="7"/>
+		</input>
+		<feature type="printer" status="unemulated"/>
+	</machine>
+	<machine name="pcf8573" sourcefile="devices/machine/pcf8573.cpp" isdevice="yes" runnable="no">
+		<description>PCF8573 RTC with Power Fail Detector</description>
+	</machine>
+	<machine name="pia6821" sourcefile="devices/machine/6821pia.cpp" isdevice="yes" runnable="no">
+		<description>6821 PIA</description>
+	</machine>
+	<machine name="printer_image" sourcefile="devices/imagedev/printer.cpp" isdevice="yes" runnable="no">
+		<description>Printer</description>
+	</machine>
+	<machine name="pseudo_terminal" sourcefile="devices/bus/rs232/pty.cpp" isdevice="yes" runnable="no">
+		<description>Pseudo Terminal</description>
+		<configuration name="Flow Control" tag=":FLOW_CONTROL" mask="7">
+			<confsetting name="Off" value="0" default="yes"/>
+			<confsetting name="RTS" value="1"/>
+			<confsetting name="DTR" value="2"/>
+			<confsetting name="XON/XOFF" value="4"/>
+		</configuration>
+		<configuration name="Data Bits" tag=":RS232_DATABITS" mask="255">
+			<confsetting name="5" value="0"/>
+			<confsetting name="6" value="1"/>
+			<confsetting name="7" value="2"/>
+			<confsetting name="8" value="3" default="yes"/>
+		</configuration>
+		<configuration name="Parity" tag=":RS232_PARITY" mask="255">
+			<confsetting name="None" value="0" default="yes"/>
+			<confsetting name="Odd" value="1"/>
+			<confsetting name="Even" value="2"/>
+			<confsetting name="Mark" value="3"/>
+			<confsetting name="Space" value="4"/>
+		</configuration>
+		<configuration name="RX Baud" tag=":RS232_RXBAUD" mask="255">
+			<confsetting name="50" value="14"/>
+			<confsetting name="75" value="15"/>
+			<confsetting name="110" value="0"/>
+			<confsetting name="134.5" value="16"/>
+			<confsetting name="150" value="1"/>
+			<confsetting name="200" value="17"/>
+			<confsetting name="300" value="2"/>
+			<confsetting name="600" value="3"/>
+			<confsetting name="1200" value="4"/>
+			<confsetting name="1800" value="18"/>
+			<confsetting name="2000" value="19"/>
+			<confsetting name="2400" value="5"/>
+			<confsetting name="3600" value="20"/>
+			<confsetting name="4800" value="6"/>
+			<confsetting name="7200" value="21"/>
+			<confsetting name="9600" value="7" default="yes"/>
+			<confsetting name="14400" value="8"/>
+			<confsetting name="19200" value="9"/>
+			<confsetting name="28800" value="10"/>
+			<confsetting name="38400" value="11"/>
+			<confsetting name="57600" value="12"/>
+			<confsetting name="76800" value="23"/>
+			<confsetting name="78125" value="24"/>
+			<confsetting name="111900" value="22"/>
+			<confsetting name="115200" value="13"/>
+		</configuration>
+		<configuration name="Stop Bits" tag=":RS232_STOPBITS" mask="255">
+			<confsetting name="0" value="0"/>
+			<confsetting name="1" value="1" default="yes"/>
+			<confsetting name="1.5" value="2"/>
+			<confsetting name="2" value="3"/>
+		</configuration>
+		<configuration name="TX Baud" tag=":RS232_TXBAUD" mask="255">
+			<confsetting name="50" value="14"/>
+			<confsetting name="75" value="15"/>
+			<confsetting name="110" value="0"/>
+			<confsetting name="134.5" value="16"/>
+			<confsetting name="150" value="1"/>
+			<confsetting name="200" value="17"/>
+			<confsetting name="300" value="2"/>
+			<confsetting name="600" value="3"/>
+			<confsetting name="1200" value="4"/>
+			<confsetting name="1800" value="18"/>
+			<confsetting name="2000" value="19"/>
+			<confsetting name="2400" value="5"/>
+			<confsetting name="3600" value="20"/>
+			<confsetting name="4800" value="6"/>
+			<confsetting name="7200" value="21"/>
+			<confsetting name="9600" value="7" default="yes"/>
+			<confsetting name="14400" value="8"/>
+			<confsetting name="19200" value="9"/>
+			<confsetting name="28800" value="10"/>
+			<confsetting name="38400" value="11"/>
+			<confsetting name="57600" value="12"/>
+			<confsetting name="76800" value="23"/>
+			<confsetting name="78125" value="24"/>
+			<confsetting name="111900" value="22"/>
+			<confsetting name="115200" value="13"/>
+		</configuration>
+	</machine>
+	<machine name="quickload" sourcefile="devices/imagedev/snapquik.cpp" isdevice="yes" runnable="no">
+		<description>Quickload</description>
+	</machine>
+	<machine name="r65c102" sourcefile="devices/cpu/m6502/r65c02.cpp" isdevice="yes" runnable="no">
+		<description>Rockwell R65C102</description>
+	</machine>
+	<machine name="r65c22" sourcefile="devices/machine/6522via.cpp" isdevice="yes" runnable="no">
+		<description>Rockwell R65C22 VIA</description>
+	</machine>
+	<machine name="ram" sourcefile="devices/machine/ram.cpp" isdevice="yes" runnable="no">
+		<description>RAM</description>
+	</machine>
+	<machine name="robinlp" sourcefile="devices/bus/bbc/analogue/lightpen.cpp" isdevice="yes" runnable="no">
+		<description>The Robin Educational Light Pen</description>
+		<input players="1">
+			<control type="lightgun" buttons="1" minimum="0" maximum="1023" sensitivity="50" keydelta="10"/>
+		</input>
+	</machine>
+	<machine name="rs232" sourcefile="devices/bus/rs232/rs232.cpp" isdevice="yes" runnable="no">
+		<description>RS-232 Port</description>
+	</machine>
+	<machine name="rs232_loopback" sourcefile="devices/bus/rs232/loopback.cpp" isdevice="yes" runnable="no">
+		<description>RS-232 Loopback</description>
+	</machine>
+	<machine name="rs232_mouse_hle_msystems" sourcefile="devices/bus/rs232/hlemouse.cpp" isdevice="yes" runnable="no">
+		<description>Mouse Systems Non-rotatable Mouse (HLE)</description>
+		<input players="1">
+			<control type="mouse" buttons="3" minimum="0" maximum="61440" sensitivity="100"/>
+		</input>
+	</machine>
+	<machine name="rs232_patch_box" sourcefile="devices/bus/rs232/patchbox.cpp" isdevice="yes" runnable="no">
+		<description>RS-232 Patch Box</description>
+		<device_ref tag=":_tmp:dce" name="rs232"/>
+		<configuration name="TxD Source (V.24 103)" tag=":CONF0" mask="15">
+			<confsetting name="TxD" value="0" default="yes"/>
+			<confsetting name="RxD" value="1"/>
+			<confsetting name="RTS" value="2"/>
+			<confsetting name="CTS" value="3"/>
+			<confsetting name="DSR" value="4"/>
+			<confsetting name="DTR" value="5"/>
+			<confsetting name="DCD" value="6"/>
+			<confsetting name="SpdS" value="7"/>
+			<confsetting name="SI" value="8"/>
+			<confsetting name="ETC" value="9"/>
+			<confsetting name="TxC" value="10"/>
+			<confsetting name="RxC" value="11"/>
+			<confsetting name="RI" value="12"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<configuration name="RxD Source (V.24 104)" tag=":CONF1" mask="15">
+			<confsetting name="TxD" value="0"/>
+			<confsetting name="RxD" value="1" default="yes"/>
+			<confsetting name="RTS" value="2"/>
+			<confsetting name="CTS" value="3"/>
+			<confsetting name="DSR" value="4"/>
+			<confsetting name="DTR" value="5"/>
+			<confsetting name="DCD" value="6"/>
+			<confsetting name="SpdS" value="7"/>
+			<confsetting name="SI" value="8"/>
+			<confsetting name="ETC" value="9"/>
+			<confsetting name="TxC" value="10"/>
+			<confsetting name="RxC" value="11"/>
+			<confsetting name="RI" value="12"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<configuration name="TxC Source (V.24 114)" tag=":CONF10" mask="15">
+			<confsetting name="TxD" value="0"/>
+			<confsetting name="RxD" value="1"/>
+			<confsetting name="RTS" value="2"/>
+			<confsetting name="CTS" value="3"/>
+			<confsetting name="DSR" value="4"/>
+			<confsetting name="DTR" value="5"/>
+			<confsetting name="DCD" value="6"/>
+			<confsetting name="SpdS" value="7"/>
+			<confsetting name="SI" value="8"/>
+			<confsetting name="ETC" value="9"/>
+			<confsetting name="TxC" value="10" default="yes"/>
+			<confsetting name="RxC" value="11"/>
+			<confsetting name="RI" value="12"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<configuration name="RxC Source (V.24 115)" tag=":CONF11" mask="15">
+			<confsetting name="TxD" value="0"/>
+			<confsetting name="RxD" value="1"/>
+			<confsetting name="RTS" value="2"/>
+			<confsetting name="CTS" value="3"/>
+			<confsetting name="DSR" value="4"/>
+			<confsetting name="DTR" value="5"/>
+			<confsetting name="DCD" value="6"/>
+			<confsetting name="SpdS" value="7"/>
+			<confsetting name="SI" value="8"/>
+			<confsetting name="ETC" value="9"/>
+			<confsetting name="TxC" value="10"/>
+			<confsetting name="RxC" value="11" default="yes"/>
+			<confsetting name="RI" value="12"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<configuration name="RI Source (V.24 125)" tag=":CONF12" mask="15">
+			<confsetting name="TxD" value="0"/>
+			<confsetting name="RxD" value="1"/>
+			<confsetting name="RTS" value="2"/>
+			<confsetting name="CTS" value="3"/>
+			<confsetting name="DSR" value="4"/>
+			<confsetting name="DTR" value="5"/>
+			<confsetting name="DCD" value="6"/>
+			<confsetting name="SpdS" value="7"/>
+			<confsetting name="SI" value="8"/>
+			<confsetting name="ETC" value="9"/>
+			<confsetting name="TxC" value="10"/>
+			<confsetting name="RxC" value="11"/>
+			<confsetting name="RI" value="12" default="yes"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<configuration name="RTS Source (V.24 105)" tag=":CONF2" mask="15">
+			<confsetting name="TxD" value="0"/>
+			<confsetting name="RxD" value="1"/>
+			<confsetting name="RTS" value="2" default="yes"/>
+			<confsetting name="CTS" value="3"/>
+			<confsetting name="DSR" value="4"/>
+			<confsetting name="DTR" value="5"/>
+			<confsetting name="DCD" value="6"/>
+			<confsetting name="SpdS" value="7"/>
+			<confsetting name="SI" value="8"/>
+			<confsetting name="ETC" value="9"/>
+			<confsetting name="TxC" value="10"/>
+			<confsetting name="RxC" value="11"/>
+			<confsetting name="RI" value="12"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<configuration name="CTS Source (V.24 106)" tag=":CONF3" mask="15">
+			<confsetting name="TxD" value="0"/>
+			<confsetting name="RxD" value="1"/>
+			<confsetting name="RTS" value="2"/>
+			<confsetting name="CTS" value="3" default="yes"/>
+			<confsetting name="DSR" value="4"/>
+			<confsetting name="DTR" value="5"/>
+			<confsetting name="DCD" value="6"/>
+			<confsetting name="SpdS" value="7"/>
+			<confsetting name="SI" value="8"/>
+			<confsetting name="ETC" value="9"/>
+			<confsetting name="TxC" value="10"/>
+			<confsetting name="RxC" value="11"/>
+			<confsetting name="RI" value="12"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<configuration name="DSR Source (V.24 107)" tag=":CONF4" mask="15">
+			<confsetting name="TxD" value="0"/>
+			<confsetting name="RxD" value="1"/>
+			<confsetting name="RTS" value="2"/>
+			<confsetting name="CTS" value="3"/>
+			<confsetting name="DSR" value="4" default="yes"/>
+			<confsetting name="DTR" value="5"/>
+			<confsetting name="DCD" value="6"/>
+			<confsetting name="SpdS" value="7"/>
+			<confsetting name="SI" value="8"/>
+			<confsetting name="ETC" value="9"/>
+			<confsetting name="TxC" value="10"/>
+			<confsetting name="RxC" value="11"/>
+			<confsetting name="RI" value="12"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<configuration name="DTR Source (V.24 108/2)" tag=":CONF5" mask="15">
+			<confsetting name="TxD" value="0"/>
+			<confsetting name="RxD" value="1"/>
+			<confsetting name="RTS" value="2"/>
+			<confsetting name="CTS" value="3"/>
+			<confsetting name="DSR" value="4"/>
+			<confsetting name="DTR" value="5" default="yes"/>
+			<confsetting name="DCD" value="6"/>
+			<confsetting name="SpdS" value="7"/>
+			<confsetting name="SI" value="8"/>
+			<confsetting name="ETC" value="9"/>
+			<confsetting name="TxC" value="10"/>
+			<confsetting name="RxC" value="11"/>
+			<confsetting name="RI" value="12"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<configuration name="DCD Source (V.24 109)" tag=":CONF6" mask="15">
+			<confsetting name="TxD" value="0"/>
+			<confsetting name="RxD" value="1"/>
+			<confsetting name="RTS" value="2"/>
+			<confsetting name="CTS" value="3"/>
+			<confsetting name="DSR" value="4"/>
+			<confsetting name="DTR" value="5"/>
+			<confsetting name="DCD" value="6" default="yes"/>
+			<confsetting name="SpdS" value="7"/>
+			<confsetting name="SI" value="8"/>
+			<confsetting name="ETC" value="9"/>
+			<confsetting name="TxC" value="10"/>
+			<confsetting name="RxC" value="11"/>
+			<confsetting name="RI" value="12"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<configuration name="SpdS Source (V.24 111)" tag=":CONF7" mask="15">
+			<confsetting name="TxD" value="0"/>
+			<confsetting name="RxD" value="1"/>
+			<confsetting name="RTS" value="2"/>
+			<confsetting name="CTS" value="3"/>
+			<confsetting name="DSR" value="4"/>
+			<confsetting name="DTR" value="5"/>
+			<confsetting name="DCD" value="6"/>
+			<confsetting name="SpdS" value="7" default="yes"/>
+			<confsetting name="SI" value="8"/>
+			<confsetting name="ETC" value="9"/>
+			<confsetting name="TxC" value="10"/>
+			<confsetting name="RxC" value="11"/>
+			<confsetting name="RI" value="12"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<configuration name="SI Source (V.24 112)" tag=":CONF8" mask="15">
+			<confsetting name="TxD" value="0"/>
+			<confsetting name="RxD" value="1"/>
+			<confsetting name="RTS" value="2"/>
+			<confsetting name="CTS" value="3"/>
+			<confsetting name="DSR" value="4"/>
+			<confsetting name="DTR" value="5"/>
+			<confsetting name="DCD" value="6"/>
+			<confsetting name="SpdS" value="7"/>
+			<confsetting name="SI" value="8" default="yes"/>
+			<confsetting name="ETC" value="9"/>
+			<confsetting name="TxC" value="10"/>
+			<confsetting name="RxC" value="11"/>
+			<confsetting name="RI" value="12"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<configuration name="ETC Source (V.24 113)" tag=":CONF9" mask="15">
+			<confsetting name="TxD" value="0"/>
+			<confsetting name="RxD" value="1"/>
+			<confsetting name="RTS" value="2"/>
+			<confsetting name="CTS" value="3"/>
+			<confsetting name="DSR" value="4"/>
+			<confsetting name="DTR" value="5"/>
+			<confsetting name="DCD" value="6"/>
+			<confsetting name="SpdS" value="7"/>
+			<confsetting name="SI" value="8"/>
+			<confsetting name="ETC" value="9" default="yes"/>
+			<confsetting name="TxC" value="10"/>
+			<confsetting name="RxC" value="11"/>
+			<confsetting name="RI" value="12"/>
+			<confsetting name="Asserted" value="13"/>
+			<confsetting name="Deasserted" value="14"/>
+		</configuration>
+		<slot name=":dce">
+			<slotoption name="terminal" devname="serial_terminal"/>
+			<slotoption name="sunkbd" devname="sunkbd_adaptor"/>
+			<slotoption name="votraxtnt" devname="serial_votraxtnt"/>
+			<slotoption name="s97801" devname="s97801_terminal"/>
+			<slotoption name="rs_printer" devname="rs_serial_printer"/>
+			<slotoption name="rs232_sync_io" devname="rs232_sync_io"/>
+			<slotoption name="auto3a" devname="auto3a_terminal"/>
+			<slotoption name="dec_loopback" devname="dec_rs232_loopback"/>
+			<slotoption name="h19" devname="serial_heath_h19"/>
+			<slotoption name="ie15" devname="ie15_terminal"/>
+			<slotoption name="null_modem" devname="null_modem"/>
+			<slotoption name="keyboard" devname="serial_keyboard"/>
+			<slotoption name="patch" devname="rs232_patch_box"/>
+			<slotoption name="swtpc8212" devname="swtpc8212_terminal"/>
+			<slotoption name="printer" devname="serial_printer"/>
+			<slotoption name="scorpion" devname="scorpion_ic"/>
+			<slotoption name="loopback" devname="rs232_loopback"/>
+			<slotoption name="mockingboard" devname="mockingboardd"/>
+			<slotoption name="msystems_mouse" devname="rs232_mouse_hle_msystems"/>
+			<slotoption name="nss_tvi" devname="nss_tvinterface"/>
+			<slotoption name="pty" devname="pseudo_terminal"/>
+		</slot>
+	</machine>
+	<machine name="rs232_sync_io" sourcefile="devices/bus/rs232/rs232_sync_io.cpp" isdevice="yes" runnable="no">
+		<description>RS-232 Synchronous I/O</description>
+		<device_ref tag=":_tmp:stream" name="bitbanger"/>
+		<configuration name="Baud rate" tag=":RS232_BAUD" mask="255">
+			<confsetting name="50" value="14"/>
+			<confsetting name="75" value="15"/>
+			<confsetting name="110" value="0"/>
+			<confsetting name="134.5" value="16"/>
+			<confsetting name="150" value="1"/>
+			<confsetting name="200" value="17"/>
+			<confsetting name="300" value="2"/>
+			<confsetting name="600" value="3"/>
+			<confsetting name="1200" value="4"/>
+			<confsetting name="1800" value="18"/>
+			<confsetting name="2000" value="19"/>
+			<confsetting name="2400" value="5" default="yes"/>
+			<confsetting name="3600" value="20"/>
+			<confsetting name="4800" value="6"/>
+			<confsetting name="7200" value="21"/>
+			<confsetting name="9600" value="7"/>
+			<confsetting name="14400" value="8"/>
+			<confsetting name="19200" value="9"/>
+			<confsetting name="28800" value="10"/>
+			<confsetting name="38400" value="11"/>
+			<confsetting name="57600" value="12"/>
+			<confsetting name="76800" value="23"/>
+			<confsetting name="78125" value="24"/>
+			<confsetting name="111900" value="22"/>
+			<confsetting name="115200" value="13"/>
+		</configuration>
+		<configuration name="RTS controls half-duplex" tag=":rtsduplex" mask="1">
+			<confsetting name="Off" value="0"/>
+			<confsetting name="On" value="1" default="yes"/>
+		</configuration>
+		<configuration name="RxC generated" tag=":rxcontrol" mask="3">
+			<confsetting name="Always" value="0"/>
+			<confsetting name="When Rx is active" value="1" default="yes"/>
+			<confsetting name="When a byte is available" value="2"/>
+		</configuration>
+		<configuration name="TxC generated" tag=":txcontrol" mask="1">
+			<confsetting name="Always" value="0"/>
+			<confsetting name="When Tx is active" value="1" default="yes"/>
+		</configuration>
+		<device type="bitbanger" tag=":stream">
+			<instance name="bitbanger" briefname="bitb"/>
+			<extension name=""/>
+		</device>
+	</machine>
+	<machine name="rs_serial_printer" sourcefile="devices/bus/rs232/printer.cpp" isdevice="yes" runnable="no">
+		<description>Radio Shack Serial Printer</description>
+		<device_ref tag=":_tmp:printer" name="printer_image"/>
+		<configuration name="Data Bits" tag=":RS232_DATABITS" mask="255">
+			<confsetting name="5" value="0"/>
+			<confsetting name="6" value="1"/>
+			<confsetting name="7" value="2"/>
+			<confsetting name="8" value="3" default="yes"/>
+		</configuration>
+		<configuration name="Parity" tag=":RS232_PARITY" mask="255">
+			<confsetting name="None" value="0" default="yes"/>
+			<confsetting name="Odd" value="1"/>
+			<confsetting name="Even" value="2"/>
+			<confsetting name="Mark" value="3"/>
+			<confsetting name="Space" value="4"/>
+		</configuration>
+		<configuration name="RX Baud" tag=":RS232_RXBAUD" mask="255">
+			<confsetting name="50" value="14"/>
+			<confsetting name="75" value="15"/>
+			<confsetting name="110" value="0"/>
+			<confsetting name="134.5" value="16"/>
+			<confsetting name="150" value="1"/>
+			<confsetting name="200" value="17"/>
+			<confsetting name="300" value="2"/>
+			<confsetting name="600" value="3"/>
+			<confsetting name="1200" value="4"/>
+			<confsetting name="1800" value="18"/>
+			<confsetting name="2000" value="19"/>
+			<confsetting name="2400" value="5"/>
+			<confsetting name="3600" value="20"/>
+			<confsetting name="4800" value="6"/>
+			<confsetting name="7200" value="21"/>
+			<confsetting name="9600" value="7" default="yes"/>
+			<confsetting name="14400" value="8"/>
+			<confsetting name="19200" value="9"/>
+			<confsetting name="28800" value="10"/>
+			<confsetting name="38400" value="11"/>
+			<confsetting name="57600" value="12"/>
+			<confsetting name="76800" value="23"/>
+			<confsetting name="78125" value="24"/>
+			<confsetting name="111900" value="22"/>
+			<confsetting name="115200" value="13"/>
+		</configuration>
+		<configuration name="Stop Bits" tag=":RS232_STOPBITS" mask="255">
+			<confsetting name="0" value="0"/>
+			<confsetting name="1" value="1" default="yes"/>
+			<confsetting name="1.5" value="2"/>
+			<confsetting name="2" value="3"/>
+		</configuration>
+		<device type="printout" tag=":printer">
+			<instance name="printout" briefname="prin"/>
+			<extension name="prn"/>
+		</device>
+	</machine>
+	<machine name="s97801_device" sourcefile="devices/machine/s97801.cpp" isdevice="yes" runnable="no">
+		<description>Siemens 97801 Terminal</description>
+		<rom name="010_d26__0118_04.d26" size="8192" crc="fcf045d7" sha1="4a98e7d2d98272970d627ce5c10e9572b87293d1" region="maincpu" offset="0"/>
+		<rom name="010_d21__0118_04.d21" size="8192" crc="b9b9df32" sha1="9a3ba060ebcf00b1ed9112493a1d73212c04d8e5" region="unk" offset="0"/>
+		<rom name="010_d23__0118_03.d23" size="8192" crc="23b22a7d" sha1="649abcfde9752f427ec7d1efdc013a4f01dc271c" region="chargen" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="i8031"/>
+		<device_ref tag=":_tmp:kbd" name="s97801_kbd"/>
+		<device_ref tag=":_tmp:kbd:mcu" name="i8035"/>
+		<device_ref tag=":_tmp:kbd:mono" name="speaker"/>
+		<device_ref tag=":_tmp:kbd:beep" name="beep"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:avdc" name="scn2672"/>
+		<device_ref tag=":_tmp:epci" name="scn2661b"/>
+		<chip type="cpu" tag=":maincpu" name="Intel 8031" clock="11059200"/>
+		<chip type="cpu" tag=":kbd:mcu" name="Intel 8035" clock="5760000"/>
+		<chip type="audio" tag=":kbd:mono" name="Speaker"/>
+		<chip type="audio" tag=":kbd:beep" name="Beep" clock="1500"/>
+		<display tag=":screen" type="raster" rotate="0" width="640" height="400" refresh="57.334826" pixclock="22118400" htotal="912" hbend="0" hbstart="640" vtotal="423" vbend="0" vbstart="400" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="130"/>
+		</input>
+		<configuration name="Keylock switch" tag=":kbd:MOD" mask="96">
+			<confsetting name="Position 1 (status DC)" value="96" default="yes"/>
+			<confsetting name="Position 2 (status DD)" value="64"/>
+			<confsetting name="Position 3 (status DE)" value="32"/>
+			<confsetting name="Position 4 (status DF)" value="0"/>
+		</configuration>
+	</machine>
+	<machine name="s97801_kbd" sourcefile="devices/machine/s97801_kbd.cpp" isdevice="yes" runnable="no">
+		<description>Siemens 97801 Keyboard (International V1)</description>
+		<rom name="p26361_k111_v1_3.d3" size="4096" crc="aba8f4b7" sha1="970a45b509081603e25319e1bbf0f7941f91a056" region="mcu" offset="0"/>
+		<device_ref tag=":_tmp:mcu" name="i8035"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:beep" name="beep"/>
+		<chip type="cpu" tag=":mcu" name="Intel 8035" clock="5760000"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":beep" name="Beep" clock="1500"/>
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="130"/>
+		</input>
+		<configuration name="Keylock switch" tag=":MOD" mask="96">
+			<confsetting name="Position 1 (status DC)" value="96" default="yes"/>
+			<confsetting name="Position 2 (status DD)" value="64"/>
+			<confsetting name="Position 3 (status DE)" value="32"/>
+			<confsetting name="Position 4 (status DF)" value="0"/>
+		</configuration>
+	</machine>
+	<machine name="s97801_terminal" sourcefile="devices/bus/rs232/s97801.cpp" isdevice="yes" runnable="no">
+		<description>Siemens 97801 Terminal (RS-232)</description>
+		<device_ref tag=":_tmp:term" name="s97801_device"/>
+		<device_ref tag=":_tmp:term:maincpu" name="i8031"/>
+		<device_ref tag=":_tmp:term:kbd" name="s97801_kbd"/>
+		<device_ref tag=":_tmp:term:kbd:mcu" name="i8035"/>
+		<device_ref tag=":_tmp:term:kbd:mono" name="speaker"/>
+		<device_ref tag=":_tmp:term:kbd:beep" name="beep"/>
+		<device_ref tag=":_tmp:term:screen" name="screen"/>
+		<device_ref tag=":_tmp:term:avdc" name="scn2672"/>
+		<device_ref tag=":_tmp:term:epci" name="scn2661b"/>
+		<chip type="cpu" tag=":term:maincpu" name="Intel 8031" clock="11059200"/>
+		<chip type="cpu" tag=":term:kbd:mcu" name="Intel 8035" clock="5760000"/>
+		<chip type="audio" tag=":term:kbd:mono" name="Speaker"/>
+		<chip type="audio" tag=":term:kbd:beep" name="Beep" clock="1500"/>
+		<display tag=":term:screen" type="raster" rotate="0" width="640" height="400" refresh="57.334826" pixclock="22118400" htotal="912" hbend="0" hbstart="640" vtotal="423" vbend="0" vbstart="400" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="130"/>
+		</input>
+		<configuration name="Keylock switch" tag=":term:kbd:MOD" mask="96">
+			<confsetting name="Position 1 (status DC)" value="96" default="yes"/>
+			<confsetting name="Position 2 (status DD)" value="64"/>
+			<confsetting name="Position 3 (status DE)" value="32"/>
+			<confsetting name="Position 4 (status DF)" value="0"/>
+		</configuration>
+	</machine>
+	<machine name="saa5050" sourcefile="devices/video/saa5050.cpp" isdevice="yes" runnable="no">
+		<description>SAA5050 Teletext Character Generator</description>
+		<rom name="saa5050" size="960" crc="201490f3" sha1="6c8daba70374e5aa3a6402f24cdc5f8677d58a0f" region="chargen" offset="140"/>
+	</machine>
+	<machine name="samples" sourcefile="devices/sound/samples.cpp" isdevice="yes" runnable="no">
+		<description>Samples</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="scn2661b" sourcefile="devices/machine/scn_pci.cpp" isdevice="yes" runnable="no">
+		<description>Signetics SCN2661B EPCI</description>
+	</machine>
+	<machine name="scn2672" sourcefile="devices/video/scn2674.cpp" isdevice="yes" runnable="no">
+		<description>Signetics SCN2672 PVTC</description>
+	</machine>
+	<machine name="scorpion_ic" sourcefile="devices/bus/rs232/scorpion.cpp" isdevice="yes" runnable="no">
+		<description>Micro-Robotics Scorpion Intelligent Controller</description>
+		<biosset name="61203" description="Version 61203 (3rd Dec 1986)"/>
+		<rom name="scorpion_61203.bin" bios="61203" size="32768" crc="4ff495d1" sha1="91c273c94cd0dbca655e192dd01ac6dc3a4f60a8" region="sys_rom" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="hd6303x"/>
+		<device_ref tag=":_tmp:nvram" name="nvram"/>
+		<device_ref tag=":_tmp:rtc" name="pcf8573"/>
+		<chip type="cpu" tag=":maincpu" name="Hitachi HD6303X" clock="4915200"/>
+	</machine>
+	<machine name="screen" sourcefile="emu/screen.cpp" isdevice="yes" runnable="no">
+		<description>Video Screen</description>
+	</machine>
+	<machine name="scsi" sourcefile="devices/bus/scsi/scsi.cpp" isdevice="yes" runnable="no">
+		<description>SCSI Port</description>
+		<device_ref tag=":_tmp:1" name="scsi_slot"/>
+		<device_ref tag=":_tmp:2" name="scsi_slot"/>
+		<device_ref tag=":_tmp:3" name="scsi_slot"/>
+		<device_ref tag=":_tmp:4" name="scsi_slot"/>
+		<device_ref tag=":_tmp:5" name="scsi_slot"/>
+		<device_ref tag=":_tmp:6" name="scsi_slot"/>
+		<device_ref tag=":_tmp:7" name="scsi_slot"/>
+		<slot name=":1">
+		</slot>
+		<slot name=":2">
+		</slot>
+		<slot name=":3">
+		</slot>
+		<slot name=":4">
+		</slot>
+		<slot name=":5">
+		</slot>
+		<slot name=":6">
+		</slot>
+		<slot name=":7">
+		</slot>
+	</machine>
+	<machine name="scsi_slot" sourcefile="devices/bus/scsi/scsi.cpp" isdevice="yes" runnable="no">
+		<description>SCSI Connector</description>
+	</machine>
+	<machine name="sensorboard" sourcefile="devices/machine/sensorboard.cpp" isdevice="yes" runnable="no">
+		<description>Sensorboard</description>
+		<configuration name="Remember Position" tag=":CONF" mask="3">
+			<condition tag="UI_CHECK" mask="4" relation="ne" value="0"/>
+			<confsetting name="No" value="1"/>
+			<confsetting name="Yes" value="2"/>
+			<confsetting name="Auto" value="0" default="yes"/>
+		</configuration>
+		<configuration name="Show Pieces" tag=":CONF" mask="4">
+			<condition tag="UI_CHECK" mask="4" relation="ne" value="0"/>
+			<confsetting name="No" value="4"/>
+			<confsetting name="Yes" value="0" default="yes"/>
+		</configuration>
+	</machine>
+	<machine name="serial_heath_h19" sourcefile="devices/bus/rs232/heath_h19.cpp" isdevice="yes" runnable="no">
+		<description>Heath H19 Terminal (Serial Port)</description>
+		<device_ref tag=":_tmp:tlbc" name="heath_tlb_connector"/>
+		<slot name=":tlbc">
+			<slotoption name="watzman" devname="heath_watz_tlb"/>
+			<slotoption name="ultrarom" devname="heath_ultra_tlb"/>
+			<slotoption name="superset" devname="heath_superset_tlb"/>
+			<slotoption name="super19" devname="heath_super19_tlb"/>
+			<slotoption name="imaginator" devname="heath_imaginator_tlb"/>
+			<slotoption name="gp19" devname="heath_gp19_tlb"/>
+			<slotoption name="heath" devname="heath_tlb" default="yes"/>
+		</slot>
+	</machine>
+	<machine name="serial_keyboard" sourcefile="devices/bus/rs232/keyboard.cpp" isdevice="yes" runnable="no">
+		<description>Serial Keyboard</description>
+		<input players="1">
+			<control type="keyboard" buttons="73"/>
+		</input>
+		<configuration name="Layout" tag=":GENKBD_CFG" mask="1">
+			<confsetting name="ANSI" value="0" default="yes"/>
+			<confsetting name="JIS" value="1"/>
+		</configuration>
+		<configuration name="Typematic Delay" tag=":GENKBD_CFG" mask="6">
+			<confsetting name="0.25s" value="0"/>
+			<confsetting name="0.5s" value="2"/>
+			<confsetting name="0.75s" value="4" default="yes"/>
+			<confsetting name="1.0s" value="6"/>
+		</configuration>
+		<configuration name="Typematic Rate" tag=":GENKBD_CFG" mask="248">
+			<confsetting name="2.0cps" value="0"/>
+			<confsetting name="2.1cps" value="8"/>
+			<confsetting name="2.5cps" value="16"/>
+			<confsetting name="2.7cps" value="24"/>
+			<confsetting name="2.0cps" value="32"/>
+			<confsetting name="2.1cps" value="40"/>
+			<confsetting name="2.5cps" value="48"/>
+			<confsetting name="2.7cps" value="56"/>
+			<confsetting name="3.3cps" value="64"/>
+			<confsetting name="3.8cps" value="72"/>
+			<confsetting name="4.0cps" value="80"/>
+			<confsetting name="4.3cps" value="88"/>
+			<confsetting name="4.6cps" value="96"/>
+			<confsetting name="5.0cps" value="104"/>
+			<confsetting name="5.5cps" value="112"/>
+			<confsetting name="6.0cps" value="120"/>
+			<confsetting name="8.0cps" value="128"/>
+			<confsetting name="8.6cps" value="136"/>
+			<confsetting name="9.2cps" value="144"/>
+			<confsetting name="10.0cps" value="152" default="yes"/>
+			<confsetting name="10.9cps" value="160"/>
+			<confsetting name="12.0cps" value="168"/>
+			<confsetting name="13.3cps" value="176"/>
+			<confsetting name="15.0cps" value="184"/>
+			<confsetting name="16.0cps" value="192"/>
+			<confsetting name="17.1cps" value="200"/>
+			<confsetting name="18.5cps" value="208"/>
+			<confsetting name="20.0cps" value="216"/>
+			<confsetting name="21.8cps" value="224"/>
+			<confsetting name="24.0cps" value="232"/>
+			<confsetting name="26.7cps" value="240"/>
+			<confsetting name="30.0cps" value="248"/>
+		</configuration>
+		<configuration name="Data Bits" tag=":RS232_DATABITS" mask="255">
+			<confsetting name="5" value="0"/>
+			<confsetting name="6" value="1"/>
+			<confsetting name="7" value="2"/>
+			<confsetting name="8" value="3" default="yes"/>
+		</configuration>
+		<configuration name="Parity" tag=":RS232_PARITY" mask="255">
+			<confsetting name="None" value="0" default="yes"/>
+			<confsetting name="Odd" value="1"/>
+			<confsetting name="Even" value="2"/>
+			<confsetting name="Mark" value="3"/>
+			<confsetting name="Space" value="4"/>
+		</configuration>
+		<configuration name="Stop Bits" tag=":RS232_STOPBITS" mask="255">
+			<confsetting name="0" value="0"/>
+			<confsetting name="1" value="1" default="yes"/>
+			<confsetting name="1.5" value="2"/>
+			<confsetting name="2" value="3"/>
+		</configuration>
+		<configuration name="TX Baud" tag=":RS232_TXBAUD" mask="255">
+			<confsetting name="50" value="14"/>
+			<confsetting name="75" value="15"/>
+			<confsetting name="110" value="0"/>
+			<confsetting name="134.5" value="16"/>
+			<confsetting name="150" value="1"/>
+			<confsetting name="200" value="17"/>
+			<confsetting name="300" value="2"/>
+			<confsetting name="600" value="3"/>
+			<confsetting name="1200" value="4"/>
+			<confsetting name="1800" value="18"/>
+			<confsetting name="2000" value="19"/>
+			<confsetting name="2400" value="5"/>
+			<confsetting name="3600" value="20"/>
+			<confsetting name="4800" value="6"/>
+			<confsetting name="7200" value="21"/>
+			<confsetting name="9600" value="7" default="yes"/>
+			<confsetting name="14400" value="8"/>
+			<confsetting name="19200" value="9"/>
+			<confsetting name="28800" value="10"/>
+			<confsetting name="38400" value="11"/>
+			<confsetting name="57600" value="12"/>
+			<confsetting name="76800" value="23"/>
+			<confsetting name="78125" value="24"/>
+			<confsetting name="111900" value="22"/>
+			<confsetting name="115200" value="13"/>
+		</configuration>
+	</machine>
+	<machine name="serial_printer" sourcefile="devices/bus/rs232/printer.cpp" isdevice="yes" runnable="no">
+		<description>Serial Printer</description>
+		<device_ref tag=":_tmp:printer" name="printer_image"/>
+		<configuration name="Data Bits" tag=":RS232_DATABITS" mask="255">
+			<confsetting name="5" value="0"/>
+			<confsetting name="6" value="1"/>
+			<confsetting name="7" value="2"/>
+			<confsetting name="8" value="3" default="yes"/>
+		</configuration>
+		<configuration name="Parity" tag=":RS232_PARITY" mask="255">
+			<confsetting name="None" value="0" default="yes"/>
+			<confsetting name="Odd" value="1"/>
+			<confsetting name="Even" value="2"/>
+			<confsetting name="Mark" value="3"/>
+			<confsetting name="Space" value="4"/>
+		</configuration>
+		<configuration name="RX Baud" tag=":RS232_RXBAUD" mask="255">
+			<confsetting name="50" value="14"/>
+			<confsetting name="75" value="15"/>
+			<confsetting name="110" value="0"/>
+			<confsetting name="134.5" value="16"/>
+			<confsetting name="150" value="1"/>
+			<confsetting name="200" value="17"/>
+			<confsetting name="300" value="2"/>
+			<confsetting name="600" value="3"/>
+			<confsetting name="1200" value="4"/>
+			<confsetting name="1800" value="18"/>
+			<confsetting name="2000" value="19"/>
+			<confsetting name="2400" value="5"/>
+			<confsetting name="3600" value="20"/>
+			<confsetting name="4800" value="6"/>
+			<confsetting name="7200" value="21"/>
+			<confsetting name="9600" value="7" default="yes"/>
+			<confsetting name="14400" value="8"/>
+			<confsetting name="19200" value="9"/>
+			<confsetting name="28800" value="10"/>
+			<confsetting name="38400" value="11"/>
+			<confsetting name="57600" value="12"/>
+			<confsetting name="76800" value="23"/>
+			<confsetting name="78125" value="24"/>
+			<confsetting name="111900" value="22"/>
+			<confsetting name="115200" value="13"/>
+		</configuration>
+		<configuration name="Stop Bits" tag=":RS232_STOPBITS" mask="255">
+			<confsetting name="0" value="0"/>
+			<confsetting name="1" value="1" default="yes"/>
+			<confsetting name="1.5" value="2"/>
+			<confsetting name="2" value="3"/>
+		</configuration>
+		<device type="printout" tag=":printer">
+			<instance name="printout" briefname="prin"/>
+			<extension name="prn"/>
+		</device>
+	</machine>
+	<machine name="serial_terminal" sourcefile="devices/bus/rs232/terminal.cpp" isdevice="yes" runnable="no">
+		<description>Serial Terminal</description>
+		<device_ref tag=":_tmp:terminal_screen" name="screen"/>
+		<device_ref tag=":_tmp:keyboard" name="generic_keyboard"/>
+		<device_ref tag=":_tmp:bell" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<chip type="audio" tag=":bell" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="2000"/>
+		<display tag=":terminal_screen" type="raster" rotate="0" width="640" height="240" refresh="50.000000" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="73"/>
+		</input>
+		<configuration name="Data Bits" tag=":RS232_DATABITS" mask="255">
+			<confsetting name="5" value="0"/>
+			<confsetting name="6" value="1"/>
+			<confsetting name="7" value="2"/>
+			<confsetting name="8" value="3" default="yes"/>
+		</configuration>
+		<configuration name="Parity" tag=":RS232_PARITY" mask="255">
+			<confsetting name="None" value="0" default="yes"/>
+			<confsetting name="Odd" value="1"/>
+			<confsetting name="Even" value="2"/>
+			<confsetting name="Mark" value="3"/>
+			<confsetting name="Space" value="4"/>
+		</configuration>
+		<configuration name="RX Baud" tag=":RS232_RXBAUD" mask="255">
+			<confsetting name="50" value="14"/>
+			<confsetting name="75" value="15"/>
+			<confsetting name="110" value="0"/>
+			<confsetting name="134.5" value="16"/>
+			<confsetting name="150" value="1"/>
+			<confsetting name="200" value="17"/>
+			<confsetting name="300" value="2"/>
+			<confsetting name="600" value="3"/>
+			<confsetting name="1200" value="4"/>
+			<confsetting name="1800" value="18"/>
+			<confsetting name="2000" value="19"/>
+			<confsetting name="2400" value="5"/>
+			<confsetting name="3600" value="20"/>
+			<confsetting name="4800" value="6"/>
+			<confsetting name="7200" value="21"/>
+			<confsetting name="9600" value="7" default="yes"/>
+			<confsetting name="14400" value="8"/>
+			<confsetting name="19200" value="9"/>
+			<confsetting name="28800" value="10"/>
+			<confsetting name="38400" value="11"/>
+			<confsetting name="57600" value="12"/>
+			<confsetting name="76800" value="23"/>
+			<confsetting name="78125" value="24"/>
+			<confsetting name="111900" value="22"/>
+			<confsetting name="115200" value="13"/>
+		</configuration>
+		<configuration name="Stop Bits" tag=":RS232_STOPBITS" mask="255">
+			<confsetting name="0" value="0"/>
+			<confsetting name="1" value="1" default="yes"/>
+			<confsetting name="1.5" value="2"/>
+			<confsetting name="2" value="3"/>
+		</configuration>
+		<configuration name="TX Baud" tag=":RS232_TXBAUD" mask="255">
+			<confsetting name="50" value="14"/>
+			<confsetting name="75" value="15"/>
+			<confsetting name="110" value="0"/>
+			<confsetting name="134.5" value="16"/>
+			<confsetting name="150" value="1"/>
+			<confsetting name="200" value="17"/>
+			<confsetting name="300" value="2"/>
+			<confsetting name="600" value="3"/>
+			<confsetting name="1200" value="4"/>
+			<confsetting name="1800" value="18"/>
+			<confsetting name="2000" value="19"/>
+			<confsetting name="2400" value="5"/>
+			<confsetting name="3600" value="20"/>
+			<confsetting name="4800" value="6"/>
+			<confsetting name="7200" value="21"/>
+			<confsetting name="9600" value="7" default="yes"/>
+			<confsetting name="14400" value="8"/>
+			<confsetting name="19200" value="9"/>
+			<confsetting name="28800" value="10"/>
+			<confsetting name="38400" value="11"/>
+			<confsetting name="57600" value="12"/>
+			<confsetting name="76800" value="23"/>
+			<confsetting name="78125" value="24"/>
+			<confsetting name="111900" value="22"/>
+			<confsetting name="115200" value="13"/>
+		</configuration>
+		<configuration name="Cursor" tag=":TERM_CONF" mask="1">
+			<confsetting name="No" value="0"/>
+			<confsetting name="Yes" value="1" default="yes"/>
+		</configuration>
+		<configuration name="Type" tag=":TERM_CONF" mask="2">
+			<confsetting name="Underline" value="0"/>
+			<confsetting name="Block" value="2" default="yes"/>
+		</configuration>
+		<configuration name="Blinking" tag=":TERM_CONF" mask="4">
+			<confsetting name="No" value="0"/>
+			<confsetting name="Yes" value="4" default="yes"/>
+		</configuration>
+		<configuration name="Invert" tag=":TERM_CONF" mask="8">
+			<confsetting name="No" value="0"/>
+			<confsetting name="Yes" value="8" default="yes"/>
+		</configuration>
+		<configuration name="Color" tag=":TERM_CONF" mask="48">
+			<confsetting name="Green" value="0" default="yes"/>
+			<confsetting name="Amber" value="16"/>
+			<confsetting name="White" value="32"/>
+		</configuration>
+		<configuration name="Auto CR on LF" tag=":TERM_CONF" mask="64">
+			<confsetting name="No" value="0"/>
+			<confsetting name="Yes" value="64" default="yes"/>
+		</configuration>
+		<configuration name="Auto LF on CR" tag=":TERM_CONF" mask="128">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="128"/>
+		</configuration>
+		<configuration name="Local echo" tag=":TERM_CONF" mask="256">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="256"/>
+		</configuration>
+		<configuration name="Layout" tag=":keyboard:GENKBD_CFG" mask="1">
+			<confsetting name="ANSI" value="0" default="yes"/>
+			<confsetting name="JIS" value="1"/>
+		</configuration>
+		<configuration name="Typematic Delay" tag=":keyboard:GENKBD_CFG" mask="6">
+			<confsetting name="0.25s" value="0"/>
+			<confsetting name="0.5s" value="2"/>
+			<confsetting name="0.75s" value="4" default="yes"/>
+			<confsetting name="1.0s" value="6"/>
+		</configuration>
+		<configuration name="Typematic Rate" tag=":keyboard:GENKBD_CFG" mask="248">
+			<confsetting name="2.0cps" value="0"/>
+			<confsetting name="2.1cps" value="8"/>
+			<confsetting name="2.5cps" value="16"/>
+			<confsetting name="2.7cps" value="24"/>
+			<confsetting name="2.0cps" value="32"/>
+			<confsetting name="2.1cps" value="40"/>
+			<confsetting name="2.5cps" value="48"/>
+			<confsetting name="2.7cps" value="56"/>
+			<confsetting name="3.3cps" value="64"/>
+			<confsetting name="3.8cps" value="72"/>
+			<confsetting name="4.0cps" value="80"/>
+			<confsetting name="4.3cps" value="88"/>
+			<confsetting name="4.6cps" value="96"/>
+			<confsetting name="5.0cps" value="104"/>
+			<confsetting name="5.5cps" value="112"/>
+			<confsetting name="6.0cps" value="120"/>
+			<confsetting name="8.0cps" value="128"/>
+			<confsetting name="8.6cps" value="136"/>
+			<confsetting name="9.2cps" value="144"/>
+			<confsetting name="10.0cps" value="152" default="yes"/>
+			<confsetting name="10.9cps" value="160"/>
+			<confsetting name="12.0cps" value="168"/>
+			<confsetting name="13.3cps" value="176"/>
+			<confsetting name="15.0cps" value="184"/>
+			<confsetting name="16.0cps" value="192"/>
+			<confsetting name="17.1cps" value="200"/>
+			<confsetting name="18.5cps" value="208"/>
+			<confsetting name="20.0cps" value="216"/>
+			<confsetting name="21.8cps" value="224"/>
+			<confsetting name="24.0cps" value="232"/>
+			<confsetting name="26.7cps" value="240"/>
+			<confsetting name="30.0cps" value="248"/>
+		</configuration>
+	</machine>
+	<machine name="serial_votraxtnt" sourcefile="devices/bus/rs232/votraxtnt.cpp" isdevice="yes" runnable="no">
+		<description>Votrax Type 'N Talk (Serial Port)</description>
+		<device_ref tag=":_tmp:tnt" name="votraxtnt"/>
+		<device_ref tag=":_tmp:tnt:maincpu" name="m6802"/>
+		<device_ref tag=":_tmp:tnt:acia" name="acia6850"/>
+		<device_ref tag=":_tmp:tnt:acia_clock" name="clock"/>
+		<device_ref tag=":_tmp:tnt:mono" name="speaker"/>
+		<device_ref tag=":_tmp:tnt:votrax" name="votrsc01a"/>
+		<chip type="cpu" tag=":tnt:maincpu" name="Motorola MC6802" clock="2457600"/>
+		<chip type="audio" tag=":tnt:mono" name="Speaker"/>
+		<chip type="audio" tag=":tnt:votrax" name="Votrax SC-01-A" clock="720000"/>
+		<sound channels="1"/>
+		<dipswitch name="Baud Select" tag=":tnt:DSW1" mask="255">
+			<diplocation name="SW1" number="1"/>
+			<diplocation name="SW1" number="2"/>
+			<diplocation name="SW1" number="3"/>
+			<diplocation name="SW1" number="4"/>
+			<diplocation name="SW1" number="5"/>
+			<diplocation name="SW1" number="6"/>
+			<diplocation name="SW1" number="7"/>
+			<diplocation name="SW1" number="8"/>
+			<dipvalue name="75" value="1"/>
+			<dipvalue name="150" value="2"/>
+			<dipvalue name="300" value="4"/>
+			<dipvalue name="600" value="8"/>
+			<dipvalue name="1200" value="16"/>
+			<dipvalue name="2400" value="32"/>
+			<dipvalue name="4800" value="64"/>
+			<dipvalue name="9600" value="128" default="yes"/>
+		</dipswitch>
+	</machine>
+	<machine name="serproc" sourcefile="acorn/acorn_serproc.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Serial ULA (SERPROC)</description>
+	</machine>
+	<machine name="sn76489a" sourcefile="devices/sound/sn76496.cpp" isdevice="yes" runnable="no">
+		<description>SN76489A</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="software_list" sourcefile="emu/softlist_dev.cpp" isdevice="yes" runnable="no">
+		<description>Software List</description>
+	</machine>
+	<machine name="sp0256" sourcefile="devices/sound/sp0256.cpp" isdevice="yes" runnable="no">
+		<description>GI SP0256 Narrator Speech Processor</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="speaker" sourcefile="emu/speaker.cpp" isdevice="yes" runnable="no">
+		<description>Speaker</description>
+		<sound channels="1"/>
+	</machine>
+	<machine name="spi_sdcard" sourcefile="devices/machine/spi_sdcard.cpp" isdevice="yes" runnable="no">
+		<description>SD Card (SPI interface)</description>
+		<device_ref tag=":_tmp:image" name="harddisk_image"/>
+		<device type="harddisk" tag=":image" interface="sdcard">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="stacklp" sourcefile="devices/bus/bbc/analogue/lightpen.cpp" isdevice="yes" runnable="no">
+		<description>Stack Light Pen (BBC Micro)</description>
+		<input players="1">
+			<control type="lightgun" buttons="1" minimum="0" maximum="1023" sensitivity="50" keydelta="10"/>
+		</input>
+	</machine>
+	<machine name="stacklr" sourcefile="devices/bus/bbc/analogue/lightpen.cpp" isdevice="yes" runnable="no">
+		<description>Stack Light Rifle (BBC Micro)</description>
+		<input players="1">
+			<control type="lightgun" buttons="1" minimum="0" maximum="1023" sensitivity="50" keydelta="10"/>
+		</input>
+	</machine>
+	<machine name="stepper" sourcefile="devices/machine/steppers.cpp" isdevice="yes" runnable="no">
+		<description>Stepper Motor</description>
+	</machine>
+	<machine name="sunkbd" sourcefile="devices/bus/sunkbd/sunkbd.cpp" isdevice="yes" runnable="no">
+		<description>Sun Keyboard Port</description>
+	</machine>
+	<machine name="sunkbd_adaptor" sourcefile="devices/bus/rs232/sun_kbd.cpp" isdevice="yes" runnable="no">
+		<description>Sun Keyboard Adaptor</description>
+		<device_ref tag=":_tmp:keyboard" name="sunkbd"/>
+		<slot name=":keyboard">
+			<slotoption name="type5jphle" devname="kbd_type5_hle_jp"/>
+			<slotoption name="type5sehle" devname="kbd_type5_hle_se"/>
+			<slotoption name="type5hle" devname="kbd_type5_hle_us"/>
+			<slotoption name="type4hle" devname="kbd_type4_hle"/>
+			<slotoption name="type5gbhle" devname="kbd_type5_hle_gb"/>
+			<slotoption name="type3hle" devname="kbd_type3_hle"/>
+			<slotoption name="type2hle" devname="kbd_type2_hle"/>
+		</slot>
+	</machine>
+	<machine name="swtpc8212_device" sourcefile="devices/machine/swtpc8212.cpp" isdevice="yes" runnable="no">
+		<description>SWTPC8212</description>
+		<rom name="8224g_ver.1.1_6oct80.ic1" size="2048" crc="7d7f3c21" sha1="f7e6e20b36a1c724a4e348bc784d0b7b5fb462a3" region="program" offset="0"/>
+		<rom name="8224g_ver.1.1_6oct80.ic2" size="2048" crc="2b118c22" sha1="5fa031c834c7c582d5715764941499fcef51f477" region="program" offset="800"/>
+		<rom name="mcm66750.rom" size="2048" crc="aedc2830" sha1="49ce17d5b5cefb24e89ed3fd59887a652501b919" region="chargen1" offset="0"/>
+		<rom name="grafix_8x12_22aug80.bin" size="2048" crc="a525ed65" sha1="813d2e85ddb258c5b032b959e695ad33200cbcc4" region="chargen2" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="m6802"/>
+		<device_ref tag=":_tmp:mainirq" name="ipt_merge_any_hi"/>
+		<device_ref tag=":_tmp:pia0" name="pia6821"/>
+		<device_ref tag=":_tmp:pia1" name="pia6821"/>
+		<device_ref tag=":_tmp:uart" name="ins8250"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:crtc" name="mc6845"/>
+		<device_ref tag=":_tmp:keyboard" name="generic_keyboard"/>
+		<device_ref tag=":_tmp:bell" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<device_ref tag=":_tmp:printer" name="printer_image"/>
+		<chip type="cpu" tag=":maincpu" name="Motorola MC6802" clock="1843200"/>
+		<chip type="audio" tag=":bell" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="2000"/>
+		<display tag=":screen" type="raster" rotate="0" width="738" height="280" refresh="60.000000" pixclock="17074800" htotal="918" hbend="0" hbstart="738" vtotal="310" vbend="0" vbstart="280" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keypad" buttons="16"/>
+			<control type="keyboard" buttons="73"/>
+		</input>
+		<dipswitch name="Baud Rate" tag=":DIP_SWITCHES" mask="31">
+			<diplocation name="DIP" number="5"/>
+			<diplocation name="DIP" number="4"/>
+			<diplocation name="DIP" number="3"/>
+			<diplocation name="DIP" number="2"/>
+			<diplocation name="DIP" number="1"/>
+			<dipvalue name="110" value="4"/>
+			<dipvalue name="300" value="10"/>
+			<dipvalue name="600" value="13"/>
+			<dipvalue name="1200" value="15"/>
+			<dipvalue name="2400" value="18"/>
+			<dipvalue name="4800" value="22"/>
+			<dipvalue name="7200" value="24"/>
+			<dipvalue name="9600" value="25" default="yes"/>
+			<dipvalue name="19200" value="28"/>
+			<dipvalue name="38400" value="31"/>
+		</dipswitch>
+		<dipswitch name="Mode switch" tag=":DIP_SWITCHES" mask="32">
+			<diplocation name="DIP" number="6"/>
+			<dipvalue name="Conversational" value="0" default="yes"/>
+			<dipvalue name="Page edit" value="32"/>
+		</dipswitch>
+		<dipswitch name="No Parity" tag=":DIP_SWITCHES" mask="64">
+			<diplocation name="DIP" number="7"/>
+			<dipvalue name="No Parity" value="0" default="yes"/>
+			<dipvalue name="Parity" value="64"/>
+		</dipswitch>
+		<dipswitch name="Parity Select" tag=":DIP_SWITCHES" mask="128">
+			<diplocation name="DIP" number="8"/>
+			<dipvalue name="Odd or Mark" value="0" default="yes"/>
+			<dipvalue name="Even or Space" value="128"/>
+		</dipswitch>
+		<configuration name="Duplex" tag=":CONFIG" mask="1">
+			<confsetting name="Full duplex" value="0"/>
+			<confsetting name="Half duplex" value="1" default="yes"/>
+		</configuration>
+		<configuration name="Option ROM (Not used)" tag=":CONFIG" mask="2">
+			<confsetting name="On" value="0" default="yes"/>
+			<confsetting name="Off" value="2"/>
+		</configuration>
+		<configuration name="Parity Select (Jumper B)" tag=":CONFIG" mask="4">
+			<confsetting name="Odd or Even (On)" value="0"/>
+			<confsetting name="Mark or Space (Off)" value="4" default="yes"/>
+		</configuration>
+		<configuration name="Data bits (Jumper A)" tag=":CONFIG" mask="8">
+			<confsetting name="7 bit data (On)" value="0"/>
+			<confsetting name="8 bit data (Off)" value="8" default="yes"/>
+		</configuration>
+		<configuration name="One stop bit patch" tag=":ONE_STOP_BIT" mask="1">
+			<confsetting name="No" value="0"/>
+			<confsetting name="Yes - apply patch" value="1" default="yes"/>
+		</configuration>
+		<configuration name="Layout" tag=":keyboard:GENKBD_CFG" mask="1">
+			<confsetting name="ANSI" value="0" default="yes"/>
+			<confsetting name="JIS" value="1"/>
+		</configuration>
+		<configuration name="Typematic Delay" tag=":keyboard:GENKBD_CFG" mask="6">
+			<confsetting name="0.25s" value="0"/>
+			<confsetting name="0.5s" value="2"/>
+			<confsetting name="0.75s" value="4" default="yes"/>
+			<confsetting name="1.0s" value="6"/>
+		</configuration>
+		<configuration name="Typematic Rate" tag=":keyboard:GENKBD_CFG" mask="248">
+			<confsetting name="2.0cps" value="0"/>
+			<confsetting name="2.1cps" value="8"/>
+			<confsetting name="2.5cps" value="16"/>
+			<confsetting name="2.7cps" value="24"/>
+			<confsetting name="2.0cps" value="32"/>
+			<confsetting name="2.1cps" value="40"/>
+			<confsetting name="2.5cps" value="48"/>
+			<confsetting name="2.7cps" value="56"/>
+			<confsetting name="3.3cps" value="64"/>
+			<confsetting name="3.8cps" value="72"/>
+			<confsetting name="4.0cps" value="80"/>
+			<confsetting name="4.3cps" value="88"/>
+			<confsetting name="4.6cps" value="96"/>
+			<confsetting name="5.0cps" value="104"/>
+			<confsetting name="5.5cps" value="112"/>
+			<confsetting name="6.0cps" value="120"/>
+			<confsetting name="8.0cps" value="128"/>
+			<confsetting name="8.6cps" value="136"/>
+			<confsetting name="9.2cps" value="144"/>
+			<confsetting name="10.0cps" value="152" default="yes"/>
+			<confsetting name="10.9cps" value="160"/>
+			<confsetting name="12.0cps" value="168"/>
+			<confsetting name="13.3cps" value="176"/>
+			<confsetting name="15.0cps" value="184"/>
+			<confsetting name="16.0cps" value="192"/>
+			<confsetting name="17.1cps" value="200"/>
+			<confsetting name="18.5cps" value="208"/>
+			<confsetting name="20.0cps" value="216"/>
+			<confsetting name="21.8cps" value="224"/>
+			<confsetting name="24.0cps" value="232"/>
+			<confsetting name="26.7cps" value="240"/>
+			<confsetting name="30.0cps" value="248"/>
+		</configuration>
+		<device type="printout" tag=":printer">
+			<instance name="printout" briefname="prin"/>
+			<extension name="prn"/>
+		</device>
+	</machine>
+	<machine name="swtpc8212_terminal" sourcefile="devices/bus/rs232/swtpc8212.cpp" isdevice="yes" runnable="no">
+		<description>SWTPC8212 Terminal</description>
+		<device_ref tag=":_tmp:swtpc8212" name="swtpc8212_device"/>
+		<device_ref tag=":_tmp:swtpc8212:maincpu" name="m6802"/>
+		<device_ref tag=":_tmp:swtpc8212:mainirq" name="ipt_merge_any_hi"/>
+		<device_ref tag=":_tmp:swtpc8212:pia0" name="pia6821"/>
+		<device_ref tag=":_tmp:swtpc8212:pia1" name="pia6821"/>
+		<device_ref tag=":_tmp:swtpc8212:uart" name="ins8250"/>
+		<device_ref tag=":_tmp:swtpc8212:screen" name="screen"/>
+		<device_ref tag=":_tmp:swtpc8212:crtc" name="mc6845"/>
+		<device_ref tag=":_tmp:swtpc8212:keyboard" name="generic_keyboard"/>
+		<device_ref tag=":_tmp:swtpc8212:bell" name="speaker"/>
+		<device_ref tag=":_tmp:swtpc8212:beeper" name="beep"/>
+		<device_ref tag=":_tmp:swtpc8212:printer" name="printer_image"/>
+		<chip type="cpu" tag=":swtpc8212:maincpu" name="Motorola MC6802" clock="1843200"/>
+		<chip type="audio" tag=":swtpc8212:bell" name="Speaker"/>
+		<chip type="audio" tag=":swtpc8212:beeper" name="Beep" clock="2000"/>
+		<display tag=":swtpc8212:screen" type="raster" rotate="0" width="738" height="280" refresh="60.000000" pixclock="17074800" htotal="918" hbend="0" hbstart="738" vtotal="310" vbend="0" vbstart="280" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keypad" buttons="16"/>
+			<control type="keyboard" buttons="73"/>
+		</input>
+		<dipswitch name="Baud Rate" tag=":swtpc8212:DIP_SWITCHES" mask="31">
+			<diplocation name="DIP" number="5"/>
+			<diplocation name="DIP" number="4"/>
+			<diplocation name="DIP" number="3"/>
+			<diplocation name="DIP" number="2"/>
+			<diplocation name="DIP" number="1"/>
+			<dipvalue name="110" value="4"/>
+			<dipvalue name="300" value="10"/>
+			<dipvalue name="600" value="13"/>
+			<dipvalue name="1200" value="15"/>
+			<dipvalue name="2400" value="18"/>
+			<dipvalue name="4800" value="22"/>
+			<dipvalue name="7200" value="24"/>
+			<dipvalue name="9600" value="25" default="yes"/>
+			<dipvalue name="19200" value="28"/>
+			<dipvalue name="38400" value="31"/>
+		</dipswitch>
+		<dipswitch name="Mode switch" tag=":swtpc8212:DIP_SWITCHES" mask="32">
+			<diplocation name="DIP" number="6"/>
+			<dipvalue name="Conversational" value="0" default="yes"/>
+			<dipvalue name="Page edit" value="32"/>
+		</dipswitch>
+		<dipswitch name="No Parity" tag=":swtpc8212:DIP_SWITCHES" mask="64">
+			<diplocation name="DIP" number="7"/>
+			<dipvalue name="No Parity" value="0" default="yes"/>
+			<dipvalue name="Parity" value="64"/>
+		</dipswitch>
+		<dipswitch name="Parity Select" tag=":swtpc8212:DIP_SWITCHES" mask="128">
+			<diplocation name="DIP" number="8"/>
+			<dipvalue name="Odd or Mark" value="0" default="yes"/>
+			<dipvalue name="Even or Space" value="128"/>
+		</dipswitch>
+		<configuration name="Flow control" tag=":FLOW_CONTROL" mask="1">
+			<confsetting name="None" value="0"/>
+			<confsetting name="Terminal DTR to remote CTS" value="1" default="yes"/>
+		</configuration>
+		<configuration name="Duplex" tag=":swtpc8212:CONFIG" mask="1">
+			<confsetting name="Full duplex" value="0"/>
+			<confsetting name="Half duplex" value="1" default="yes"/>
+		</configuration>
+		<configuration name="Option ROM (Not used)" tag=":swtpc8212:CONFIG" mask="2">
+			<confsetting name="On" value="0" default="yes"/>
+			<confsetting name="Off" value="2"/>
+		</configuration>
+		<configuration name="Parity Select (Jumper B)" tag=":swtpc8212:CONFIG" mask="4">
+			<confsetting name="Odd or Even (On)" value="0"/>
+			<confsetting name="Mark or Space (Off)" value="4" default="yes"/>
+		</configuration>
+		<configuration name="Data bits (Jumper A)" tag=":swtpc8212:CONFIG" mask="8">
+			<confsetting name="7 bit data (On)" value="0"/>
+			<confsetting name="8 bit data (Off)" value="8" default="yes"/>
+		</configuration>
+		<configuration name="One stop bit patch" tag=":swtpc8212:ONE_STOP_BIT" mask="1">
+			<confsetting name="No" value="0"/>
+			<confsetting name="Yes - apply patch" value="1" default="yes"/>
+		</configuration>
+		<configuration name="Layout" tag=":swtpc8212:keyboard:GENKBD_CFG" mask="1">
+			<confsetting name="ANSI" value="0" default="yes"/>
+			<confsetting name="JIS" value="1"/>
+		</configuration>
+		<configuration name="Typematic Delay" tag=":swtpc8212:keyboard:GENKBD_CFG" mask="6">
+			<confsetting name="0.25s" value="0"/>
+			<confsetting name="0.5s" value="2"/>
+			<confsetting name="0.75s" value="4" default="yes"/>
+			<confsetting name="1.0s" value="6"/>
+		</configuration>
+		<configuration name="Typematic Rate" tag=":swtpc8212:keyboard:GENKBD_CFG" mask="248">
+			<confsetting name="2.0cps" value="0"/>
+			<confsetting name="2.1cps" value="8"/>
+			<confsetting name="2.5cps" value="16"/>
+			<confsetting name="2.7cps" value="24"/>
+			<confsetting name="2.0cps" value="32"/>
+			<confsetting name="2.1cps" value="40"/>
+			<confsetting name="2.5cps" value="48"/>
+			<confsetting name="2.7cps" value="56"/>
+			<confsetting name="3.3cps" value="64"/>
+			<confsetting name="3.8cps" value="72"/>
+			<confsetting name="4.0cps" value="80"/>
+			<confsetting name="4.3cps" value="88"/>
+			<confsetting name="4.6cps" value="96"/>
+			<confsetting name="5.0cps" value="104"/>
+			<confsetting name="5.5cps" value="112"/>
+			<confsetting name="6.0cps" value="120"/>
+			<confsetting name="8.0cps" value="128"/>
+			<confsetting name="8.6cps" value="136"/>
+			<confsetting name="9.2cps" value="144"/>
+			<confsetting name="10.0cps" value="152" default="yes"/>
+			<confsetting name="10.9cps" value="160"/>
+			<confsetting name="12.0cps" value="168"/>
+			<confsetting name="13.3cps" value="176"/>
+			<confsetting name="15.0cps" value="184"/>
+			<confsetting name="16.0cps" value="192"/>
+			<confsetting name="17.1cps" value="200"/>
+			<confsetting name="18.5cps" value="208"/>
+			<confsetting name="20.0cps" value="216"/>
+			<confsetting name="21.8cps" value="224"/>
+			<confsetting name="24.0cps" value="232"/>
+			<confsetting name="26.7cps" value="240"/>
+			<confsetting name="30.0cps" value="248"/>
+		</configuration>
+		<device type="printout" tag=":swtpc8212:printer">
+			<instance name="printout" briefname="prin"/>
+			<extension name="prn"/>
+		</device>
+	</machine>
+	<machine name="t11" sourcefile="devices/cpu/t11/t11.cpp" isdevice="yes" runnable="no">
+		<description>DEC T11</description>
+	</machine>
+	<machine name="tasc_sb30" sourcefile="devices/machine/smartboard.cpp" isdevice="yes" runnable="no">
+		<description>Tasc SmartBoard SB30</description>
+		<device_ref tag=":_tmp:board" name="sensorboard"/>
+		<configuration name="Duplicate Piece IDs" tag=":CONF" mask="1">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="1"/>
+		</configuration>
+		<configuration name="Remember Position" tag=":board:CONF" mask="3">
+			<condition tag="UI_CHECK" mask="4" relation="ne" value="0"/>
+			<confsetting name="No" value="1"/>
+			<confsetting name="Yes" value="2"/>
+			<confsetting name="Auto" value="0" default="yes"/>
+		</configuration>
+		<configuration name="Show Pieces" tag=":board:CONF" mask="4">
+			<condition tag="UI_CHECK" mask="4" relation="ne" value="0"/>
+			<confsetting name="No" value="4"/>
+			<confsetting name="Yes" value="0" default="yes"/>
+		</configuration>
+	</machine>
+	<machine name="tms1025" sourcefile="devices/machine/tms1024.cpp" isdevice="yes" runnable="no">
+		<description>TMS1025 I/O Expander</description>
+	</machine>
+	<machine name="tms9129" sourcefile="devices/video/tms9928a.cpp" isdevice="yes" runnable="no">
+		<description>TMS9129 VDP</description>
+	</machine>
+	<machine name="tms9914" sourcefile="devices/machine/tms9914.cpp" isdevice="yes" runnable="no">
+		<description>TMS9914 GPIB Controller</description>
+	</machine>
+	<machine name="tube" sourcefile="devices/machine/tube.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Tube ULA</description>
+	</machine>
+	<machine name="upd7002" sourcefile="devices/machine/upd7002.cpp" isdevice="yes" runnable="no">
+		<description>uPD7002 ADC</description>
+	</machine>
+	<machine name="upd7801" sourcefile="devices/cpu/upd7810/upd7810.cpp" isdevice="yes" runnable="no">
+		<description>NEC uPD7801</description>
+	</machine>
+	<machine name="upd7810" sourcefile="devices/cpu/upd7810/upd7810.cpp" isdevice="yes" runnable="no">
+		<description>NEC uPD7810</description>
+	</machine>
+	<machine name="v33" sourcefile="devices/cpu/nec/nec.cpp" isdevice="yes" runnable="no">
+		<description>NEC V33</description>
+	</machine>
+	<machine name="vcs_control_port" sourcefile="devices/bus/vcs_ctrl/ctrl.cpp" isdevice="yes" runnable="no">
+		<description>Atari VCS controller port</description>
+	</machine>
+	<machine name="votraxtnt" sourcefile="devices/machine/votraxtnt.cpp" isdevice="yes" runnable="no">
+		<description>Votrax Type 'N Talk</description>
+		<rom name="cn49752n.bin" size="4096" crc="a44e1af3" sha1="af83b9e84f44c126b24ee754a22e34ca992a8d3d" region="maincpu" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="m6802"/>
+		<device_ref tag=":_tmp:acia" name="acia6850"/>
+		<device_ref tag=":_tmp:acia_clock" name="clock"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:votrax" name="votrsc01a"/>
+		<chip type="cpu" tag=":maincpu" name="Motorola MC6802" clock="2457600"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":votrax" name="Votrax SC-01-A" clock="720000"/>
+		<sound channels="1"/>
+		<dipswitch name="Baud Select" tag=":DSW1" mask="255">
+			<diplocation name="SW1" number="1"/>
+			<diplocation name="SW1" number="2"/>
+			<diplocation name="SW1" number="3"/>
+			<diplocation name="SW1" number="4"/>
+			<diplocation name="SW1" number="5"/>
+			<diplocation name="SW1" number="6"/>
+			<diplocation name="SW1" number="7"/>
+			<diplocation name="SW1" number="8"/>
+			<dipvalue name="75" value="1"/>
+			<dipvalue name="150" value="2"/>
+			<dipvalue name="300" value="4"/>
+			<dipvalue name="600" value="8"/>
+			<dipvalue name="1200" value="16"/>
+			<dipvalue name="2400" value="32"/>
+			<dipvalue name="4800" value="64"/>
+			<dipvalue name="9600" value="128" default="yes"/>
+		</dipswitch>
+	</machine>
+	<machine name="votrsc01a" sourcefile="devices/sound/votrax.cpp" isdevice="yes" runnable="no">
+		<description>Votrax SC-01-A</description>
+		<rom name="sc01a.bin" size="512" crc="fc416227" sha1="1d6da90b1807a01b5e186ef08476119a862b5e6d" region="internal" offset="0"/>
+		<sound channels="0"/>
+	</machine>
+	<machine name="w65c02s" sourcefile="devices/cpu/m6502/w65c02s.cpp" isdevice="yes" runnable="no">
+		<description>WDC W65C02S</description>
+	</machine>
+	<machine name="w65c816" sourcefile="devices/cpu/g65816/g65816.cpp" isdevice="yes" runnable="no">
+		<description>WDC W65C816</description>
+	</machine>
+	<machine name="wd1770" sourcefile="devices/machine/wd_fdc.cpp" isdevice="yes" runnable="no">
+		<description>Western Digital WD1770 FDC</description>
+	</machine>
+	<machine name="wd2793" sourcefile="devices/machine/wd_fdc.cpp" isdevice="yes" runnable="no">
+		<description>Western Digital WD2793 FDC</description>
+	</machine>
+	<machine name="ym3812" sourcefile="devices/sound/ymopl.cpp" isdevice="yes" runnable="no">
+		<description>YM3812 OPL2</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="z80" sourcefile="devices/cpu/z80/z80.cpp" isdevice="yes" runnable="no">
+		<description>Zilog Z80</description>
+	</machine>
+	<machine name="zn428e" sourcefile="devices/sound/dac.h" isdevice="yes" runnable="no">
+		<description>ZN428E-8 DAC</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="zn449" sourcefile="devices/sound/adc.cpp" isdevice="yes" runnable="no">
+		<description>ZN449 ADC</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="aplcd150" sourcefile="devices/bus/nscsi/applecd.cpp" isdevice="yes" runnable="no">
+		<description>AppleCD 150</description>
+		<rom name="apl_1.8g_1289.ic303" size="32768" crc="54ebf81f" sha1="e4cd656e2a433229543e874a29f1567758170fc6" region="eeprom" offset="0"/>
+		<rom name="m37450m8-452fp.ic201" size="16384" status="nodump" region="mcu2" offset="0"/>
+		<device_ref tag=":_tmp:mcu1" name="i80c31"/>
+		<device_ref tag=":_tmp:mcu2" name="m37450"/>
+		<device_ref tag=":_tmp:scsic" name="cxd1180"/>
+		<chip type="cpu" tag=":mcu1" name="Intel 80C31" clock="12000000"/>
+		<chip type="cpu" tag=":mcu2" name="Mitsubishi M37450" clock="8467200"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="atacf" sourcefile="devices/bus/ata/hdd.cpp" isdevice="yes" runnable="no">
+		<description>ATA CompactFlash Card</description>
+		<device_ref tag=":_tmp:image" name="harddisk_image"/>
+		<device type="harddisk" tag=":image" interface="ata_cf">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="atari_cx85" sourcefile="devices/bus/vcs_ctrl/cx85.cpp" isdevice="yes" runnable="no">
+		<description>Atari CX85 Numeric Keypad</description>
+		<device_ref tag=":_tmp:encoder" name="mm74c923"/>
+		<input players="1">
+			<control type="keypad" buttons="17"/>
+		</input>
+	</machine>
+	<machine name="atari_trakball" sourcefile="devices/bus/vcs_ctrl/trakball.cpp" isdevice="yes" runnable="no">
+		<description>Atari CX22/CX80 Trak-Ball</description>
+		<input players="1">
+			<control type="trackball" buttons="1" minimum="0" maximum="255" sensitivity="80"/>
+		</input>
+	</machine>
+	<machine name="bbc_autoprom" sourcefile="devices/bus/bbc/1mhzbus/autoprom.cpp" isdevice="yes" runnable="no">
+		<description>ATPL AutoPrommer</description>
+		<rom name="prommer.rom" size="8192" crc="9ec497ec" sha1="48d76606d55bfce866baac1d9ac6390f5243c244" region="autorun" offset="0"/>
+		<rom name="boot.rom" size="4096" crc="0843bb06" sha1="9f584f0cc54bbbf6128e96f5f97fa811cc3d68ce" region="autorun" offset="4000"/>
+		<dipswitch name="EPROM" tag=":boot" mask="3">
+			<diplocation name="BOOT" number="1"/>
+			<diplocation name="BOOT" number="2"/>
+			<dipvalue name="Disable Auto-Run" value="0"/>
+			<dipvalue name="4K" value="1" default="yes"/>
+			<dipvalue name="8K" value="2"/>
+			<dipvalue name="16K" value="3"/>
+		</dipswitch>
+		<dipswitch name="Program" tag=":boot" mask="4">
+			<diplocation name="BOOT" number="3"/>
+			<dipvalue name="BASIC" value="0"/>
+			<dipvalue name="M/C" value="4" default="yes"/>
+		</dipswitch>
+		<dipswitch name="OS" tag=":boot" mask="8">
+			<diplocation name="BOOT" number="4"/>
+			<dipvalue name="0.1" value="0"/>
+			<dipvalue name="1.x" value="8" default="yes"/>
+		</dipswitch>
+	</machine>
+	<machine name="bbc_cisco" sourcefile="devices/bus/bbc/1mhzbus/cisco.cpp" isdevice="yes" runnable="no">
+		<description>Cisco Terminal Data Board</description>
+		<biosset name="confex" description="Confex '88"/>
+		<rom name="101.bin" bios="confex" size="16384" crc="36b42ed2" sha1="bbbcef59e12da4cddc7a5cebf4c8597b0e76fbac" region="rom" offset="0"/>
+		<rom name="102.bin" bios="confex" size="16384" crc="e323e6b1" sha1="d3344a964c0a37b4dfbdd0d01c8f16a1b796197b" region="rom" offset="4000"/>
+		<rom name="103.bin" bios="confex" size="16384" crc="f8faaf74" sha1="b11edeaa9eefd75bcfcb5e39bab01b74b7dbc45f" region="rom" offset="8000"/>
+		<rom name="104.bin" bios="confex" size="16384" crc="c66ae87c" sha1="500339258bd5cad363709c774c0cee36a17986cb" region="rom" offset="c000"/>
+	</machine>
+	<machine name="bbc_m500" sourcefile="devices/bus/bbc/1mhzbus/m5000.cpp" isdevice="yes" runnable="no">
+		<description>Acorn Music 500</description>
+		<device_ref tag=":_tmp:speaker" name="speaker"/>
+		<device_ref tag=":_tmp:hybrid" name="htmusic"/>
+		<device_ref tag=":_tmp:1mhzbus" name="bbc_1mhzbus_slot"/>
+		<device_ref tag=":_tmp:flop_ls_hybrid" name="software_list"/>
+		<chip type="audio" tag=":speaker" name="Speaker"/>
+		<chip type="audio" tag=":hybrid" name="Hybrid Technology Music System" clock="6000000"/>
+		<chip type="audio" tag=":1mhzbus" name="BBC Micro 1MHz Bus port"/>
+		<sound channels="1"/>
+		<slot name=":1mhzbus">
+			<slotoption name="cc500" devname="bbc_cc500"/>
+			<slotoption name="beebsid" devname="beebsid"/>
+			<slotoption name="dc" devname="bbc_datacentre"/>
+			<slotoption name="sprite" devname="bbc_sprite"/>
+			<slotoption name="torchhd" devname="bbc_torchhd"/>
+			<slotoption name="pms64k" devname="bbc_pms64k"/>
+			<slotoption name="pdram" devname="bbc_pdram"/>
+			<slotoption name="opus3" devname="bbc_opus3"/>
+			<slotoption name="multiform" devname="bbc_multiform"/>
+			<slotoption name="m87" devname="bbc_m87"/>
+			<slotoption name="m3000" devname="bbc_m3000"/>
+			<slotoption name="ieee488" devname="bbc_ieee488"/>
+			<slotoption name="m500" devname="bbc_m500"/>
+			<slotoption name="awhd" devname="bbc_awhd"/>
+			<slotoption name="autoprom" devname="bbc_autoprom"/>
+			<slotoption name="ramdisc" devname="bbc_ramdisc"/>
+			<slotoption name="24bbc" devname="bbc_24bbc"/>
+			<slotoption name="barrybox" devname="bbc_barrybox"/>
+			<slotoption name="b488" devname="bbc_b488"/>
+			<slotoption name="beebex" devname="bbc_beebex"/>
+			<slotoption name="m2000" devname="bbc_m2000"/>
+			<slotoption name="m5000" devname="bbc_m5000"/>
+			<slotoption name="2ndserial" devname="bbc_2ndserial"/>
+			<slotoption name="beebopl" devname="beebopl"/>
+			<slotoption name="beebide" devname="bbc_beebide"/>
+			<slotoption name="emrmidi" devname="bbc_emrmidi"/>
+			<slotoption name="ide8" devname="bbc_ide8"/>
+		</slot>
+		<softwarelist tag=":flop_ls_hybrid" name="bbc_flop_hybrid" status="original" filter="M500"/>
+	</machine>
+	<machine name="bbc_opus3" sourcefile="devices/bus/bbc/1mhzbus/opus3.cpp" isdevice="yes" runnable="no">
+		<description>Opus Challenger 3-in-1</description>
+		<biosset name="ch100" description="Challenger 1.00"/>
+		<biosset name="ch101" description="Challenger 1.01"/>
+		<biosset name="ch103" description="Challenger 1.03" default="yes"/>
+		<rom name="chal100.rom" bios="ch100" size="16384" crc="740a8335" sha1="f3c75c21bcd7d4a4dfff922fd287230dcdb91d0e" region="exp_rom" offset="0"/>
+		<rom name="chal101.rom" bios="ch101" size="16384" crc="2f64503d" sha1="37ee3f20bed50555720703b279f62aab0ed28922" region="exp_rom" offset="0"/>
+		<rom name="chal103.rom" bios="ch103" size="16384" crc="98367cf4" sha1="eca3631aa420691f96b72bfdf2e9c2b613e1bf33" region="exp_rom" offset="0"/>
+		<device_ref tag=":_tmp:wd1770" name="wd1770"/>
+		<device_ref tag=":_tmp:wd1770:0" name="floppy_connector"/>
+		<device_ref tag=":_tmp:wd1770:1" name="floppy_connector"/>
+		<device_ref tag=":_tmp:ramdisk" name="ram"/>
+		<slot name=":wd1770:0">
+			<slotoption name="525qd" devname="floppy_525_qd" default="yes"/>
+		</slot>
+		<slot name=":wd1770:1">
+			<slotoption name="525qd" devname="floppy_525_qd"/>
+		</slot>
+	</machine>
+	<machine name="bbc_quinkey" sourcefile="devices/bus/bbc/analogue/quinkey.cpp" isdevice="yes" runnable="no">
+		<description>Microwriter Quinkey</description>
+		<input players="1">
+			<control type="only_buttons" buttons="6"/>
+		</input>
+	</machine>
+	<machine name="c2031" sourcefile="devices/bus/ieee488/c2031.cpp" isdevice="yes" runnable="no">
+		<description>Commodore 2031 single disk drive</description>
+		<rom name="901484-03.u5f" size="8192" crc="ee4b893b" sha1="54d608f7f07860f24186749f21c96724dd48bc50" region="ucd5" offset="0"/>
+		<rom name="901484-05.u5h" size="8192" crc="6a629054" sha1="ec6b75ecfdd4744e5d57979ef6af990444c11ae1" region="ucd5" offset="2000"/>
+		<device_ref tag=":_tmp:ucd5" name="m6502"/>
+		<device_ref tag=":_tmp:uab1" name="mos6522"/>
+		<device_ref tag=":_tmp:ucd4" name="mos6522"/>
+		<device_ref tag=":_tmp:64h156" name="c64h156"/>
+		<device_ref tag=":_tmp:64h156:0" name="floppy_connector"/>
+		<chip type="cpu" tag=":ucd5" name="MOS Technology 6502" clock="1000000"/>
+		<dipswitch name="Device Address" tag=":ADDRESS" mask="3">
+			<dipvalue name="8" value="0" default="yes"/>
+			<dipvalue name="9" value="1"/>
+			<dipvalue name="10" value="2"/>
+			<dipvalue name="11" value="3"/>
+		</dipswitch>
+	</machine>
+	<machine name="c2040" sourcefile="devices/bus/ieee488/c2040.cpp" isdevice="yes" runnable="no">
+		<description>Commodore 2040 disk drive</description>
+		<biosset name="dos10" description="DOS 1.0"/>
+		<biosset name="dos12" description="DOS 1.2" default="yes"/>
+		<rom name="901468-xx.ul1" bios="dos10" size="4096" status="nodump" region="un1" offset="1000"/>
+		<rom name="901468-xx.uh1" bios="dos10" size="4096" status="nodump" region="un1" offset="2000"/>
+		<rom name="901468-06.ul1" bios="dos12" size="4096" crc="25b5eed5" sha1="4d9658f2e6ff3276e5c6e224611a66ce44b16fc7" region="un1" offset="1000"/>
+		<rom name="901468-07.uh1" bios="dos12" size="4096" crc="9b09ae83" sha1="6a51c7954938439ca8342fc295bda050c06e1791" region="un1" offset="2000"/>
+		<rom name="901466-01.uk3" size="1024" crc="9d1e25ce" sha1="d539858f839f96393f218307df7394362a84a26a" region="uh3" offset="0"/>
+		<device_ref tag=":_tmp:un1" name="m6502"/>
+		<device_ref tag=":_tmp:uc1" name="mos6532"/>
+		<device_ref tag=":_tmp:ue1" name="mos6532"/>
+		<device_ref tag=":_tmp:uh3" name="m6504"/>
+		<device_ref tag=":_tmp:um3" name="mos6522"/>
+		<device_ref tag=":_tmp:uk3" name="mos6530"/>
+		<device_ref tag=":_tmp:fdc" name="c2040_fdc"/>
+		<device_ref tag=":_tmp:fdc:0" name="floppy_connector"/>
+		<device_ref tag=":_tmp:fdc:1" name="floppy_connector"/>
+		<chip type="cpu" tag=":un1" name="MOS Technology 6502" clock="1000000"/>
+		<chip type="cpu" tag=":uh3" name="MOS Technology 6504" clock="1000000"/>
+		<dipswitch name="Device Address" tag=":ADDRESS" mask="7">
+			<dipvalue name="8" value="0" default="yes"/>
+			<dipvalue name="9" value="1"/>
+			<dipvalue name="10" value="2"/>
+			<dipvalue name="11" value="3"/>
+			<dipvalue name="12" value="4"/>
+			<dipvalue name="13" value="5"/>
+			<dipvalue name="14" value="6"/>
+			<dipvalue name="15" value="7"/>
+		</dipswitch>
+	</machine>
+	<machine name="c2040_fdc" sourcefile="devices/bus/ieee488/c2040fdc.cpp" isdevice="yes" runnable="no">
+		<description>Commodore 2040 FDC</description>
+		<rom name="901467.uk6" size="2048" crc="a23337eb" sha1="97df576397608455616331f8e837cb3404363fa2" region="gcr" offset="0"/>
+	</machine>
+	<machine name="c3040" sourcefile="devices/bus/ieee488/c2040.cpp" isdevice="yes" runnable="no">
+		<description>Commodore 3040 disk drive</description>
+		<rom name="901468-06.ul1" size="4096" crc="25b5eed5" sha1="4d9658f2e6ff3276e5c6e224611a66ce44b16fc7" region="un1" offset="1000"/>
+		<rom name="901468-07.uh1" size="4096" crc="9b09ae83" sha1="6a51c7954938439ca8342fc295bda050c06e1791" region="un1" offset="2000"/>
+		<rom name="901466-02.uk3" size="1024" crc="9d1e25ce" sha1="d539858f839f96393f218307df7394362a84a26a" region="uh3" offset="0"/>
+		<device_ref tag=":_tmp:un1" name="m6502"/>
+		<device_ref tag=":_tmp:uc1" name="mos6532"/>
+		<device_ref tag=":_tmp:ue1" name="mos6532"/>
+		<device_ref tag=":_tmp:uh3" name="m6504"/>
+		<device_ref tag=":_tmp:um3" name="mos6522"/>
+		<device_ref tag=":_tmp:uk3" name="mos6530"/>
+		<device_ref tag=":_tmp:fdc" name="c2040_fdc"/>
+		<device_ref tag=":_tmp:fdc:0" name="floppy_connector"/>
+		<device_ref tag=":_tmp:fdc:1" name="floppy_connector"/>
+		<chip type="cpu" tag=":un1" name="MOS Technology 6502" clock="1000000"/>
+		<chip type="cpu" tag=":uh3" name="MOS Technology 6504" clock="1000000"/>
+		<dipswitch name="Device Address" tag=":ADDRESS" mask="7">
+			<dipvalue name="8" value="0" default="yes"/>
+			<dipvalue name="9" value="1"/>
+			<dipvalue name="10" value="2"/>
+			<dipvalue name="11" value="3"/>
+			<dipvalue name="12" value="4"/>
+			<dipvalue name="13" value="5"/>
+			<dipvalue name="14" value="6"/>
+			<dipvalue name="15" value="7"/>
+		</dipswitch>
+	</machine>
+	<machine name="c4023" sourcefile="devices/bus/cbmiec/c1526.cpp" isdevice="yes" runnable="no">
+		<description>Commodore 4023 Printer</description>
+		<rom name="325360-03.u8d" size="8192" crc="c6bb0977" sha1="7a8c43d2e205f58d83709c04bc7795602a892ddd" region="u7d" offset="0"/>
+		<device_ref tag=":_tmp:u7d" name="m6504"/>
+		<chip type="cpu" tag=":u7d" name="MOS Technology 6504" clock="1000000"/>
+	</machine>
+	<machine name="c4040" sourcefile="devices/bus/ieee488/c2040.cpp" isdevice="yes" runnable="no">
+		<description>Commodore 4040 disk drive</description>
+		<biosset name="dos20r1" description="DOS 2.0 Revision 1"/>
+		<biosset name="dos20r2" description="DOS 2.0 Revision 2" default="yes"/>
+		<rom name="901468-11.uj1" bios="dos20r1" size="4096" crc="b7157458" sha1="8415f3159dea73161e0cef7960afa6c76953b6f8" region="un1" offset="0"/>
+		<rom name="901468-12.ul1" bios="dos20r1" size="4096" crc="02c44ff9" sha1="e8a94f239082d45f64f01b2d8e488d18fe659cbb" region="un1" offset="1000"/>
+		<rom name="901468-13.uh1" bios="dos20r1" size="4096" crc="cbd785b3" sha1="6ada7904ac9d13c3f1c0a8715f9c4be1aa6eb0bb" region="un1" offset="2000"/>
+		<rom name="901468-14.uj1" bios="dos20r2" size="4096" crc="bc4d4872" sha1="ffb992b82ec913ddff7be964d7527aca3e21580c" region="un1" offset="0"/>
+		<rom name="901468-15.ul1" bios="dos20r2" size="4096" crc="b6970533" sha1="f702d6917fe8a798740ba4d467b500944ae7b70a" region="un1" offset="1000"/>
+		<rom name="901468-16.uh1" bios="dos20r2" size="4096" crc="1f5eefb7" sha1="04b918cf4adeee8015b43383d3cea7288a7d0aa8" region="un1" offset="2000"/>
+		<rom name="901466-04.uk3" size="1024" crc="0ab338dc" sha1="6645fa40b81be1ff7d1384e9b52df06a26ab0bfb" region="uh3" offset="0"/>
+		<device_ref tag=":_tmp:un1" name="m6502"/>
+		<device_ref tag=":_tmp:uc1" name="mos6532"/>
+		<device_ref tag=":_tmp:ue1" name="mos6532"/>
+		<device_ref tag=":_tmp:uh3" name="m6504"/>
+		<device_ref tag=":_tmp:um3" name="mos6522"/>
+		<device_ref tag=":_tmp:uk3" name="mos6530"/>
+		<device_ref tag=":_tmp:fdc" name="c2040_fdc"/>
+		<device_ref tag=":_tmp:fdc:0" name="floppy_connector"/>
+		<device_ref tag=":_tmp:fdc:1" name="floppy_connector"/>
+		<chip type="cpu" tag=":un1" name="MOS Technology 6502" clock="1000000"/>
+		<chip type="cpu" tag=":uh3" name="MOS Technology 6504" clock="1000000"/>
+		<dipswitch name="Device Address" tag=":ADDRESS" mask="7">
+			<dipvalue name="8" value="0" default="yes"/>
+			<dipvalue name="9" value="1"/>
+			<dipvalue name="10" value="2"/>
+			<dipvalue name="11" value="3"/>
+			<dipvalue name="12" value="4"/>
+			<dipvalue name="13" value="5"/>
+			<dipvalue name="14" value="6"/>
+			<dipvalue name="15" value="7"/>
+		</dipswitch>
+	</machine>
+	<machine name="c64h156" sourcefile="devices/machine/64h156.cpp" isdevice="yes" runnable="no">
+		<description>Commodore 64H156</description>
+	</machine>
+	<machine name="c8050" sourcefile="devices/bus/ieee488/c8050.cpp" isdevice="yes" runnable="no">
+		<description>Commodore 8050 disk drive</description>
+		<biosset name="dos25m" description="DOS 2.5 (Micropolis)"/>
+		<biosset name="dos25r2m" description="DOS 2.5 rev 2 (Micropolis)"/>
+		<biosset name="dos25r3m" description="DOS 2.5 rev 3 (Micropolis)"/>
+		<biosset name="dos25t" description="DOS 2.5 rev 3 (Tandon)"/>
+		<biosset name="dos27t" description="DOS 2.7 (Tandon)"/>
+		<biosset name="dos27mo" description="DOS 2.7 (Micropolis, older)"/>
+		<biosset name="dos27m" description="DOS 2.7 (Micropolis)"/>
+		<biosset name="dos27mpi" description="DOS 2.7 (MPI)" default="yes"/>
+		<rom name="901482-01.ul1" bios="dos25m" size="8192" status="nodump" region="un1" offset="0"/>
+		<rom name="901482-02.uh1" bios="dos25m" size="8192" status="nodump" region="un1" offset="2000"/>
+		<rom name="901482-03.ul1" bios="dos25r2m" size="8192" crc="09a609b9" sha1="166d8bfaaa9c4767f9b17ad63fc7ae77c199a64e" region="un1" offset="0"/>
+		<rom name="901482-04.uh1" bios="dos25r2m" size="8192" crc="1bcf9df9" sha1="217f4a8b348658bb365f4a1de21ecbaa6402b1c0" region="un1" offset="2000"/>
+		<rom name="901482-06.ul1" bios="dos25r3m" size="8192" crc="3cbd2756" sha1="7f5fbed0cddb95138dd99b8fe84fddab900e3650" region="un1" offset="0"/>
+		<rom name="901482-07.uh1" bios="dos25r3m" size="8192" crc="c7532d90" sha1="0b6d1e55afea612516df5f07f4a6dccd3bd73963" region="un1" offset="2000"/>
+		<rom name="901482-06.ul1" bios="dos25t" size="8192" crc="3cbd2756" sha1="7f5fbed0cddb95138dd99b8fe84fddab900e3650" region="un1" offset="0"/>
+		<rom name="901482-07.uh1" bios="dos25t" size="8192" crc="c7532d90" sha1="0b6d1e55afea612516df5f07f4a6dccd3bd73963" region="un1" offset="2000"/>
+		<rom name="901887-01.ul1" bios="dos27t" size="8192" crc="0073b8b2" sha1="b10603195f240118fe5fb6c6dfe5c5097463d890" region="un1" offset="0"/>
+		<rom name="901888-01.uh1" bios="dos27t" size="8192" crc="de9b6132" sha1="2e6c2d7ca934e5c550ad14bd5e9e7749686b7af4" region="un1" offset="2000"/>
+		<rom name="901887-01.ul1" bios="dos27mo" size="8192" crc="0073b8b2" sha1="b10603195f240118fe5fb6c6dfe5c5097463d890" region="un1" offset="0"/>
+		<rom name="901888-01.uh1" bios="dos27mo" size="8192" crc="de9b6132" sha1="2e6c2d7ca934e5c550ad14bd5e9e7749686b7af4" region="un1" offset="2000"/>
+		<rom name="901887-01.ul1" bios="dos27m" size="8192" crc="0073b8b2" sha1="b10603195f240118fe5fb6c6dfe5c5097463d890" region="un1" offset="0"/>
+		<rom name="901888-01.uh1" bios="dos27m" size="8192" crc="de9b6132" sha1="2e6c2d7ca934e5c550ad14bd5e9e7749686b7af4" region="un1" offset="2000"/>
+		<rom name="901887-01.ul1" bios="dos27mpi" size="8192" crc="0073b8b2" sha1="b10603195f240118fe5fb6c6dfe5c5097463d890" region="un1" offset="0"/>
+		<rom name="901888-01.uh1" bios="dos27mpi" size="8192" crc="de9b6132" sha1="2e6c2d7ca934e5c550ad14bd5e9e7749686b7af4" region="un1" offset="2000"/>
+		<rom name="901483-02.uk3" bios="dos25m" size="1024" crc="d7277f95" sha1="7607f9357f3a08f2a9f20931058d60d9e3c17d39" region="uk3" offset="0"/>
+		<rom name="901483-02.uk3" bios="dos25r2m" size="1024" crc="d7277f95" sha1="7607f9357f3a08f2a9f20931058d60d9e3c17d39" region="uk3" offset="0"/>
+		<rom name="901483-03.uk3" bios="dos25r3m" size="1024" crc="9e83fa70" sha1="e367ea8a5ddbd47f13570088427293138a10784b" region="uk3" offset="0"/>
+		<rom name="901483-04.uk3" bios="dos25t" size="1024" crc="ae1c7866" sha1="13bdf0bb387159167534c07a4554964734373f11" region="uk3" offset="0"/>
+		<rom name="901884-01.uk3" bios="dos27t" size="1024" crc="9e9a9f90" sha1="39498d7369a31ea7527b5044071acf35a84ea2ac" region="uk3" offset="0"/>
+		<rom name="901885-01.uk3" bios="dos27mo" size="1024" status="nodump" region="uk3" offset="0"/>
+		<rom name="901885-04.uk3" bios="dos27m" size="1024" crc="bab998c9" sha1="0dc9a3b60f1b866c63eebd882403532fc59fe57f" region="uk3" offset="0"/>
+		<rom name="901869-01.uk3" bios="dos27mpi" size="1024" crc="2915327a" sha1="3a9a80f72ce76e5f5c72513f8ef7553212912ae3" region="uk3" offset="0"/>
+		<device_ref tag=":_tmp:un1" name="m6502"/>
+		<device_ref tag=":_tmp:uc1" name="mos6532"/>
+		<device_ref tag=":_tmp:ue1" name="mos6532"/>
+		<device_ref tag=":_tmp:uh3" name="m6504"/>
+		<device_ref tag=":_tmp:um3" name="mos6522"/>
+		<device_ref tag=":_tmp:uk3" name="mos6530"/>
+		<device_ref tag=":_tmp:fdc" name="c8050fdc"/>
+		<device_ref tag=":_tmp:fdc:0" name="floppy_connector"/>
+		<device_ref tag=":_tmp:fdc:1" name="floppy_connector"/>
+		<chip type="cpu" tag=":un1" name="MOS Technology 6502" clock="1000000"/>
+		<chip type="cpu" tag=":uh3" name="MOS Technology 6504" clock="1000000"/>
+		<dipswitch name="Device Address" tag=":ADDRESS" mask="7">
+			<dipvalue name="8" value="0" default="yes"/>
+			<dipvalue name="9" value="1"/>
+			<dipvalue name="10" value="2"/>
+			<dipvalue name="11" value="3"/>
+			<dipvalue name="12" value="4"/>
+			<dipvalue name="13" value="5"/>
+			<dipvalue name="14" value="6"/>
+			<dipvalue name="15" value="7"/>
+		</dipswitch>
+		<slot name=":fdc:0">
+			<slotoption name="525ssqd" devname="floppy_525_ssqd" default="yes"/>
+		</slot>
+		<slot name=":fdc:1">
+			<slotoption name="525ssqd" devname="floppy_525_ssqd" default="yes"/>
+		</slot>
+	</machine>
+	<machine name="c8050fdc" sourcefile="devices/bus/ieee488/c8050fdc.cpp" isdevice="yes" runnable="no">
+		<description>Commodore 8050 FDC</description>
+		<rom name="901467.uk6" size="2048" crc="a23337eb" sha1="97df576397608455616331f8e837cb3404363fa2" region="gcr" offset="0"/>
+	</machine>
+	<machine name="c8250" sourcefile="devices/bus/ieee488/c8050.cpp" isdevice="yes" runnable="no">
+		<description>Commodore 8250 disk drive</description>
+		<biosset name="dos25m" description="DOS 2.5 (Micropolis)"/>
+		<biosset name="dos25r2m" description="DOS 2.5 rev 2 (Micropolis)"/>
+		<biosset name="dos25r3m" description="DOS 2.5 rev 3 (Micropolis)"/>
+		<biosset name="dos25t" description="DOS 2.5 rev 3 (Tandon)"/>
+		<biosset name="dos27t" description="DOS 2.7 (Tandon)"/>
+		<biosset name="dos27mo" description="DOS 2.7 (Micropolis, older)"/>
+		<biosset name="dos27m" description="DOS 2.7 (Micropolis)"/>
+		<biosset name="dos27mpi" description="DOS 2.7 (MPI)" default="yes"/>
+		<rom name="901482-01.ul1" bios="dos25m" size="8192" status="nodump" region="un1" offset="0"/>
+		<rom name="901482-02.uh1" bios="dos25m" size="8192" status="nodump" region="un1" offset="2000"/>
+		<rom name="901482-03.ul1" bios="dos25r2m" size="8192" crc="09a609b9" sha1="166d8bfaaa9c4767f9b17ad63fc7ae77c199a64e" region="un1" offset="0"/>
+		<rom name="901482-04.uh1" bios="dos25r2m" size="8192" crc="1bcf9df9" sha1="217f4a8b348658bb365f4a1de21ecbaa6402b1c0" region="un1" offset="2000"/>
+		<rom name="901482-06.ul1" bios="dos25r3m" size="8192" crc="3cbd2756" sha1="7f5fbed0cddb95138dd99b8fe84fddab900e3650" region="un1" offset="0"/>
+		<rom name="901482-07.uh1" bios="dos25r3m" size="8192" crc="c7532d90" sha1="0b6d1e55afea612516df5f07f4a6dccd3bd73963" region="un1" offset="2000"/>
+		<rom name="901482-06.ul1" bios="dos25t" size="8192" crc="3cbd2756" sha1="7f5fbed0cddb95138dd99b8fe84fddab900e3650" region="un1" offset="0"/>
+		<rom name="901482-07.uh1" bios="dos25t" size="8192" crc="c7532d90" sha1="0b6d1e55afea612516df5f07f4a6dccd3bd73963" region="un1" offset="2000"/>
+		<rom name="901887-01.ul1" bios="dos27t" size="8192" crc="0073b8b2" sha1="b10603195f240118fe5fb6c6dfe5c5097463d890" region="un1" offset="0"/>
+		<rom name="901888-01.uh1" bios="dos27t" size="8192" crc="de9b6132" sha1="2e6c2d7ca934e5c550ad14bd5e9e7749686b7af4" region="un1" offset="2000"/>
+		<rom name="901887-01.ul1" bios="dos27mo" size="8192" crc="0073b8b2" sha1="b10603195f240118fe5fb6c6dfe5c5097463d890" region="un1" offset="0"/>
+		<rom name="901888-01.uh1" bios="dos27mo" size="8192" crc="de9b6132" sha1="2e6c2d7ca934e5c550ad14bd5e9e7749686b7af4" region="un1" offset="2000"/>
+		<rom name="901887-01.ul1" bios="dos27m" size="8192" crc="0073b8b2" sha1="b10603195f240118fe5fb6c6dfe5c5097463d890" region="un1" offset="0"/>
+		<rom name="901888-01.uh1" bios="dos27m" size="8192" crc="de9b6132" sha1="2e6c2d7ca934e5c550ad14bd5e9e7749686b7af4" region="un1" offset="2000"/>
+		<rom name="901887-01.ul1" bios="dos27mpi" size="8192" crc="0073b8b2" sha1="b10603195f240118fe5fb6c6dfe5c5097463d890" region="un1" offset="0"/>
+		<rom name="901888-01.uh1" bios="dos27mpi" size="8192" crc="de9b6132" sha1="2e6c2d7ca934e5c550ad14bd5e9e7749686b7af4" region="un1" offset="2000"/>
+		<rom name="901483-02.uk3" bios="dos25m" size="1024" crc="d7277f95" sha1="7607f9357f3a08f2a9f20931058d60d9e3c17d39" region="uk3" offset="0"/>
+		<rom name="901483-02.uk3" bios="dos25r2m" size="1024" crc="d7277f95" sha1="7607f9357f3a08f2a9f20931058d60d9e3c17d39" region="uk3" offset="0"/>
+		<rom name="901483-03.uk3" bios="dos25r3m" size="1024" crc="9e83fa70" sha1="e367ea8a5ddbd47f13570088427293138a10784b" region="uk3" offset="0"/>
+		<rom name="901483-04.uk3" bios="dos25t" size="1024" crc="ae1c7866" sha1="13bdf0bb387159167534c07a4554964734373f11" region="uk3" offset="0"/>
+		<rom name="901884-01.uk3" bios="dos27t" size="1024" crc="9e9a9f90" sha1="39498d7369a31ea7527b5044071acf35a84ea2ac" region="uk3" offset="0"/>
+		<rom name="901885-01.uk3" bios="dos27mo" size="1024" status="nodump" region="uk3" offset="0"/>
+		<rom name="901885-04.uk3" bios="dos27m" size="1024" crc="bab998c9" sha1="0dc9a3b60f1b866c63eebd882403532fc59fe57f" region="uk3" offset="0"/>
+		<rom name="901869-01.uk3" bios="dos27mpi" size="1024" crc="2915327a" sha1="3a9a80f72ce76e5f5c72513f8ef7553212912ae3" region="uk3" offset="0"/>
+		<device_ref tag=":_tmp:un1" name="m6502"/>
+		<device_ref tag=":_tmp:uc1" name="mos6532"/>
+		<device_ref tag=":_tmp:ue1" name="mos6532"/>
+		<device_ref tag=":_tmp:uh3" name="m6504"/>
+		<device_ref tag=":_tmp:um3" name="mos6522"/>
+		<device_ref tag=":_tmp:uk3" name="mos6530"/>
+		<device_ref tag=":_tmp:fdc" name="c8050fdc"/>
+		<device_ref tag=":_tmp:fdc:0" name="floppy_connector"/>
+		<device_ref tag=":_tmp:fdc:1" name="floppy_connector"/>
+		<chip type="cpu" tag=":un1" name="MOS Technology 6502" clock="1000000"/>
+		<chip type="cpu" tag=":uh3" name="MOS Technology 6504" clock="1000000"/>
+		<dipswitch name="Device Address" tag=":ADDRESS" mask="7">
+			<dipvalue name="8" value="0" default="yes"/>
+			<dipvalue name="9" value="1"/>
+			<dipvalue name="10" value="2"/>
+			<dipvalue name="11" value="3"/>
+			<dipvalue name="12" value="4"/>
+			<dipvalue name="13" value="5"/>
+			<dipvalue name="14" value="6"/>
+			<dipvalue name="15" value="7"/>
+		</dipswitch>
+		<slot name=":fdc:0">
+			<slotoption name="525qd" devname="floppy_525_qd" default="yes"/>
+		</slot>
+		<slot name=":fdc:1">
+			<slotoption name="525qd" devname="floppy_525_qd" default="yes"/>
+		</slot>
+	</machine>
+	<machine name="c8280" sourcefile="devices/bus/ieee488/c8280.cpp" isdevice="yes" runnable="no">
+		<description>Commodore 8280 dual 8&quot; disk drive</description>
+		<biosset name="r1" description="Revision 1"/>
+		<biosset name="r2" description="Revision 2" default="yes"/>
+		<rom name="300542-001.10c" bios="r1" size="8192" crc="3c6eee1e" sha1="0726f6ab4de4fc9c18707fe87780ffd9f5ed72ab" region="5c" offset="0"/>
+		<rom name="300543-001.10d" bios="r1" size="8192" crc="f58e665e" sha1="9e58b47c686c91efc6ef1a27f72dbb5e26c485ec" region="5c" offset="2000"/>
+		<rom name="300542-reva.10c" bios="r2" size="8192" crc="6f32ccfb" sha1="6926c049f1635e6769ec69891de8c92941ff880e" region="5c" offset="0"/>
+		<rom name="300543-reva.10d" bios="r2" size="8192" crc="1af93f2c" sha1="ad197b1d5dfa273487b33f473403ebd20dd15b2b" region="5c" offset="2000"/>
+		<rom name="300541-001.3c" bios="r1" size="2048" crc="cb07b2db" sha1="a1f9c5a7bd3798f5a97dc0b465c3bf5e3513e148" status="baddump" region="9e" offset="0"/>
+		<rom name="300541-revb.3c" bios="r2" size="2048" crc="403e632c" sha1="a0994c80025240d2b49ffd209dbfe8a4de3975b0" region="9e" offset="0"/>
+		<device_ref tag=":_tmp:5c" name="m6502"/>
+		<device_ref tag=":_tmp:9f" name="mos6532"/>
+		<device_ref tag=":_tmp:9g" name="mos6532"/>
+		<device_ref tag=":_tmp:9e" name="m6502"/>
+		<device_ref tag=":_tmp:5e" name="fd1797"/>
+		<device_ref tag=":_tmp:5e:0" name="floppy_connector"/>
+		<device_ref tag=":_tmp:5e:1" name="floppy_connector"/>
+		<chip type="cpu" tag=":5c" name="MOS Technology 6502" clock="1500000"/>
+		<chip type="cpu" tag=":9e" name="MOS Technology 6502" clock="1500000"/>
+		<dipswitch name="Device Address" tag=":ADDRESS" mask="7">
+			<dipvalue name="8" value="0" default="yes"/>
+			<dipvalue name="9" value="1"/>
+			<dipvalue name="10" value="2"/>
+			<dipvalue name="11" value="3"/>
+			<dipvalue name="12" value="4"/>
+			<dipvalue name="13" value="5"/>
+			<dipvalue name="14" value="6"/>
+			<dipvalue name="15" value="7"/>
+		</dipswitch>
+		<slot name=":5e:0">
+			<slotoption name="8dsdd" devname="floppy_8_dsdd" default="yes"/>
+		</slot>
+		<slot name=":5e:1">
+			<slotoption name="8dsdd" devname="floppy_8_dsdd" default="yes"/>
+		</slot>
+	</machine>
+	<machine name="cdd2000" sourcefile="devices/bus/nscsi/cdd2000.cpp" isdevice="yes" runnable="no">
+		<description>Philips CDD2000 CD-R</description>
+		<biosset name="v126" description="Firmware v1.26"/>
+		<biosset name="v125" description="Firmware v1.25"/>
+		<rom name="cdd2_126.bin" bios="v126" size="262144" crc="8a9f0f85" sha1="efc6c696b12af7d29fcc37c641bc5879517d6fd8" region="flash" offset="0"/>
+		<rom name="cdd2_125.bin" bios="v125" size="262144" crc="17f1c04a" sha1="882be4ed5daf70a686929fffcb66fa95b431bbe2" region="flash" offset="0"/>
+		<device_ref tag=":_tmp:cdcpu" name="mc68hc11f1"/>
+		<device_ref tag=":_tmp:scsic" name="ncr53cf94"/>
+		<chip type="cpu" tag=":cdcpu" name="Motorola MC68HC11F1" clock="8000000"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="cdda" sourcefile="devices/sound/cdda.cpp" isdevice="yes" runnable="no">
+		<description>CD/DA</description>
+		<sound channels="0"/>
+	</machine>
+	<machine name="cdr4210" sourcefile="devices/bus/nscsi/cw7501.cpp" isdevice="yes" runnable="no">
+		<description>Creative Technology Blaster CD-R 4210</description>
+		<rom name="cr113.bin" size="262144" crc="fd2faff9" sha1="6aafdedf12240ad347427287c0db289f90bd064d" region="flash" offset="0"/>
+		<device_ref tag=":_tmp:cdcpu" name="m37710s4"/>
+		<device_ref tag=":_tmp:scsic" name="ncr53cf94"/>
+		<chip type="cpu" tag=":cdcpu" name="Mitsubishi M37710S4" clock="12500000"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="cdrn820s" sourcefile="devices/bus/nscsi/cdrn820s.cpp" isdevice="yes" runnable="no">
+		<description>Caravelle CDR-N820s</description>
+		<rom name="cdr_120.bin" size="131072" crc="8cac6862" sha1="e498dcd9006d257ced6cd0b50c76608e9a8023f7" region="program" offset="0"/>
+		<device_ref tag=":_tmp:h8" name="h83048"/>
+		<device_ref tag=":_tmp:h8:intc" name="h8h_intc"/>
+		<device_ref tag=":_tmp:h8:adc" name="h8_adc_3337"/>
+		<device_ref tag=":_tmp:h8:dma" name="h8h_dma"/>
+		<device_ref tag=":_tmp:h8:dma:0" name="h8h_dma_channel"/>
+		<device_ref tag=":_tmp:h8:dma:1" name="h8h_dma_channel"/>
+		<device_ref tag=":_tmp:h8:port1" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:h8:port2" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:h8:port3" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:h8:port4" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:h8:port5" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:h8:port6" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:h8:port7" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:h8:port8" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:h8:port9" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:h8:porta" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:h8:portb" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:h8:timer16" name="h8_timer16"/>
+		<device_ref tag=":_tmp:h8:timer16:0" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:h8:timer16:1" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:h8:timer16:2" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:h8:timer16:3" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:h8:timer16:4" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:h8:sci0" name="h8_sci"/>
+		<device_ref tag=":_tmp:h8:sci1" name="h8_sci"/>
+		<device_ref tag=":_tmp:h8:watchdog" name="h8_watchdog"/>
+		<device_ref tag=":_tmp:scsic" name="wd33c93a"/>
+		<chip type="cpu" tag=":h8" name="Hitachi H8/3048" clock="8000000"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="cdrom" sourcefile="devices/bus/ata/atapicdr.cpp" isdevice="yes" runnable="no">
+		<description>ATAPI CD-ROM</description>
+		<device_ref tag=":_tmp:image" name="cdrom_image"/>
+		<device_ref tag=":_tmp:cdda" name="cdda"/>
+		<chip type="audio" tag=":cdda" name="CD/DA" clock="44100"/>
+		<sound channels="0"/>
+		<device type="cdrom" tag=":image" interface="cdrom">
+			<instance name="cdrom" briefname="cdrm"/>
+			<extension name="chd"/>
+			<extension name="cue"/>
+			<extension name="toc"/>
+			<extension name="nrg"/>
+			<extension name="gdi"/>
+			<extension name="iso"/>
+			<extension name="cdr"/>
+		</device>
+	</machine>
+	<machine name="cdrom_image" sourcefile="devices/imagedev/cdromimg.cpp" isdevice="yes" runnable="no">
+		<description>CD-ROM Image</description>
+	</machine>
+	<machine name="cdu415" sourcefile="devices/bus/nscsi/cdu415.cpp" isdevice="yes" runnable="no">
+		<description>Sony CDU415 CD-R</description>
+		<rom name="cdu415.bin" size="65536" crc="9873b898" sha1="72d0b192efc32f7c8985dd96df3e346c57a236e7" region="mcu" offset="10000"/>
+		<device_ref tag=":_tmp:mcu" name="h83032"/>
+		<device_ref tag=":_tmp:mcu:intc" name="h8h_intc"/>
+		<device_ref tag=":_tmp:mcu:adc" name="h8_adc_3337"/>
+		<device_ref tag=":_tmp:mcu:port1" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port2" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port3" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port5" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port6" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port7" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port8" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port9" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:porta" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:portb" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:portc" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:timer16" name="h8_timer16"/>
+		<device_ref tag=":_tmp:mcu:timer16:0" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:timer16:1" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:timer16:2" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:timer16:3" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:timer16:4" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:sci0" name="h8_sci"/>
+		<device_ref tag=":_tmp:mcu:watchdog" name="h8_watchdog"/>
+		<device_ref tag=":_tmp:cxd1804ar" name="ncr53c94"/>
+		<chip type="cpu" tag=":mcu" name="Hitachi H8/3032" clock="10000000"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="cdu561_25" sourcefile="devices/bus/nscsi/cdu561.cpp" isdevice="yes" runnable="no">
+		<description>Sony CDU561-25</description>
+		<biosset name="19a" description="apl1.9a"/>
+		<biosset name="18f" description="apl1.8F"/>
+		<biosset name="17w" description="apl1.7w"/>
+		<rom name="apl1.9a_83fb.ic302" bios="19a" size="131072" crc="0efc50eb" sha1="8bfd6ebc0863017914808e8282a5914cdc828f56" region="eprom" offset="0"/>
+		<rom name="apl1.8f_d905.ic302" bios="18f" size="131072" crc="3ea92e48" sha1="2f409fd59c5f09d22e00b39f4b0b57e16316090d" region="eprom" offset="0"/>
+		<rom name="apl_1.7w.bin" bios="17w" size="131072" crc="12ba5843" sha1="70aa550693020431ccbd374ff85e4de8809431df" region="eprom" offset="0"/>
+		<device_ref tag=":_tmp:mcu" name="m37732s4"/>
+		<device_ref tag=":_tmp:scsic" name="cxd1185"/>
+		<chip type="cpu" tag=":mcu" name="Mitsubishi M37732S4" clock="12000000"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="cdu75s" sourcefile="devices/bus/nscsi/cdu75s.cpp" isdevice="yes" runnable="no">
+		<description>Sony/Apple CDU75S CD-R</description>
+		<rom name="ic201.bin" size="65536" crc="8781ad49" sha1="abdfb2561f2420a7f462e3bd5c8bd4d6eb0a9dfb" region="mcu" offset="0"/>
+		<rom name="cdu-75s_1.0j_95.03.14_apple.bin" size="65536" crc="f4ad4d48" sha1="7d674116304bc6948fe4a52d9859b4eb5d40b914" region="mcu" offset="10000"/>
+		<device_ref tag=":_tmp:mcu" name="h83032"/>
+		<device_ref tag=":_tmp:mcu:intc" name="h8h_intc"/>
+		<device_ref tag=":_tmp:mcu:adc" name="h8_adc_3337"/>
+		<device_ref tag=":_tmp:mcu:port1" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port2" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port3" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port5" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port6" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port7" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port8" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port9" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:porta" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:portb" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:portc" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:timer16" name="h8_timer16"/>
+		<device_ref tag=":_tmp:mcu:timer16:0" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:timer16:1" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:timer16:2" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:timer16:3" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:timer16:4" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:sci0" name="h8_sci"/>
+		<device_ref tag=":_tmp:mcu:watchdog" name="h8_watchdog"/>
+		<device_ref tag=":_tmp:fas204" name="ncr53c94"/>
+		<chip type="cpu" tag=":mcu" name="Hitachi H8/3032" clock="16934400"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="cfp1080s" sourcefile="devices/bus/nscsi/cfp1080s.cpp" isdevice="yes" runnable="no">
+		<description>Conner CFP1080S</description>
+		<rom name="conner_cfp1080s.bin" size="131072" crc="3254150a" sha1="605be871e75ff775554fc8ce4e09bc2e35a6db09" region="firmware" offset="0"/>
+		<device_ref tag=":_tmp:hdcpu" name="mc68hc16z1"/>
+		<chip type="cpu" tag=":hdcpu" name="Motorola MC68HC16Z1" clock="20000000"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="com8116" sourcefile="devices/machine/com8116.cpp" isdevice="yes" runnable="no">
+		<description>COM8116 Dual BRG</description>
+	</machine>
+	<machine name="corvus_hdc" sourcefile="devices/machine/corvushd.cpp" isdevice="yes" runnable="no">
+		<description>Corvus Flat Cable HDC</description>
+	</machine>
+	<machine name="cp2024" sourcefile="devices/bus/ata/cp2024.cpp" isdevice="yes" runnable="no">
+		<description>Conner Peripherals CP-2024 hard disk</description>
+		<rom name="27c256.bin" size="32768" crc="574b5904" sha1="79bccc33835ba01fc4eb33fb4d412a691e7790c2" region="eprom" offset="0"/>
+		<device_ref tag=":_tmp:mcu" name="mc68hc11a1"/>
+		<chip type="cpu" tag=":mcu" name="Motorola MC68HC11A1" clock="10000000"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="cr589" sourcefile="devices/bus/ata/cr589.cpp" isdevice="yes" runnable="no">
+		<description>Matsushita CR589 CD-ROM Drive</description>
+		<device_ref tag=":_tmp:image" name="cdrom_image"/>
+		<device_ref tag=":_tmp:cdda" name="cdda"/>
+		<chip type="audio" tag=":cdda" name="CD/DA" clock="44100"/>
+		<sound channels="0"/>
+		<device type="cdrom" tag=":image" interface="cdrom">
+			<instance name="cdrom" briefname="cdrm"/>
+			<extension name="chd"/>
+			<extension name="cue"/>
+			<extension name="toc"/>
+			<extension name="nrg"/>
+			<extension name="gdi"/>
+			<extension name="iso"/>
+			<extension name="cdr"/>
+		</device>
+	</machine>
+	<machine name="crd254sh" sourcefile="devices/bus/nscsi/crd254sh.cpp" isdevice="yes" runnable="no">
+		<description>Sanyo CRD-254SH CD-ROM</description>
+		<rom name="crd-254s_1.02.bin" size="65536" crc="539df5f0" sha1="edb1f7d96f351ef70b8ade03449fb63e0e0a652b" region="mcu" offset="0"/>
+		<device_ref tag=":_tmp:mcu" name="h83040"/>
+		<device_ref tag=":_tmp:mcu:intc" name="h8h_intc"/>
+		<device_ref tag=":_tmp:mcu:adc" name="h8_adc_3337"/>
+		<device_ref tag=":_tmp:mcu:dma" name="h8h_dma"/>
+		<device_ref tag=":_tmp:mcu:dma:0" name="h8h_dma_channel"/>
+		<device_ref tag=":_tmp:mcu:dma:1" name="h8h_dma_channel"/>
+		<device_ref tag=":_tmp:mcu:port1" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port2" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port3" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port4" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port5" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port6" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port7" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port8" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:port9" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:porta" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:portb" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:mcu:timer16" name="h8_timer16"/>
+		<device_ref tag=":_tmp:mcu:timer16:0" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:timer16:1" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:timer16:2" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:timer16:3" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:timer16:4" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:mcu:sci0" name="h8_sci"/>
+		<device_ref tag=":_tmp:mcu:sci1" name="h8_sci"/>
+		<device_ref tag=":_tmp:mcu:watchdog" name="h8_watchdog"/>
+		<device_ref tag=":_tmp:dummy_scsi" name="ncr53c94"/>
+		<chip type="cpu" tag=":mcu" name="Hitachi H8/3040" clock="20000000"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="cu_cubio_race" sourcefile="devices/bus/acorn/cu/cubio.cpp" isdevice="yes" runnable="no">
+		<description>Control Universal CUBIO w/ Race Controllers</description>
+		<device_ref tag=":_tmp:irqs" name="ipt_merge_any_hi"/>
+		<device_ref tag=":_tmp:via0" name="mos6522"/>
+		<device_ref tag=":_tmp:via1" name="mos6522"/>
+		<device_ref tag=":_tmp:via2" name="mos6522"/>
+		<device_ref tag=":_tmp:via3" name="mos6522"/>
+		<input players="4">
+			<control type="joy" player="1" buttons="1" ways="8"/>
+			<control type="joy" player="2" buttons="1" ways="8"/>
+			<control type="joy" player="3" buttons="1" ways="8"/>
+			<control type="joy" player="4" buttons="1" ways="8"/>
+		</input>
+		<configuration name="Device Select" tag=":SW1" mask="1">
+			<confsetting name="VIA" value="0" default="yes"/>
+			<confsetting name="PIA" value="1"/>
+		</configuration>
+		<configuration name="Address Select - Block" tag=":SW2" mask="15">
+			<confsetting name="0" value="0" default="yes"/>
+			<confsetting name="1" value="1"/>
+			<confsetting name="2" value="2"/>
+			<confsetting name="3" value="3"/>
+			<confsetting name="4" value="4"/>
+			<confsetting name="5" value="5"/>
+			<confsetting name="6" value="6"/>
+			<confsetting name="7" value="7"/>
+			<confsetting name="8" value="8"/>
+			<confsetting name="9" value="9"/>
+			<confsetting name="A" value="10"/>
+			<confsetting name="B" value="11"/>
+			<confsetting name="C" value="12"/>
+			<confsetting name="D" value="13"/>
+			<confsetting name="E" value="14"/>
+			<confsetting name="F" value="15"/>
+		</configuration>
+		<configuration name="Address Select - Page" tag=":SW3" mask="15">
+			<confsetting name="0" value="0" default="yes"/>
+			<confsetting name="1" value="1"/>
+			<confsetting name="2" value="2"/>
+			<confsetting name="3" value="3"/>
+			<confsetting name="4" value="4"/>
+			<confsetting name="5" value="5"/>
+			<confsetting name="6" value="6"/>
+			<confsetting name="7" value="7"/>
+			<confsetting name="8" value="8"/>
+			<confsetting name="9" value="9"/>
+			<confsetting name="A" value="10"/>
+			<confsetting name="B" value="11"/>
+			<confsetting name="C" value="12"/>
+			<confsetting name="D" value="13"/>
+			<confsetting name="E" value="14"/>
+			<confsetting name="F" value="15"/>
+		</configuration>
+	</machine>
+	<machine name="cu_graphc" sourcefile="devices/bus/acorn/cu/cugraph.cpp" isdevice="yes" runnable="no">
+		<description>Control Universal High Resolution Graphics card (colour)</description>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<device_ref tag=":_tmp:ef9366" name="ef9365"/>
+		<display tag=":screen" type="raster" rotate="0" width="512" height="256" refresh="50.000000" pixclock="7987200" htotal="512" hbend="0" hbstart="512" vtotal="312" vbend="0" vbstart="256" />
+		<feature type="graphics" status="imperfect"/>
+		<feature type="palette" status="imperfect"/>
+	</machine>
+	<machine name="cu_graphm" sourcefile="devices/bus/acorn/cu/cugraph.cpp" isdevice="yes" runnable="no">
+		<description>Control Universal High Resolution Graphics card (monochrome)</description>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<device_ref tag=":_tmp:ef9366" name="ef9365"/>
+		<display tag=":screen" type="raster" rotate="0" width="512" height="256" refresh="50.000000" pixclock="7987200" htotal="512" hbend="0" hbstart="512" vtotal="312" vbend="0" vbstart="256" />
+		<feature type="graphics" status="imperfect"/>
+		<feature type="palette" status="imperfect"/>
+	</machine>
+	<machine name="cu_teletext" sourcefile="devices/bus/acorn/cu/teletext.cpp" isdevice="yes" runnable="no">
+		<description>Control Universal Teletext Video Interface card</description>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<device_ref tag=":_tmp:mc6845" name="hd6845s"/>
+		<device_ref tag=":_tmp:saa5050" name="saa5050"/>
+		<device_ref tag=":_tmp:via6522" name="mos6522"/>
+		<device_ref tag=":_tmp:centronics" name="centronics"/>
+		<device_ref tag=":_tmp:cent_data_out" name="output_latch"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="300"/>
+		<display tag=":screen" type="raster" rotate="0" width="480" height="250" refresh="50.080128" pixclock="12000000" htotal="768" hbend="132" hbstart="612" vtotal="312" vbend="20" vbstart="270" />
+		<sound channels="1"/>
+		<configuration name="Buzzer fitted" tag=":OPTION" mask="1">
+			<confsetting name="No" value="0" default="yes"/>
+			<confsetting name="Yes" value="1"/>
+		</configuration>
+		<slot name=":centronics">
+			<slotoption name="neomania" devname="neomania_adapter"/>
+			<slotoption name="pc6022" devname="pc6022"/>
+			<slotoption name="nlq401" devname="nlq401"/>
+			<slotoption name="smartboard" devname="centronics_smartboard"/>
+			<slotoption name="chessmec" devname="centronics_chessmec"/>
+			<slotoption name="samdac" devname="centronics_samdac"/>
+			<slotoption name="covox_stereo" devname="covox_stereo"/>
+			<slotoption name="adaptator" devname="adaptator_multitap"/>
+			<slotoption name="digiblst" devname="cpcdigiblst"/>
+			<slotoption name="lx800" devname="lx800"/>
+			<slotoption name="jx80" devname="epson_jx80"/>
+			<slotoption name="ap2000" devname="ap2000"/>
+			<slotoption name="ex800" devname="ex800"/>
+			<slotoption name="fx80" devname="epson_fx80"/>
+			<slotoption name="rx80" devname="epson_rx80"/>
+			<slotoption name="mz1p16" devname="mz1p16"/>
+			<slotoption name="covox" devname="covox"/>
+			<slotoption name="pl80" devname="comx_pl80"/>
+			<slotoption name="lx810l" devname="lx810l"/>
+			<slotoption name="p72" devname="p72"/>
+			<slotoption name="printer" devname="centronics_printer" default="yes"/>
+		</slot>
+	</machine>
+	<machine name="cw7501" sourcefile="devices/bus/nscsi/cw7501.cpp" isdevice="yes" runnable="no">
+		<description>Panasonic CW-7501 CD-R</description>
+		<rom name="mk200.bin" size="262144" crc="12efd802" sha1="2986ee5eedbe0cb662a9a7e7fa4e6ca7ccd8c539" region="flash" offset="0"/>
+		<device_ref tag=":_tmp:cdcpu" name="m37710s4"/>
+		<device_ref tag=":_tmp:scsic" name="ncr53cf94"/>
+		<chip type="cpu" tag=":cdcpu" name="Mitsubishi M37710S4" clock="12500000"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="cxd1180" sourcefile="devices/machine/ncr5380.cpp" isdevice="yes" runnable="no">
+		<description>Sony CXD1180</description>
+	</machine>
+	<machine name="cxd1185" sourcefile="devices/machine/cxd1185.cpp" isdevice="yes" runnable="no">
+		<description>Sony CXD1185 SCSI 1 Protocol Controller</description>
+	</machine>
+	<machine name="d9060" sourcefile="devices/bus/ieee488/d9060.cpp" isdevice="yes" runnable="no">
+		<description>Commodore D9060 hard disk drive</description>
+		<biosset name="ra" description="Revision A"/>
+		<biosset name="rb" description="Revision B"/>
+		<biosset name="rc" description="Revision C" default="yes"/>
+		<rom name="300516-001.7c" bios="ra" size="8192" status="nodump" region="7e" offset="0"/>
+		<rom name="300517-001.7d" bios="ra" size="8192" crc="566df630" sha1="b1602dfff408b165ee52a6a4ca3e2ec27e689ba9" region="7e" offset="2000"/>
+		<rom name="300516-002.7c" bios="rb" size="8192" crc="2d758a14" sha1="c959cc9dde84fc3d64e95e58a0a096a26d8107fd" region="7e" offset="0"/>
+		<rom name="300517-002.7d" bios="rb" size="8192" crc="f0382bc3" sha1="0b0a8dc520f5b41ffa832e4a636b3d226ccbb7f1" region="7e" offset="2000"/>
+		<rom name="300516-003.7c" bios="rc" size="8192" crc="d6a3e88f" sha1="bb1ddb5da94a86266012eca54818aa21dc4cef6a" region="7e" offset="0"/>
+		<rom name="300517-003.7d" bios="rc" size="8192" crc="2a9ad4ad" sha1="4c17d014de48c906871b9b6c7d037d8736b1fd52" region="7e" offset="2000"/>
+		<rom name="300515-001.4c" size="2048" crc="99e096f7" sha1="a3d1deb27bf5918b62b89c27fa3e488eb8f717a4" region="4a" offset="0"/>
+		<rom name="300515-002.4c" size="2048" crc="49adf4fb" sha1="59dafbd4855083074ba8dc96a04d4daa5b76e0d6" region="4a" offset="0"/>
+		<rom name="44_1.5b" size="1024" crc="67a49dd3" sha1="be39f55bc0ff9a508ec55224c52549856ad3270a" region="9d" offset="0"/>
+		<rom name="44_2.6b" size="1024" crc="f6d1bdbc" sha1="bca7a96a60144c36eff1124485ec26df7cfa8143" region="9d" offset="400"/>
+		<rom name="44_3.7b" size="1024" crc="68af3a1f" sha1="d3823a0d23e828a2dff6d89211fbcd7034112298" region="9d" offset="800"/>
+		<rom name="44_4.8b" size="1024" crc="a767b1dc" sha1="fff11b662c74040981822ccdcc8cbd0e22b517a9" region="9d" offset="c00"/>
+		<rom name="44_5.9b" size="1024" crc="85743073" sha1="95a48835bc2bd1c79fb1a63778de3807fb731ac6" region="9d" offset="1000"/>
+		<device_ref tag=":_tmp:7e" name="m6502"/>
+		<device_ref tag=":_tmp:7f" name="mos6532"/>
+		<device_ref tag=":_tmp:7g" name="mos6532"/>
+		<device_ref tag=":_tmp:4a" name="m6502"/>
+		<device_ref tag=":_tmp:4b" name="mos6522"/>
+		<device_ref tag=":_tmp:sasi" name="scsi"/>
+		<device_ref tag=":_tmp:sasi:1" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi:2" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi:3" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi:4" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi:5" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi:6" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi:7" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi_data_out" name="output_latch"/>
+		<chip type="cpu" tag=":7e" name="MOS Technology 6502" clock="1000000"/>
+		<chip type="cpu" tag=":4a" name="MOS Technology 6502" clock="1000000"/>
+		<dipswitch name="Device Address" tag=":ADDRESS" mask="7">
+			<dipvalue name="8" value="0"/>
+			<dipvalue name="9" value="1" default="yes"/>
+			<dipvalue name="10" value="2"/>
+			<dipvalue name="11" value="3"/>
+			<dipvalue name="12" value="4"/>
+			<dipvalue name="13" value="5"/>
+			<dipvalue name="14" value="6"/>
+			<dipvalue name="15" value="7"/>
+		</dipswitch>
+		<slot name=":sasi:1">
+			<slotoption name="harddisk" devname="d9060hd" default="yes"/>
+		</slot>
+		<slot name=":sasi:2">
+		</slot>
+		<slot name=":sasi:3">
+		</slot>
+		<slot name=":sasi:4">
+		</slot>
+		<slot name=":sasi:5">
+		</slot>
+		<slot name=":sasi:6">
+		</slot>
+		<slot name=":sasi:7">
+		</slot>
+	</machine>
+	<machine name="d9090" sourcefile="devices/bus/ieee488/d9060.cpp" isdevice="yes" runnable="no">
+		<description>Commodore D9090 hard disk drive</description>
+		<biosset name="ra" description="Revision A"/>
+		<biosset name="rb" description="Revision B"/>
+		<biosset name="rc" description="Revision C" default="yes"/>
+		<rom name="300516-001.7c" bios="ra" size="8192" status="nodump" region="7e" offset="0"/>
+		<rom name="300517-001.7d" bios="ra" size="8192" crc="566df630" sha1="b1602dfff408b165ee52a6a4ca3e2ec27e689ba9" region="7e" offset="2000"/>
+		<rom name="300516-002.7c" bios="rb" size="8192" crc="2d758a14" sha1="c959cc9dde84fc3d64e95e58a0a096a26d8107fd" region="7e" offset="0"/>
+		<rom name="300517-002.7d" bios="rb" size="8192" crc="f0382bc3" sha1="0b0a8dc520f5b41ffa832e4a636b3d226ccbb7f1" region="7e" offset="2000"/>
+		<rom name="300516-003.7c" bios="rc" size="8192" crc="d6a3e88f" sha1="bb1ddb5da94a86266012eca54818aa21dc4cef6a" region="7e" offset="0"/>
+		<rom name="300517-003.7d" bios="rc" size="8192" crc="2a9ad4ad" sha1="4c17d014de48c906871b9b6c7d037d8736b1fd52" region="7e" offset="2000"/>
+		<rom name="300515-001.4c" size="2048" crc="99e096f7" sha1="a3d1deb27bf5918b62b89c27fa3e488eb8f717a4" region="4a" offset="0"/>
+		<rom name="300515-002.4c" size="2048" crc="49adf4fb" sha1="59dafbd4855083074ba8dc96a04d4daa5b76e0d6" region="4a" offset="0"/>
+		<rom name="44_1.5b" size="1024" crc="67a49dd3" sha1="be39f55bc0ff9a508ec55224c52549856ad3270a" region="9d" offset="0"/>
+		<rom name="44_2.6b" size="1024" crc="f6d1bdbc" sha1="bca7a96a60144c36eff1124485ec26df7cfa8143" region="9d" offset="400"/>
+		<rom name="44_3.7b" size="1024" crc="68af3a1f" sha1="d3823a0d23e828a2dff6d89211fbcd7034112298" region="9d" offset="800"/>
+		<rom name="44_4.8b" size="1024" crc="a767b1dc" sha1="fff11b662c74040981822ccdcc8cbd0e22b517a9" region="9d" offset="c00"/>
+		<rom name="44_5.9b" size="1024" crc="85743073" sha1="95a48835bc2bd1c79fb1a63778de3807fb731ac6" region="9d" offset="1000"/>
+		<device_ref tag=":_tmp:7e" name="m6502"/>
+		<device_ref tag=":_tmp:7f" name="mos6532"/>
+		<device_ref tag=":_tmp:7g" name="mos6532"/>
+		<device_ref tag=":_tmp:4a" name="m6502"/>
+		<device_ref tag=":_tmp:4b" name="mos6522"/>
+		<device_ref tag=":_tmp:sasi" name="scsi"/>
+		<device_ref tag=":_tmp:sasi:1" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi:2" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi:3" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi:4" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi:5" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi:6" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi:7" name="scsi_slot"/>
+		<device_ref tag=":_tmp:sasi_data_out" name="output_latch"/>
+		<chip type="cpu" tag=":7e" name="MOS Technology 6502" clock="1000000"/>
+		<chip type="cpu" tag=":4a" name="MOS Technology 6502" clock="1000000"/>
+		<dipswitch name="Device Address" tag=":ADDRESS" mask="7">
+			<dipvalue name="8" value="0"/>
+			<dipvalue name="9" value="1" default="yes"/>
+			<dipvalue name="10" value="2"/>
+			<dipvalue name="11" value="3"/>
+			<dipvalue name="12" value="4"/>
+			<dipvalue name="13" value="5"/>
+			<dipvalue name="14" value="6"/>
+			<dipvalue name="15" value="7"/>
+		</dipswitch>
+		<slot name=":sasi:1">
+			<slotoption name="harddisk" devname="d9060hd" default="yes"/>
+		</slot>
+		<slot name=":sasi:2">
+		</slot>
+		<slot name=":sasi:3">
+		</slot>
+		<slot name=":sasi:4">
+		</slot>
+		<slot name=":sasi:5">
+		</slot>
+		<slot name=":sasi:6">
+		</slot>
+		<slot name=":sasi:7">
+		</slot>
+	</machine>
+	<machine name="ef9365" sourcefile="devices/video/ef9365.cpp" isdevice="yes" runnable="no">
+		<description>Thomson EF9365</description>
+		<rom name="charset_ef9365.rom" size="480" crc="8d3053be" sha1="0f9a64d217a0f7f04ee0720d49c5b680ad0ae359" region="ef9365" offset="0"/>
+	</machine>
+	<machine name="fd1793" sourcefile="devices/machine/wd_fdc.cpp" isdevice="yes" runnable="no">
+		<description>FD1793 FDC</description>
+	</machine>
+	<machine name="fd1797" sourcefile="devices/machine/wd_fdc.cpp" isdevice="yes" runnable="no">
+		<description>FD1797 FDC</description>
+	</machine>
+	<machine name="gpib_hardbox" sourcefile="devices/bus/ieee488/hardbox.cpp" isdevice="yes" runnable="no">
+		<description>SSE HardBox</description>
+		<biosset name="v2.3" description="Version 2.3 (Corvus)"/>
+		<biosset name="v2.4" description="Version 2.4 (Corvus)" default="yes"/>
+		<biosset name="v3.1" description="Version 3.1 (Sunol)"/>
+		<rom name="295-2.3.ic3" bios="v2.3" size="4096" crc="a3eb5fc2" sha1="39941b45b0696db928615c41c7eae18d951d9ada" region="z80" offset="0"/>
+		<rom name="296-2.3.ic4" bios="v2.3" size="4096" crc="fb55b058" sha1="8f9ec313ec6beaf7b513edf39d9628e6abcc7bc3" region="z80" offset="1000"/>
+		<rom name="289.ic3" bios="v2.4" size="4096" crc="c39e058f" sha1="45b390d7125a40f84c7b411a479218baff079746" region="z80" offset="0"/>
+		<rom name="290.ic4" bios="v2.4" size="4096" crc="62f51405" sha1="fdfa0d7b7e8d0182f2df0aa8163c790506104dcf" region="z80" offset="1000"/>
+		<rom name="295-3.1.ic3" bios="v3.1" size="4096" crc="654a5db1" sha1="c40859526921e3d8bfd58fc28cc9cc64e59ec638" region="z80" offset="0"/>
+		<rom name="296-3.1.ic4" bios="v3.1" size="4096" crc="4c62ddc0" sha1="151f99dc554d3762b805fc8383cf1b3e1455784f" region="z80" offset="1000"/>
+		<device_ref tag=":_tmp:z80" name="z80"/>
+		<device_ref tag=":_tmp:ic17" name="i8255"/>
+		<device_ref tag=":_tmp:ic16" name="i8255"/>
+		<device_ref tag=":_tmp:corvus" name="corvus_hdc"/>
+		<device_ref tag=":_tmp:harddisk1" name="harddisk_image"/>
+		<device_ref tag=":_tmp:harddisk2" name="harddisk_image"/>
+		<device_ref tag=":_tmp:harddisk3" name="harddisk_image"/>
+		<device_ref tag=":_tmp:harddisk4" name="harddisk_image"/>
+		<chip type="cpu" tag=":z80" name="Zilog Z80" clock="4000000"/>
+		<dipswitch name="Unknown" tag=":SW1" mask="1">
+			<diplocation name="SW1" number="1"/>
+			<dipvalue name="Off" value="1" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="Device Address" tag=":SW1" mask="14">
+			<diplocation name="SW1" number="2"/>
+			<diplocation name="SW1" number="3"/>
+			<diplocation name="SW1" number="4"/>
+			<dipvalue name="8" value="14"/>
+			<dipvalue name="9" value="12" default="yes"/>
+			<dipvalue name="10" value="10"/>
+			<dipvalue name="11" value="8"/>
+			<dipvalue name="12" value="6"/>
+			<dipvalue name="13" value="4"/>
+			<dipvalue name="14" value="2"/>
+			<dipvalue name="15" value="0"/>
+		</dipswitch>
+		<dipswitch name="Unknown" tag=":SW1" mask="16">
+			<diplocation name="SW1" number="5"/>
+			<dipvalue name="Off" value="16" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="Unknown" tag=":SW1" mask="32">
+			<diplocation name="SW1" number="6"/>
+			<dipvalue name="Off" value="32" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="Unknown" tag=":SW1" mask="64">
+			<diplocation name="SW1" number="7"/>
+			<dipvalue name="Off" value="64" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="Unknown" tag=":SW1" mask="128">
+			<diplocation name="SW1" number="8"/>
+			<dipvalue name="Off" value="128" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<device type="harddisk" tag=":harddisk1" interface="corvus_hdd">
+			<instance name="harddisk1" briefname="hard1"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+		<device type="harddisk" tag=":harddisk2" interface="corvus_hdd">
+			<instance name="harddisk2" briefname="hard2"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+		<device type="harddisk" tag=":harddisk3" interface="corvus_hdd">
+			<instance name="harddisk3" briefname="hard3"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+		<device type="harddisk" tag=":harddisk4" interface="corvus_hdd">
+			<instance name="harddisk4" briefname="hard4"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="gpib_mshark" sourcefile="devices/bus/ieee488/shark.cpp" isdevice="yes" runnable="no">
+		<description>Mator SHARK</description>
+		<rom name="pch488 3450 v22.1 @1" size="4096" crc="03bff9d7" sha1="ac506df6509e1b2185a69f9f8f44b8b456aa9834" region="i8085" offset="0"/>
+		<rom name="pch488 3450 v22.1 @2" size="4096" crc="c14fa5fe" sha1="bcfd1dd65d692c76b90e6134b85f22c39c049430" region="i8085" offset="1000"/>
+		<rom name="pch488 3450 v22.1 @3" size="4096" crc="4dfaa482" sha1="fe2c44bb650572616c8bdad6358032fe64b1e363" region="i8085" offset="2000"/>
+		<rom name="pch488 3450 v22.1 @4" size="4096" crc="aef665e9" sha1="80a4c00b717100b4e22fa3704e34060fffce2bc3" region="i8085" offset="3000"/>
+		<rom name="pch488 3450 v22.1 @5" size="4096" crc="f30adf60" sha1="96c15264d5a9b52e1d238921880c48a797a6da1e" region="i8085" offset="4000"/>
+		<rom name="micro p3450 v1.3" size="2048" crc="0e69202e" sha1="3b384951ff54c4b45a3a778a88966d13e2c9d57a" region="micro" offset="0"/>
+		<device_ref tag=":_tmp:i8085" name="i8085a"/>
+		<device_ref tag=":_tmp:harddisk1" name="harddisk_image"/>
+		<device_ref tag=":_tmp:rs232" name="rs232"/>
+		<chip type="cpu" tag=":i8085" name="Intel 8085A" clock="1000000"/>
+		<device type="harddisk" tag=":harddisk1">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+		<slot name=":rs232">
+			<slotoption name="terminal" devname="serial_terminal"/>
+			<slotoption name="sunkbd" devname="sunkbd_adaptor"/>
+			<slotoption name="votraxtnt" devname="serial_votraxtnt"/>
+			<slotoption name="s97801" devname="s97801_terminal"/>
+			<slotoption name="rs_printer" devname="rs_serial_printer"/>
+			<slotoption name="rs232_sync_io" devname="rs232_sync_io"/>
+			<slotoption name="auto3a" devname="auto3a_terminal"/>
+			<slotoption name="dec_loopback" devname="dec_rs232_loopback"/>
+			<slotoption name="h19" devname="serial_heath_h19"/>
+			<slotoption name="ie15" devname="ie15_terminal"/>
+			<slotoption name="null_modem" devname="null_modem"/>
+			<slotoption name="keyboard" devname="serial_keyboard"/>
+			<slotoption name="patch" devname="rs232_patch_box"/>
+			<slotoption name="swtpc8212" devname="swtpc8212_terminal"/>
+			<slotoption name="printer" devname="serial_printer"/>
+			<slotoption name="scorpion" devname="scorpion_ic"/>
+			<slotoption name="loopback" devname="rs232_loopback"/>
+			<slotoption name="mockingboard" devname="mockingboardd"/>
+			<slotoption name="msystems_mouse" devname="rs232_mouse_hle_msystems"/>
+			<slotoption name="nss_tvi" devname="nss_tvinterface"/>
+			<slotoption name="pty" devname="pseudo_terminal"/>
+		</slot>
+	</machine>
+	<machine name="gpib_softbox" sourcefile="devices/bus/ieee488/softbox.cpp" isdevice="yes" runnable="no">
+		<description>SSE SoftBox</description>
+		<biosset name="19810908" description="8/9/81"/>
+		<biosset name="19811027" description="27-Oct-81"/>
+		<biosset name="19830609" description="09-June-1983" default="yes"/>
+		<rom name="375.ic3" bios="19810908" size="2048" crc="177580e7" sha1="af6a97495de825b80cdc9fbf72329d5440826177" region="z80" offset="0"/>
+		<rom name="376.ic4" bios="19810908" size="2048" crc="edfee5be" sha1="5662e9071cc622a1c071d89b00272fc6ba122b9a" region="z80" offset="800"/>
+		<rom name="379.ic3" bios="19811027" size="2048" crc="7b5a737c" sha1="2348590884b026b7647f6864af8c9ba1c6f8746b" region="z80" offset="0"/>
+		<rom name="380.ic4" bios="19811027" size="2048" crc="65a13029" sha1="46de02e6f04be298047efeb412e00a5714dc21b3" region="z80" offset="800"/>
+		<rom name="389.ic3" bios="19830609" size="2048" crc="d66e581a" sha1="2403e25c140c41b0e6d6975d39c9cd9d6f335048" region="z80" offset="0"/>
+		<rom name="390.ic4" bios="19830609" size="2048" crc="abe6cb30" sha1="4b26d5db36f828e01268f718799f145d09b449ad" region="z80" offset="800"/>
+		<device_ref tag=":_tmp:z80" name="z80"/>
+		<device_ref tag=":_tmp:ic15" name="i8251"/>
+		<device_ref tag=":_tmp:rs232" name="rs232"/>
+		<device_ref tag=":_tmp:ic17" name="i8255"/>
+		<device_ref tag=":_tmp:ic16" name="i8255"/>
+		<device_ref tag=":_tmp:ic14" name="com8116"/>
+		<device_ref tag=":_tmp:corvus" name="corvus_hdc"/>
+		<device_ref tag=":_tmp:harddisk1" name="harddisk_image"/>
+		<device_ref tag=":_tmp:harddisk2" name="harddisk_image"/>
+		<device_ref tag=":_tmp:harddisk3" name="harddisk_image"/>
+		<device_ref tag=":_tmp:harddisk4" name="harddisk_image"/>
+		<chip type="cpu" tag=":z80" name="Zilog Z80" clock="4000000"/>
+		<dipswitch name="Unused" tag=":SW1" mask="1">
+			<diplocation name="SW1" number="1"/>
+			<dipvalue name="Off" value="1" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="Unused" tag=":SW1" mask="2">
+			<diplocation name="SW1" number="2"/>
+			<dipvalue name="Off" value="2" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="Unused" tag=":SW1" mask="4">
+			<diplocation name="SW1" number="3"/>
+			<dipvalue name="Off" value="4" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="Unused" tag=":SW1" mask="8">
+			<diplocation name="SW1" number="4"/>
+			<dipvalue name="Off" value="8" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="Unused" tag=":SW1" mask="16">
+			<diplocation name="SW1" number="5"/>
+			<dipvalue name="Off" value="16" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="Unused" tag=":SW1" mask="32">
+			<diplocation name="SW1" number="6"/>
+			<dipvalue name="Off" value="32" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="Unused" tag=":SW1" mask="64">
+			<diplocation name="SW1" number="7"/>
+			<dipvalue name="Off" value="64" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<dipswitch name="Unused" tag=":SW1" mask="128">
+			<diplocation name="SW1" number="8"/>
+			<dipvalue name="Off" value="128" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<device type="harddisk" tag=":harddisk1" interface="corvus_hdd">
+			<instance name="harddisk1" briefname="hard1"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+		<device type="harddisk" tag=":harddisk2" interface="corvus_hdd">
+			<instance name="harddisk2" briefname="hard2"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+		<device type="harddisk" tag=":harddisk3" interface="corvus_hdd">
+			<instance name="harddisk3" briefname="hard3"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+		<device type="harddisk" tag=":harddisk4" interface="corvus_hdd">
+			<instance name="harddisk4" briefname="hard4"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+		<slot name=":rs232">
+			<slotoption name="terminal" devname="serial_terminal"/>
+			<slotoption name="sunkbd" devname="sunkbd_adaptor"/>
+			<slotoption name="votraxtnt" devname="serial_votraxtnt"/>
+			<slotoption name="s97801" devname="s97801_terminal"/>
+			<slotoption name="rs_printer" devname="rs_serial_printer"/>
+			<slotoption name="rs232_sync_io" devname="rs232_sync_io"/>
+			<slotoption name="auto3a" devname="auto3a_terminal"/>
+			<slotoption name="dec_loopback" devname="dec_rs232_loopback"/>
+			<slotoption name="h19" devname="serial_heath_h19"/>
+			<slotoption name="ie15" devname="ie15_terminal"/>
+			<slotoption name="null_modem" devname="null_modem"/>
+			<slotoption name="keyboard" devname="serial_keyboard"/>
+			<slotoption name="patch" devname="rs232_patch_box"/>
+			<slotoption name="swtpc8212" devname="swtpc8212_terminal"/>
+			<slotoption name="printer" devname="serial_printer"/>
+			<slotoption name="scorpion" devname="scorpion_ic"/>
+			<slotoption name="loopback" devname="rs232_loopback"/>
+			<slotoption name="mockingboard" devname="mockingboardd"/>
+			<slotoption name="msystems_mouse" devname="rs232_mouse_hle_msystems"/>
+			<slotoption name="nss_tvi" devname="nss_tvinterface"/>
+			<slotoption name="pty" devname="pseudo_terminal"/>
+		</slot>
+	</machine>
+	<machine name="h83032" sourcefile="devices/cpu/h8/h83032.cpp" isdevice="yes" runnable="no">
+		<description>Hitachi H8/3032</description>
+		<device_ref tag=":_tmp:intc" name="h8h_intc"/>
+		<device_ref tag=":_tmp:adc" name="h8_adc_3337"/>
+		<device_ref tag=":_tmp:port1" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port2" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port3" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port5" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port6" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port7" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port8" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port9" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:porta" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:portb" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:portc" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:timer16" name="h8_timer16"/>
+		<device_ref tag=":_tmp:timer16:0" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:timer16:1" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:timer16:2" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:timer16:3" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:timer16:4" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:sci0" name="h8_sci"/>
+		<device_ref tag=":_tmp:watchdog" name="h8_watchdog"/>
+	</machine>
+	<machine name="h83040" sourcefile="devices/cpu/h8/h83042.cpp" isdevice="yes" runnable="no">
+		<description>Hitachi H8/3040</description>
+		<device_ref tag=":_tmp:intc" name="h8h_intc"/>
+		<device_ref tag=":_tmp:adc" name="h8_adc_3337"/>
+		<device_ref tag=":_tmp:dma" name="h8h_dma"/>
+		<device_ref tag=":_tmp:dma:0" name="h8h_dma_channel"/>
+		<device_ref tag=":_tmp:dma:1" name="h8h_dma_channel"/>
+		<device_ref tag=":_tmp:port1" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port2" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port3" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port4" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port5" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port6" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port7" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port8" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port9" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:porta" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:portb" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:timer16" name="h8_timer16"/>
+		<device_ref tag=":_tmp:timer16:0" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:timer16:1" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:timer16:2" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:timer16:3" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:timer16:4" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:sci0" name="h8_sci"/>
+		<device_ref tag=":_tmp:sci1" name="h8_sci"/>
+		<device_ref tag=":_tmp:watchdog" name="h8_watchdog"/>
+	</machine>
+	<machine name="h83048" sourcefile="devices/cpu/h8/h83048.cpp" isdevice="yes" runnable="no">
+		<description>Hitachi H8/3048</description>
+		<device_ref tag=":_tmp:intc" name="h8h_intc"/>
+		<device_ref tag=":_tmp:adc" name="h8_adc_3337"/>
+		<device_ref tag=":_tmp:dma" name="h8h_dma"/>
+		<device_ref tag=":_tmp:dma:0" name="h8h_dma_channel"/>
+		<device_ref tag=":_tmp:dma:1" name="h8h_dma_channel"/>
+		<device_ref tag=":_tmp:port1" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port2" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port3" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port4" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port5" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port6" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port7" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port8" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:port9" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:porta" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:portb" name="h8_digital_port"/>
+		<device_ref tag=":_tmp:timer16" name="h8_timer16"/>
+		<device_ref tag=":_tmp:timer16:0" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:timer16:1" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:timer16:2" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:timer16:3" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:timer16:4" name="h8h_timer16_channel"/>
+		<device_ref tag=":_tmp:sci0" name="h8_sci"/>
+		<device_ref tag=":_tmp:sci1" name="h8_sci"/>
+		<device_ref tag=":_tmp:watchdog" name="h8_watchdog"/>
+	</machine>
+	<machine name="h8_adc_3337" sourcefile="devices/cpu/h8/h8_adc.cpp" isdevice="yes" runnable="no">
+		<description>H8/3337 ADC</description>
+	</machine>
+	<machine name="h8_digital_port" sourcefile="devices/cpu/h8/h8_port.cpp" isdevice="yes" runnable="no">
+		<description>H8 digital port</description>
+	</machine>
+	<machine name="h8_sci" sourcefile="devices/cpu/h8/h8_sci.cpp" isdevice="yes" runnable="no">
+		<description>H8 Serial Communications Interface</description>
+	</machine>
+	<machine name="h8_timer16" sourcefile="devices/cpu/h8/h8_timer16.cpp" isdevice="yes" runnable="no">
+		<description>H8 16-bit timer</description>
+	</machine>
+	<machine name="h8_watchdog" sourcefile="devices/cpu/h8/h8_watchdog.cpp" isdevice="yes" runnable="no">
+		<description>H8 watchdog</description>
+	</machine>
+	<machine name="h8h_dma" sourcefile="devices/cpu/h8/h8_dma.cpp" isdevice="yes" runnable="no">
+		<description>H8H DMA controller</description>
+	</machine>
+	<machine name="h8h_dma_channel" sourcefile="devices/cpu/h8/h8_dma.cpp" isdevice="yes" runnable="no">
+		<description>H8H DMA channel</description>
+	</machine>
+	<machine name="h8h_intc" sourcefile="devices/cpu/h8/h8_intc.cpp" isdevice="yes" runnable="no">
+		<description>H8H interrupt controller</description>
+	</machine>
+	<machine name="h8h_timer16_channel" sourcefile="devices/cpu/h8/h8_timer16.cpp" isdevice="yes" runnable="no">
+		<description>H8H 16-bit timer channel</description>
+	</machine>
+	<machine name="heath_gp19_tlb" sourcefile="devices/bus/heathzenith/h19/tlb.cpp" isdevice="yes" runnable="no">
+		<description>Heath Terminal Logic Board plus Northwest Digital Systems GP-19</description>
+		<rom name="gp19_rom_1_ver_1_1.u26" size="4096" crc="7cbe8e0d" sha1="977df895b067fa4e4646b4518cffb08d4e6bb6e0" region="maincpu" offset="0"/>
+		<rom name="gp19_rom_2_ver_1_1.u25" size="4096" crc="a85e3bc4" sha1="f64e851c5d3ef98a9a48e0fc482baa576773ff43" region="maincpu" offset="1000"/>
+		<rom name="gp19_rom_3_ver_1_1.u24" size="4096" crc="878f577c" sha1="0756435914dcfb981de4e40d5f81af3e0f5bb1c5" region="maincpu" offset="2000"/>
+		<rom name="gp19_char_gen_cg_1.u21" size="4096" crc="49ec9242" sha1="770a8c7b5b15bcfe465fd84326d0ae3dcaa85311" region="chargen" offset="0"/>
+		<rom name="2716_444-37_h19keyb.u445" size="2048" crc="5c3e6972" sha1="df49ce64ae48652346a91648c58178a34fb37d3c" region="keyboard" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="z80"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:gfxdecode" name="gfxdecode"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<device_ref tag=":_tmp:crtc" name="mc6845"/>
+		<device_ref tag=":_tmp:ins8250" name="ins8250"/>
+		<device_ref tag=":_tmp:mm5740" name="mm5740"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<device_ref tag=":_tmp:repeatclock" name="clock"/>
+		<chip type="cpu" tag=":maincpu" name="Zilog Z80" clock="2048000"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="1000"/>
+		<display tag=":screen" type="raster" rotate="0" width="640" height="240" refresh="60.000781" pixclock="12292000" htotal="776" hbend="32" hbstart="672" vtotal="264" vbend="10" vbstart="250" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="86"/>
+		</input>
+		<dipswitch name="Trailing Characters for Tektronix Message" tag=":SW1" mask="3">
+			<diplocation name="SW1" number="1"/>
+			<diplocation name="SW1" number="2"/>
+			<dipvalue name="None" value="0"/>
+			<dipvalue name="CR" value="1" default="yes"/>
+			<dipvalue name="None" value="2"/>
+			<dipvalue name="CR,EOT" value="3"/>
+		</dipswitch>
+		<dipswitch name="Shift Key" tag=":SW1" mask="4">
+			<diplocation name="SW1" number="3"/>
+			<dipvalue name="Normal" value="0" default="yes"/>
+			<dipvalue name="Shift key inverts CAPS LOCK" value="4"/>
+		</dipswitch>
+		<dipswitch name="Terminal Transmission Rate" tag=":SW1" mask="8">
+			<diplocation name="SW1" number="4"/>
+			<dipvalue name="Only limited by baud rate" value="0" default="yes"/>
+			<dipvalue name="One character per 16.7 msec" value="8"/>
+		</dipswitch>
+		<dipswitch name="Character Set" tag=":SW1" mask="16">
+			<diplocation name="SW1" number="5"/>
+			<dipvalue name="VT100" value="0"/>
+			<dipvalue name="Zenith" value="16" default="yes"/>
+		</dipswitch>
+		<dipswitch name="ANSI Mode" tag=":SW1" mask="32">
+			<diplocation name="SW1" number="6"/>
+			<dipvalue name="Zenith ANSI" value="0" default="yes"/>
+			<dipvalue name="EDT compatible" value="32"/>
+		</dipswitch>
+		<dipswitch name="Tektronix Character Wrap" tag=":SW1" mask="64">
+			<diplocation name="SW1" number="7"/>
+			<dipvalue name="Column 74" value="0" default="yes"/>
+			<dipvalue name="Column 73" value="64"/>
+		</dipswitch>
+		<dipswitch name="Blank Screen" tag=":SW1" mask="128">
+			<diplocation name="SW1" number="8"/>
+			<dipvalue name="After 10 mins" value="0" default="yes"/>
+			<dipvalue name="Never" value="128"/>
+		</dipswitch>
+		<dipswitch name="Baud Rate" tag=":SW401" mask="15">
+			<diplocation name="SW401" number="1"/>
+			<diplocation name="SW401" number="2"/>
+			<diplocation name="SW401" number="3"/>
+			<diplocation name="SW401" number="4"/>
+			<dipvalue name="110" value="1"/>
+			<dipvalue name="150" value="2"/>
+			<dipvalue name="300" value="3"/>
+			<dipvalue name="600" value="4"/>
+			<dipvalue name="1200" value="5"/>
+			<dipvalue name="1800" value="6"/>
+			<dipvalue name="2000" value="7"/>
+			<dipvalue name="2400" value="8"/>
+			<dipvalue name="3600" value="9"/>
+			<dipvalue name="4800" value="10"/>
+			<dipvalue name="7200" value="11"/>
+			<dipvalue name="9600" value="12" default="yes"/>
+			<dipvalue name="19200" value="13"/>
+		</dipswitch>
+		<dipswitch name="Parity" tag=":SW401" mask="48">
+			<diplocation name="SW401" number="5"/>
+			<diplocation name="SW401" number="6"/>
+			<dipvalue name="None" value="0" default="yes"/>
+			<dipvalue name="Odd" value="16"/>
+			<dipvalue name="None" value="32"/>
+			<dipvalue name="Even" value="48"/>
+		</dipswitch>
+		<dipswitch name="Parity Type" tag=":SW401" mask="64">
+			<diplocation name="SW401" number="7"/>
+			<dipvalue name="Normal" value="0" default="yes"/>
+			<dipvalue name="Stick" value="64"/>
+		</dipswitch>
+		<dipswitch name="Duplex" tag=":SW401" mask="128">
+			<diplocation name="SW401" number="8"/>
+			<dipvalue name="Half" value="0"/>
+			<dipvalue name="Full" value="128" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Cursor" tag=":SW402" mask="1">
+			<diplocation name="SW402" number="1"/>
+			<dipvalue name="Underline" value="0" default="yes"/>
+			<dipvalue name="Block" value="1"/>
+		</dipswitch>
+		<dipswitch name="Keyclick" tag=":SW402" mask="2">
+			<diplocation name="SW402" number="2"/>
+			<dipvalue name="No" value="2"/>
+			<dipvalue name="Yes" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Wrap at EOL" tag=":SW402" mask="4">
+			<diplocation name="SW402" number="3"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="4"/>
+		</dipswitch>
+		<dipswitch name="Auto LF on CR" tag=":SW402" mask="8">
+			<diplocation name="SW402" number="4"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="8"/>
+		</dipswitch>
+		<dipswitch name="Auto CR on LF" tag=":SW402" mask="16">
+			<diplocation name="SW402" number="5"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="16"/>
+		</dipswitch>
+		<dipswitch name="Mode" tag=":SW402" mask="32">
+			<diplocation name="SW402" number="6"/>
+			<dipvalue name="Heath/VT52" value="0" default="yes"/>
+			<dipvalue name="ANSI" value="32"/>
+		</dipswitch>
+		<dipswitch name="Keypad Shifted" tag=":SW402" mask="64">
+			<diplocation name="SW402" number="7"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="64"/>
+		</dipswitch>
+		<dipswitch name="Automatic Holdscreen" tag=":SW402" mask="128">
+			<diplocation name="SW402" number="8"/>
+			<dipvalue name="Disabled (VT100 mode)" value="0" default="yes"/>
+			<dipvalue name="Enabled (Z19 mode)" value="128"/>
+		</dipswitch>
+		<configuration name="CPU Clock" tag=":CONFIG" mask="3">
+			<confsetting name="2 MHz" value="0" default="yes"/>
+			<confsetting name="3 MHz" value="1"/>
+			<confsetting name="4 MHz" value="2"/>
+			<confsetting name="6 MHz" value="3"/>
+		</configuration>
+		<configuration name="CRT Color" tag=":CONFIG" mask="12">
+			<confsetting name="Green" value="0" default="yes"/>
+			<confsetting name="White" value="4"/>
+			<confsetting name="Amber" value="8"/>
+		</configuration>
+		<feature type="graphics" status="imperfect"/>
+	</machine>
+	<machine name="heath_imaginator_tlb" sourcefile="devices/bus/heathzenith/h19/tlb.cpp" isdevice="yes" runnable="no">
+		<description>Heath Terminal Logic Board plus Cleveland Codonics Imaginator I-100</description>
+		<biosset name="rev12" description="GPC Rev. 1.2 P/N 9000-0002" default="yes"/>
+		<biosset name="unknown" description="GPC Unknown revision"/>
+		<rom name="2732_imaginator_gpc_rev_1.2_pn_9000_0002.u9a" bios="rev12" size="4096" crc="507bb13f" sha1="5b210f8d77e22fdf063f611eb5c29636cdb01250" region="maincpu" offset="2000"/>
+		<rom name="2764_imaginator_gpc_unknown.u9a" bios="unknown" size="8192" crc="8eff78ae" sha1="d571cc5ec2e062fafca34fcc80f015ff82e84283" region="maincpu" offset="2000"/>
+		<rom name="2732_444-46_h19code.u437" size="4096" crc="f4447da0" sha1="fb4093d5b763be21a9580a0defebed664b1f7a7b" region="maincpu" offset="0"/>
+		<rom name="2716_444-29_h19font.u420" size="2048" crc="d595ac1d" sha1="130fb4ea8754106340c318592eec2d8a0deaf3d0" region="chargen" offset="0"/>
+		<rom name="2716_444-37_h19keyb.u445" size="2048" crc="5c3e6972" sha1="df49ce64ae48652346a91648c58178a34fb37d3c" region="keyboard" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="z80"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:gfxdecode" name="gfxdecode"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<device_ref tag=":_tmp:crtc" name="mc6845"/>
+		<device_ref tag=":_tmp:ins8250" name="ins8250"/>
+		<device_ref tag=":_tmp:mm5740" name="mm5740"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<device_ref tag=":_tmp:repeatclock" name="clock"/>
+		<chip type="cpu" tag=":maincpu" name="Zilog Z80" clock="2048000"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="1000"/>
+		<display tag=":screen" type="raster" rotate="0" width="640" height="250" refresh="59.259259" pixclock="12288000" htotal="768" hbend="32" hbstart="672" vtotal="270" vbend="0" vbstart="250" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="86"/>
+		</input>
+		<dipswitch name="Baud Rate" tag=":SW401" mask="15">
+			<diplocation name="SW401" number="1"/>
+			<diplocation name="SW401" number="2"/>
+			<diplocation name="SW401" number="3"/>
+			<diplocation name="SW401" number="4"/>
+			<dipvalue name="110" value="1"/>
+			<dipvalue name="150" value="2"/>
+			<dipvalue name="300" value="3"/>
+			<dipvalue name="600" value="4"/>
+			<dipvalue name="1200" value="5"/>
+			<dipvalue name="1800" value="6"/>
+			<dipvalue name="2000" value="7"/>
+			<dipvalue name="2400" value="8"/>
+			<dipvalue name="3600" value="9"/>
+			<dipvalue name="4800" value="10"/>
+			<dipvalue name="7200" value="11"/>
+			<dipvalue name="9600" value="12" default="yes"/>
+			<dipvalue name="19200" value="13"/>
+		</dipswitch>
+		<dipswitch name="Parity" tag=":SW401" mask="48">
+			<diplocation name="SW401" number="5"/>
+			<diplocation name="SW401" number="6"/>
+			<dipvalue name="None" value="0" default="yes"/>
+			<dipvalue name="Odd" value="16"/>
+			<dipvalue name="None" value="32"/>
+			<dipvalue name="Even" value="48"/>
+		</dipswitch>
+		<dipswitch name="Parity Type" tag=":SW401" mask="64">
+			<diplocation name="SW401" number="7"/>
+			<dipvalue name="Normal" value="0" default="yes"/>
+			<dipvalue name="Stick" value="64"/>
+		</dipswitch>
+		<dipswitch name="Duplex" tag=":SW401" mask="128">
+			<diplocation name="SW401" number="8"/>
+			<dipvalue name="Half" value="0"/>
+			<dipvalue name="Full" value="128" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Cursor" tag=":SW402" mask="1">
+			<diplocation name="SW402" number="1"/>
+			<dipvalue name="Underline" value="0" default="yes"/>
+			<dipvalue name="Block" value="1"/>
+		</dipswitch>
+		<dipswitch name="Keyclick" tag=":SW402" mask="2">
+			<diplocation name="SW402" number="2"/>
+			<dipvalue name="No" value="2"/>
+			<dipvalue name="Yes" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Wrap at EOL" tag=":SW402" mask="4">
+			<diplocation name="SW402" number="3"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="4"/>
+		</dipswitch>
+		<dipswitch name="Auto LF on CR" tag=":SW402" mask="8">
+			<diplocation name="SW402" number="4"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="8"/>
+		</dipswitch>
+		<dipswitch name="Auto CR on LF" tag=":SW402" mask="16">
+			<diplocation name="SW402" number="5"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="16"/>
+		</dipswitch>
+		<dipswitch name="Mode" tag=":SW402" mask="32">
+			<diplocation name="SW402" number="6"/>
+			<dipvalue name="Heath/VT52" value="0" default="yes"/>
+			<dipvalue name="ANSI" value="32"/>
+		</dipswitch>
+		<dipswitch name="Keypad Shifted" tag=":SW402" mask="64">
+			<diplocation name="SW402" number="7"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="64"/>
+		</dipswitch>
+		<dipswitch name="Refresh" tag=":SW402" mask="128">
+			<diplocation name="SW402" number="8"/>
+			<dipvalue name="60Hz" value="0" default="yes"/>
+			<dipvalue name="50Hz" value="128"/>
+		</dipswitch>
+		<configuration name="CPU Clock" tag=":CONFIG" mask="3">
+			<confsetting name="2 MHz" value="0" default="yes"/>
+			<confsetting name="3 MHz" value="1"/>
+			<confsetting name="4 MHz" value="2"/>
+			<confsetting name="6 MHz" value="3"/>
+		</configuration>
+		<configuration name="CRT Color" tag=":CONFIG" mask="12">
+			<confsetting name="Green" value="0" default="yes"/>
+			<confsetting name="White" value="4"/>
+			<confsetting name="Amber" value="8"/>
+		</configuration>
+	</machine>
+	<machine name="heath_super19_tlb" sourcefile="devices/bus/heathzenith/h19/tlb.cpp" isdevice="yes" runnable="no">
+		<description>Heath Terminal Logic Board w/Super19 ROM</description>
+		<rom name="2732_super19_h447.u437" size="4096" crc="6c51aaa6" sha1="5e368b39fe2f1af44a905dc474663198ab630117" region="maincpu" offset="0"/>
+		<rom name="2716_444-29_h19font.u420" size="2048" crc="d595ac1d" sha1="130fb4ea8754106340c318592eec2d8a0deaf3d0" region="chargen" offset="0"/>
+		<rom name="2716_444-37_h19keyb.u445" size="2048" crc="5c3e6972" sha1="df49ce64ae48652346a91648c58178a34fb37d3c" region="keyboard" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="z80"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:gfxdecode" name="gfxdecode"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<device_ref tag=":_tmp:crtc" name="mc6845"/>
+		<device_ref tag=":_tmp:ins8250" name="ins8250"/>
+		<device_ref tag=":_tmp:mm5740" name="mm5740"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<device_ref tag=":_tmp:repeatclock" name="clock"/>
+		<chip type="cpu" tag=":maincpu" name="Zilog Z80" clock="2048000"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="1000"/>
+		<display tag=":screen" type="raster" rotate="0" width="640" height="250" refresh="59.259259" pixclock="12288000" htotal="768" hbend="32" hbstart="672" vtotal="270" vbend="0" vbstart="250" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="86"/>
+		</input>
+		<dipswitch name="Baud Rate" tag=":SW401" mask="15">
+			<diplocation name="SW401" number="1"/>
+			<diplocation name="SW401" number="2"/>
+			<diplocation name="SW401" number="3"/>
+			<diplocation name="SW401" number="4"/>
+			<dipvalue name="110" value="1"/>
+			<dipvalue name="150" value="2"/>
+			<dipvalue name="300" value="3"/>
+			<dipvalue name="600" value="4"/>
+			<dipvalue name="1200" value="5"/>
+			<dipvalue name="1800" value="6"/>
+			<dipvalue name="2000" value="7"/>
+			<dipvalue name="2400" value="8"/>
+			<dipvalue name="3600" value="9"/>
+			<dipvalue name="4800" value="10"/>
+			<dipvalue name="7200" value="11"/>
+			<dipvalue name="9600" value="12" default="yes"/>
+			<dipvalue name="19200" value="13"/>
+			<dipvalue name="38400" value="14"/>
+		</dipswitch>
+		<dipswitch name="8 bit mode" tag=":SW401" mask="112">
+			<diplocation name="SW401" number="5"/>
+			<diplocation name="SW401" number="6"/>
+			<diplocation name="SW401" number="7"/>
+			<dipvalue name="Mode A/0 - 8th bit ignored, sent as 0" value="0" default="yes"/>
+			<dipvalue name="Mode B/1 - 8th bit ignored, sent as 1" value="16"/>
+			<dipvalue name="Mode C/2 - 8 bit escape mode" value="32"/>
+			<dipvalue name="Mode D/3 - 8 bit escape mode, invert 8th bit" value="48"/>
+			<dipvalue name="Mode E/4 - 8 bit data mode" value="64"/>
+			<dipvalue name="Mode F/5 - 8 bit data mode, invert 8th bit" value="80"/>
+			<dipvalue name="7 bit data with odd parity, 8th bit ignored on input" value="96"/>
+			<dipvalue name="7 bit data with even parity, 8th bit ignored on input" value="112"/>
+		</dipswitch>
+		<dipswitch name="Duplex" tag=":SW401" mask="128">
+			<diplocation name="SW401" number="8"/>
+			<dipvalue name="Half" value="0"/>
+			<dipvalue name="Full" value="128" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Cursor" tag=":SW402" mask="1">
+			<diplocation name="SW402" number="1"/>
+			<dipvalue name="Underline" value="0" default="yes"/>
+			<dipvalue name="Block" value="1"/>
+		</dipswitch>
+		<dipswitch name="Transmit mode" tag=":SW402" mask="2">
+			<diplocation name="SW402" number="2"/>
+			<dipvalue name="Normal" value="0" default="yes"/>
+			<dipvalue name="Slow" value="2"/>
+		</dipswitch>
+		<dipswitch name="Wrap at EOL" tag=":SW402" mask="4">
+			<diplocation name="SW402" number="3"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="4"/>
+		</dipswitch>
+		<dipswitch name="Auto LF on CR" tag=":SW402" mask="8">
+			<diplocation name="SW402" number="4"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="8"/>
+		</dipswitch>
+		<dipswitch name="Auto CR on LF" tag=":SW402" mask="16">
+			<diplocation name="SW402" number="5"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="16"/>
+		</dipswitch>
+		<dipswitch name="Mode" tag=":SW402" mask="32">
+			<diplocation name="SW402" number="6"/>
+			<dipvalue name="Heath/VT52" value="0" default="yes"/>
+			<dipvalue name="ANSI" value="32"/>
+		</dipswitch>
+		<dipswitch name="Keypad Shifted" tag=":SW402" mask="64">
+			<diplocation name="SW402" number="7"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="64"/>
+		</dipswitch>
+		<dipswitch name="DEC Keypad Codes" tag=":SW402" mask="128">
+			<diplocation name="SW402" number="8"/>
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="128"/>
+		</dipswitch>
+		<configuration name="CPU Clock" tag=":CONFIG" mask="3">
+			<confsetting name="2 MHz" value="0" default="yes"/>
+			<confsetting name="3 MHz" value="1"/>
+			<confsetting name="4 MHz" value="2"/>
+			<confsetting name="6 MHz" value="3"/>
+		</configuration>
+		<configuration name="CRT Color" tag=":CONFIG" mask="12">
+			<confsetting name="Green" value="0" default="yes"/>
+			<confsetting name="White" value="4"/>
+			<confsetting name="Amber" value="8"/>
+		</configuration>
+	</machine>
+	<machine name="heath_superset_tlb" sourcefile="devices/bus/heathzenith/h19/tlb.cpp" isdevice="yes" runnable="no">
+		<description>Heath Terminal Logic Board w/Superset ROM</description>
+		<rom name="27256_101-402_superset_code.u437" size="32768" crc="a6896076" sha1="a4e2d25028dc75a665c3f5a830a4e8cdecbd481c" region="maincpu" offset="0"/>
+		<rom name="27256_101-431_superset_font.u420" size="32768" crc="4c0688f6" sha1="be6059913420ad66f5c839d619fdcb164ffae85a" region="chargen" offset="0"/>
+		<rom name="2716_101-422_superset_kbd.u445" size="2048" crc="549d15b3" sha1="981962e5e05bbdc5a66b0e86870853ce5596e877" region="keyboard" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="z80"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:gfxdecode" name="gfxdecode"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<device_ref tag=":_tmp:crtc" name="mc6845"/>
+		<device_ref tag=":_tmp:ins8250" name="ins8250"/>
+		<device_ref tag=":_tmp:mm5740" name="mm5740"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<device_ref tag=":_tmp:repeatclock" name="clock"/>
+		<chip type="cpu" tag=":maincpu" name="Zilog Z80" clock="3072000"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="1000"/>
+		<display tag=":screen" type="raster" rotate="0" width="640" height="250" refresh="59.259259" pixclock="12288000" htotal="768" hbend="32" hbstart="672" vtotal="270" vbend="0" vbstart="250" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="86"/>
+		</input>
+		<dipswitch name="Baud Rate" tag=":SW401" mask="15">
+			<diplocation name="SW401" number="1"/>
+			<diplocation name="SW401" number="2"/>
+			<diplocation name="SW401" number="3"/>
+			<diplocation name="SW401" number="4"/>
+			<dipvalue name="75" value="0"/>
+			<dipvalue name="110" value="1"/>
+			<dipvalue name="150" value="2"/>
+			<dipvalue name="300" value="3"/>
+			<dipvalue name="600" value="4"/>
+			<dipvalue name="1200" value="5"/>
+			<dipvalue name="1800" value="6"/>
+			<dipvalue name="2000" value="7"/>
+			<dipvalue name="2400" value="8"/>
+			<dipvalue name="3600" value="9"/>
+			<dipvalue name="4800" value="10"/>
+			<dipvalue name="7200" value="11"/>
+			<dipvalue name="9600" value="12" default="yes"/>
+			<dipvalue name="19200" value="13"/>
+			<dipvalue name="38400" value="14"/>
+			<dipvalue name="134.5" value="15"/>
+		</dipswitch>
+		<dipswitch name="Duplex" tag=":SW401" mask="16">
+			<diplocation name="SW401" number="5"/>
+			<dipvalue name="Half" value="0"/>
+			<dipvalue name="Full" value="0"/>
+		</dipswitch>
+		<dipswitch name="Word Length" tag=":SW401" mask="32">
+			<diplocation name="SW401" number="6"/>
+			<dipvalue name="8-bit" value="0" default="yes"/>
+			<dipvalue name="7-bit" value="32"/>
+		</dipswitch>
+		<dipswitch name="Parity Type" tag=":SW401" mask="64">
+			<diplocation name="SW401" number="7"/>
+			<dipvalue name="None" value="0" default="yes"/>
+			<dipvalue name="Even" value="64"/>
+		</dipswitch>
+		<dipswitch name="Parity" tag=":SW401" mask="128">
+			<diplocation name="SW401" number="8"/>
+			<dipvalue name="Disabled" value="0"/>
+			<dipvalue name="Enabled" value="128" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Cursor" tag=":SW402" mask="1">
+			<diplocation name="SW402" number="1"/>
+			<dipvalue name="Underline" value="0" default="yes"/>
+			<dipvalue name="Block" value="1"/>
+		</dipswitch>
+		<dipswitch name="Keyclick" tag=":SW402" mask="2">
+			<diplocation name="SW402" number="2"/>
+			<dipvalue name="No" value="2"/>
+			<dipvalue name="Yes" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Wrap at EOL" tag=":SW402" mask="4">
+			<diplocation name="SW402" number="3"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="4"/>
+		</dipswitch>
+		<dipswitch name="Auto LF on CR" tag=":SW402" mask="8">
+			<diplocation name="SW402" number="4"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="8"/>
+		</dipswitch>
+		<dipswitch name="Auto CR on LF" tag=":SW402" mask="16">
+			<diplocation name="SW402" number="5"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="16"/>
+		</dipswitch>
+		<dipswitch name="Mode" tag=":SW402" mask="32">
+			<diplocation name="SW402" number="6"/>
+			<dipvalue name="Heath/VT52" value="0" default="yes"/>
+			<dipvalue name="ANSI" value="32"/>
+		</dipswitch>
+		<dipswitch name="Keypad Shifted" tag=":SW402" mask="64">
+			<diplocation name="SW402" number="7"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="64"/>
+		</dipswitch>
+		<dipswitch name="Refresh" tag=":SW402" mask="128">
+			<diplocation name="SW402" number="8"/>
+			<dipvalue name="60Hz" value="0" default="yes"/>
+			<dipvalue name="50Hz" value="128"/>
+		</dipswitch>
+		<configuration name="CPU Clock" tag=":CONFIG" mask="3">
+			<confsetting name="2 MHz" value="0" default="yes"/>
+			<confsetting name="3 MHz" value="1"/>
+			<confsetting name="4 MHz" value="2"/>
+			<confsetting name="6 MHz" value="3"/>
+		</configuration>
+		<configuration name="CRT Color" tag=":CONFIG" mask="12">
+			<confsetting name="Green" value="0" default="yes"/>
+			<confsetting name="White" value="4"/>
+			<confsetting name="Amber" value="8"/>
+		</configuration>
+	</machine>
+	<machine name="heath_tlb" sourcefile="devices/bus/heathzenith/h19/tlb.cpp" isdevice="yes" runnable="no">
+		<description>Heath Terminal Logic Board</description>
+		<rom name="2732_444-46_h19code.u437" size="4096" crc="f4447da0" sha1="fb4093d5b763be21a9580a0defebed664b1f7a7b" region="maincpu" offset="0"/>
+		<rom name="2716_444-29_h19font.u420" size="2048" crc="d595ac1d" sha1="130fb4ea8754106340c318592eec2d8a0deaf3d0" region="chargen" offset="0"/>
+		<rom name="2716_444-37_h19keyb.u445" size="2048" crc="5c3e6972" sha1="df49ce64ae48652346a91648c58178a34fb37d3c" region="keyboard" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="z80"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:gfxdecode" name="gfxdecode"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<device_ref tag=":_tmp:crtc" name="mc6845"/>
+		<device_ref tag=":_tmp:ins8250" name="ins8250"/>
+		<device_ref tag=":_tmp:mm5740" name="mm5740"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<device_ref tag=":_tmp:repeatclock" name="clock"/>
+		<chip type="cpu" tag=":maincpu" name="Zilog Z80" clock="2048000"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="1000"/>
+		<display tag=":screen" type="raster" rotate="0" width="640" height="250" refresh="59.259259" pixclock="12288000" htotal="768" hbend="32" hbstart="672" vtotal="270" vbend="0" vbstart="250" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="86"/>
+		</input>
+		<dipswitch name="Baud Rate" tag=":SW401" mask="15">
+			<diplocation name="SW401" number="1"/>
+			<diplocation name="SW401" number="2"/>
+			<diplocation name="SW401" number="3"/>
+			<diplocation name="SW401" number="4"/>
+			<dipvalue name="110" value="1"/>
+			<dipvalue name="150" value="2"/>
+			<dipvalue name="300" value="3"/>
+			<dipvalue name="600" value="4"/>
+			<dipvalue name="1200" value="5"/>
+			<dipvalue name="1800" value="6"/>
+			<dipvalue name="2000" value="7"/>
+			<dipvalue name="2400" value="8"/>
+			<dipvalue name="3600" value="9"/>
+			<dipvalue name="4800" value="10"/>
+			<dipvalue name="7200" value="11"/>
+			<dipvalue name="9600" value="12" default="yes"/>
+			<dipvalue name="19200" value="13"/>
+		</dipswitch>
+		<dipswitch name="Parity" tag=":SW401" mask="48">
+			<diplocation name="SW401" number="5"/>
+			<diplocation name="SW401" number="6"/>
+			<dipvalue name="None" value="0" default="yes"/>
+			<dipvalue name="Odd" value="16"/>
+			<dipvalue name="None" value="32"/>
+			<dipvalue name="Even" value="48"/>
+		</dipswitch>
+		<dipswitch name="Parity Type" tag=":SW401" mask="64">
+			<diplocation name="SW401" number="7"/>
+			<dipvalue name="Normal" value="0" default="yes"/>
+			<dipvalue name="Stick" value="64"/>
+		</dipswitch>
+		<dipswitch name="Duplex" tag=":SW401" mask="128">
+			<diplocation name="SW401" number="8"/>
+			<dipvalue name="Half" value="0"/>
+			<dipvalue name="Full" value="128" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Cursor" tag=":SW402" mask="1">
+			<diplocation name="SW402" number="1"/>
+			<dipvalue name="Underline" value="0" default="yes"/>
+			<dipvalue name="Block" value="1"/>
+		</dipswitch>
+		<dipswitch name="Keyclick" tag=":SW402" mask="2">
+			<diplocation name="SW402" number="2"/>
+			<dipvalue name="No" value="2"/>
+			<dipvalue name="Yes" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Wrap at EOL" tag=":SW402" mask="4">
+			<diplocation name="SW402" number="3"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="4"/>
+		</dipswitch>
+		<dipswitch name="Auto LF on CR" tag=":SW402" mask="8">
+			<diplocation name="SW402" number="4"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="8"/>
+		</dipswitch>
+		<dipswitch name="Auto CR on LF" tag=":SW402" mask="16">
+			<diplocation name="SW402" number="5"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="16"/>
+		</dipswitch>
+		<dipswitch name="Mode" tag=":SW402" mask="32">
+			<diplocation name="SW402" number="6"/>
+			<dipvalue name="Heath/VT52" value="0" default="yes"/>
+			<dipvalue name="ANSI" value="32"/>
+		</dipswitch>
+		<dipswitch name="Keypad Shifted" tag=":SW402" mask="64">
+			<diplocation name="SW402" number="7"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="64"/>
+		</dipswitch>
+		<dipswitch name="Refresh" tag=":SW402" mask="128">
+			<diplocation name="SW402" number="8"/>
+			<dipvalue name="60Hz" value="0" default="yes"/>
+			<dipvalue name="50Hz" value="128"/>
+		</dipswitch>
+		<configuration name="CPU Clock" tag=":CONFIG" mask="3">
+			<confsetting name="2 MHz" value="0" default="yes"/>
+			<confsetting name="3 MHz" value="1"/>
+			<confsetting name="4 MHz" value="2"/>
+			<confsetting name="6 MHz" value="3"/>
+		</configuration>
+		<configuration name="CRT Color" tag=":CONFIG" mask="12">
+			<confsetting name="Green" value="0" default="yes"/>
+			<confsetting name="White" value="4"/>
+			<confsetting name="Amber" value="8"/>
+		</configuration>
+	</machine>
+	<machine name="heath_ultra_tlb" sourcefile="devices/bus/heathzenith/h19/tlb.cpp" isdevice="yes" runnable="no">
+		<description>Heath Terminal Logic Board w/Ultra ROM</description>
+		<rom name="2532_h19_ultra_firmware.u437" size="4096" crc="8ad4cdb4" sha1="d6e1fc37a1f52abfce5e9adb1819e0030bed1df3" region="maincpu" offset="0"/>
+		<rom name="2716_444-29_h19font.u420" size="2048" crc="d595ac1d" sha1="130fb4ea8754106340c318592eec2d8a0deaf3d0" region="chargen" offset="0"/>
+		<rom name="2716_h19_ultra_keyboard.u445" size="2048" crc="76130c92" sha1="ca39c602af48505139d2750a084b5f8f0e662ff7" region="keyboard" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="z80"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:gfxdecode" name="gfxdecode"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<device_ref tag=":_tmp:crtc" name="mc6845"/>
+		<device_ref tag=":_tmp:ins8250" name="ins8250"/>
+		<device_ref tag=":_tmp:mm5740" name="mm5740"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<device_ref tag=":_tmp:repeatclock" name="clock"/>
+		<chip type="cpu" tag=":maincpu" name="Zilog Z80" clock="2048000"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="1000"/>
+		<display tag=":screen" type="raster" rotate="0" width="640" height="250" refresh="59.259259" pixclock="12288000" htotal="768" hbend="32" hbstart="672" vtotal="270" vbend="0" vbstart="250" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="86"/>
+		</input>
+		<dipswitch name="Baud Rate" tag=":SW401" mask="7">
+			<diplocation name="SW401" number="1"/>
+			<diplocation name="SW401" number="2"/>
+			<diplocation name="SW401" number="3"/>
+			<dipvalue name="110" value="0"/>
+			<dipvalue name="300" value="1"/>
+			<dipvalue name="1200" value="2"/>
+			<dipvalue name="2400" value="3"/>
+			<dipvalue name="4800" value="4"/>
+			<dipvalue name="9600" value="5" default="yes"/>
+			<dipvalue name="19200" value="6"/>
+			<dipvalue name="38400" value="7"/>
+		</dipswitch>
+		<dipswitch name="Parity" tag=":SW401" mask="8">
+			<diplocation name="SW401" number="4"/>
+			<dipvalue name="Disabled" value="0" default="yes"/>
+			<dipvalue name="Enabled" value="8"/>
+		</dipswitch>
+		<dipswitch name="Parity Type" tag=":SW401" mask="16">
+			<diplocation name="SW401" number="5"/>
+			<dipvalue name="Odd" value="0" default="yes"/>
+			<dipvalue name="Even" value="16"/>
+		</dipswitch>
+		<dipswitch name="Data Size" tag=":SW401" mask="32">
+			<diplocation name="SW401" number="6"/>
+			<dipvalue name="8-bit" value="0" default="yes"/>
+			<dipvalue name="7-bit" value="32"/>
+		</dipswitch>
+		<dipswitch name="Duplex" tag=":SW401" mask="64">
+			<diplocation name="SW401" number="7"/>
+			<dipvalue name="Half" value="0"/>
+			<dipvalue name="Full" value="64" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Software Handshaking" tag=":SW401" mask="128">
+			<diplocation name="SW401" number="8"/>
+			<dipvalue name="Enabled" value="0"/>
+			<dipvalue name="Disabled" value="128" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Cursor" tag=":SW402" mask="1">
+			<diplocation name="SW402" number="1"/>
+			<dipvalue name="Underline" value="0" default="yes"/>
+			<dipvalue name="Block" value="1"/>
+		</dipswitch>
+		<dipswitch name="Keyclick" tag=":SW402" mask="2">
+			<diplocation name="SW402" number="2"/>
+			<dipvalue name="No" value="2"/>
+			<dipvalue name="Yes" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Wrap at EOL" tag=":SW402" mask="4">
+			<diplocation name="SW402" number="3"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="4"/>
+		</dipswitch>
+		<dipswitch name="Keypad Shifted" tag=":SW402" mask="8">
+			<diplocation name="SW402" number="4"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="8"/>
+		</dipswitch>
+		<dipswitch name="Default Key Values" tag=":SW402" mask="16">
+			<diplocation name="SW402" number="5"/>
+			<dipvalue name="HDOS Values" value="0" default="yes"/>
+			<dipvalue name="CP/M Values" value="16"/>
+		</dipswitch>
+		<dipswitch name="Cursor Blink" tag=":SW402" mask="96">
+			<diplocation name="SW402" number="6"/>
+			<diplocation name="SW402" number="7"/>
+			<dipvalue name="Steady" value="0"/>
+			<dipvalue name="Invisible" value="32"/>
+			<dipvalue name="Fast Blink" value="64"/>
+			<dipvalue name="Slow Blink" value="96" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Interlace Scan Mode" tag=":SW402" mask="128">
+			<diplocation name="SW402" number="8"/>
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="128"/>
+		</dipswitch>
+		<configuration name="CPU Clock" tag=":CONFIG" mask="3">
+			<confsetting name="2 MHz" value="0" default="yes"/>
+			<confsetting name="3 MHz" value="1"/>
+			<confsetting name="4 MHz" value="2"/>
+			<confsetting name="6 MHz" value="3"/>
+		</configuration>
+		<configuration name="CRT Color" tag=":CONFIG" mask="12">
+			<confsetting name="Green" value="0" default="yes"/>
+			<confsetting name="White" value="4"/>
+			<confsetting name="Amber" value="8"/>
+		</configuration>
+		<configuration name="Page 2 RAM present" tag=":CONFIG" mask="16">
+			<confsetting name="No" value="0"/>
+			<confsetting name="Yes" value="16" default="yes"/>
+		</configuration>
+	</machine>
+	<machine name="heath_watz_tlb" sourcefile="devices/bus/heathzenith/h19/tlb.cpp" isdevice="yes" runnable="no">
+		<description>Heath Terminal Logic Board w/Watzman ROM</description>
+		<biosset name="watzman" description="Watzman"/>
+		<biosset name="watzman-a" description="Watzman w/clock persists after reset" default="yes"/>
+		<rom name="watzman.u437" bios="watzman" size="4096" crc="8168b6dc" sha1="bfaebb9d766edbe545d24bc2b6630be4f3aa0ce9" region="maincpu" offset="0"/>
+		<rom name="watzman-a.u437" bios="watzman-a" size="4096" crc="1f7553e9" sha1="ac6ddb12b4fb46c1a0ad08ee43978ad3153b51aa" region="maincpu" offset="0"/>
+		<rom name="2716_444-29_h19font.u420" size="2048" crc="d595ac1d" sha1="130fb4ea8754106340c318592eec2d8a0deaf3d0" region="chargen" offset="0"/>
+		<rom name="keybd.u445" size="2048" crc="58dc8217" sha1="1b23705290bdf9fc6342065c6a528c04bff67b13" region="keyboard" offset="0"/>
+		<device_ref tag=":_tmp:maincpu" name="z80"/>
+		<device_ref tag=":_tmp:screen" name="screen"/>
+		<device_ref tag=":_tmp:gfxdecode" name="gfxdecode"/>
+		<device_ref tag=":_tmp:palette" name="palette"/>
+		<device_ref tag=":_tmp:crtc" name="mc6845"/>
+		<device_ref tag=":_tmp:ins8250" name="ins8250"/>
+		<device_ref tag=":_tmp:mm5740" name="mm5740"/>
+		<device_ref tag=":_tmp:mono" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<device_ref tag=":_tmp:repeatclock" name="clock"/>
+		<chip type="cpu" tag=":maincpu" name="Zilog Z80" clock="2048000"/>
+		<chip type="audio" tag=":mono" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="1000"/>
+		<display tag=":screen" type="raster" rotate="0" width="640" height="250" refresh="59.259259" pixclock="12288000" htotal="768" hbend="32" hbstart="672" vtotal="270" vbend="0" vbstart="250" />
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="86"/>
+		</input>
+		<dipswitch name="Baud Rate" tag=":SW401" mask="15">
+			<diplocation name="SW401" number="1"/>
+			<diplocation name="SW401" number="2"/>
+			<diplocation name="SW401" number="3"/>
+			<diplocation name="SW401" number="4"/>
+			<dipvalue name="75" value="0"/>
+			<dipvalue name="110" value="1"/>
+			<dipvalue name="150" value="2"/>
+			<dipvalue name="300" value="3"/>
+			<dipvalue name="600" value="4"/>
+			<dipvalue name="1200" value="5"/>
+			<dipvalue name="1800" value="6"/>
+			<dipvalue name="2000" value="7"/>
+			<dipvalue name="2400" value="8"/>
+			<dipvalue name="3600" value="9"/>
+			<dipvalue name="4800" value="10"/>
+			<dipvalue name="7200" value="11"/>
+			<dipvalue name="9600" value="12" default="yes"/>
+			<dipvalue name="19200" value="13"/>
+			<dipvalue name="38400" value="14"/>
+			<dipvalue name="134.5" value="15"/>
+		</dipswitch>
+		<dipswitch name="Parity" tag=":SW401" mask="48">
+			<diplocation name="SW401" number="5"/>
+			<diplocation name="SW401" number="6"/>
+			<dipvalue name="None" value="0" default="yes"/>
+			<dipvalue name="Odd" value="16"/>
+			<dipvalue name="None" value="32"/>
+			<dipvalue name="Even" value="48"/>
+		</dipswitch>
+		<dipswitch name="Word Size" tag=":SW401" mask="64">
+			<diplocation name="SW401" number="7"/>
+			<dipvalue name="8-bit Word" value="0" default="yes"/>
+			<dipvalue name="7-bit Word" value="64"/>
+		</dipswitch>
+		<dipswitch name="Duplex" tag=":SW401" mask="128">
+			<diplocation name="SW401" number="8"/>
+			<dipvalue name="Half" value="0"/>
+			<dipvalue name="Full" value="128" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Cursor" tag=":SW402" mask="1">
+			<diplocation name="SW402" number="1"/>
+			<dipvalue name="Underline" value="0" default="yes"/>
+			<dipvalue name="Block" value="1"/>
+		</dipswitch>
+		<dipswitch name="Keyclick" tag=":SW402" mask="2">
+			<diplocation name="SW402" number="2"/>
+			<dipvalue name="No" value="2"/>
+			<dipvalue name="Yes" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Wrap at EOL" tag=":SW402" mask="4">
+			<diplocation name="SW402" number="3"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="4"/>
+		</dipswitch>
+		<dipswitch name="Auto LF on CR" tag=":SW402" mask="8">
+			<diplocation name="SW402" number="4"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="8"/>
+		</dipswitch>
+		<dipswitch name="Auto CR on LF" tag=":SW402" mask="16">
+			<diplocation name="SW402" number="5"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="16"/>
+		</dipswitch>
+		<dipswitch name="Mode" tag=":SW402" mask="32">
+			<diplocation name="SW402" number="6"/>
+			<dipvalue name="Heath/VT52" value="0" default="yes"/>
+			<dipvalue name="ANSI" value="32"/>
+		</dipswitch>
+		<dipswitch name="Keypad Shifted" tag=":SW402" mask="64">
+			<diplocation name="SW402" number="7"/>
+			<dipvalue name="No" value="0" default="yes"/>
+			<dipvalue name="Yes" value="64"/>
+		</dipswitch>
+		<dipswitch name="Refresh" tag=":SW402" mask="128">
+			<diplocation name="SW402" number="8"/>
+			<dipvalue name="60Hz" value="0" default="yes"/>
+			<dipvalue name="50Hz" value="128"/>
+		</dipswitch>
+		<configuration name="CPU Clock" tag=":CONFIG" mask="3">
+			<confsetting name="2 MHz" value="0" default="yes"/>
+			<confsetting name="3 MHz" value="1"/>
+			<confsetting name="4 MHz" value="2"/>
+			<confsetting name="6 MHz" value="3"/>
+		</configuration>
+		<configuration name="CRT Color" tag=":CONFIG" mask="12">
+			<confsetting name="Green" value="0" default="yes"/>
+			<confsetting name="White" value="4"/>
+			<confsetting name="Amber" value="8"/>
+		</configuration>
+	</machine>
+	<machine name="i8085a" sourcefile="devices/cpu/i8085/i8085.cpp" isdevice="yes" runnable="no">
+		<description>Intel 8085A</description>
+	</machine>
+	<machine name="i80c31" sourcefile="devices/cpu/mcs51/i80c51.cpp" isdevice="yes" runnable="no">
+		<description>Intel 80C31</description>
+	</machine>
+	<machine name="i80c32" sourcefile="devices/cpu/mcs51/i80c52.cpp" isdevice="yes" runnable="no">
+		<description>Intel 80C32</description>
+	</machine>
+	<machine name="i8251" sourcefile="devices/machine/i8251.cpp" isdevice="yes" runnable="no">
+		<description>Intel 8251 USART</description>
+	</machine>
+	<machine name="idehd" sourcefile="devices/bus/ata/hdd.cpp" isdevice="yes" runnable="no">
+		<description>IDE Hard Disk</description>
+		<device_ref tag=":_tmp:image" name="harddisk_image"/>
+		<device type="harddisk" tag=":image" interface="ide_hdd,hdd">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="kbd_type2_hle" sourcefile="devices/bus/sunkbd/hlekbd.cpp" isdevice="yes" runnable="no">
+		<description>Sun Type 2 Keyboard (HLE)</description>
+		<device_ref tag=":_tmp:bell" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<chip type="audio" tag=":bell" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="2083"/>
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="95"/>
+		</input>
+	</machine>
+	<machine name="kbd_type3_hle" sourcefile="devices/bus/sunkbd/hlekbd.cpp" isdevice="yes" runnable="no">
+		<description>Sun Type 3 Keyboard (HLE)</description>
+		<device_ref tag=":_tmp:bell" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<chip type="audio" tag=":bell" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="2083"/>
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="95"/>
+		</input>
+	</machine>
+	<machine name="kbd_type4_hle" sourcefile="devices/bus/sunkbd/hlekbd.cpp" isdevice="yes" runnable="no">
+		<description>Sun Type 4 Keyboard (HLE)</description>
+		<device_ref tag=":_tmp:bell" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<chip type="audio" tag=":bell" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="2083"/>
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="107"/>
+		</input>
+		<dipswitch name="Layout" tag=":DIP" mask="63">
+			<diplocation name="DIP" number="8"/>
+			<diplocation name="DIP" number="7"/>
+			<diplocation name="DIP" number="6"/>
+			<diplocation name="DIP" number="5"/>
+			<diplocation name="DIP" number="4"/>
+			<diplocation name="DIP" number="3"/>
+			<dipvalue name="U.S.A. (US4.kt)" value="0" default="yes"/>
+			<dipvalue name="U.S.A. (US4.kt)" value="1"/>
+			<dipvalue name="Belgium (FranceBelg4.kt)" value="2"/>
+			<dipvalue name="Canada (Canada4.kt)" value="3"/>
+			<dipvalue name="Denmark (Denmakr4.kt)" value="4"/>
+			<dipvalue name="Germany (Germany4.kt)" value="5"/>
+			<dipvalue name="Italy (Italy4.kt)" value="6"/>
+			<dipvalue name="The Netherlands (Netherland4.kt)" value="7"/>
+			<dipvalue name="Norway (Norway4.kt)" value="8"/>
+			<dipvalue name="Portugal (Portugal4.kt)" value="9"/>
+			<dipvalue name="Latin America/Spanish (SpainLatAm4.kt)" value="10"/>
+			<dipvalue name="Sweden (SwedenFin4.kt)" value="11"/>
+			<dipvalue name="Switzerland/French (Switzer_Fr4.kt)" value="12"/>
+			<dipvalue name="Switzerland/German (Switzer_Ge4.kt)" value="13"/>
+			<dipvalue name="Great Britain (UK4.kt)" value="14"/>
+			<dipvalue name="Korea (Korea4.kt)" value="16"/>
+			<dipvalue name="Taiwan (Taiwan4.kt)" value="17"/>
+			<dipvalue name="U.S.A. (US5.kt)" value="33"/>
+			<dipvalue name="U.S.A./UNIX (US_UNIX5.kt)" value="34"/>
+			<dipvalue name="France (France5.kt)" value="35"/>
+			<dipvalue name="Denmark (Denmark5.kt)" value="36"/>
+			<dipvalue name="Germany (Germany5.kt)" value="37"/>
+			<dipvalue name="Italy (Italy5.kt)" value="38"/>
+			<dipvalue name="The Netherlands (Netherland5.kt)" value="39"/>
+			<dipvalue name="Norway (Norway5.kt)" value="40"/>
+			<dipvalue name="Portugal (Portugal5.kt)" value="41"/>
+			<dipvalue name="Spain (Spain5.kt)" value="42"/>
+			<dipvalue name="Sweden (Sweden5.kt)" value="43"/>
+			<dipvalue name="Switzerland/French (Switzer_Fr5.kt)" value="44"/>
+			<dipvalue name="Switzerland/German (Switzer_Ge5.kt)" value="45"/>
+			<dipvalue name="Great Britain (UK5.kt)" value="46"/>
+			<dipvalue name="Korea (Korea5.kt)" value="47"/>
+			<dipvalue name="Taiwan (Taiwan5.kt)" value="48"/>
+			<dipvalue name="Japan (Japan5.kt)" value="49"/>
+			<dipvalue name="Canada/French (Canada_Fr5.kt)" value="50"/>
+			<dipvalue name="Hungary (Hungary5.kt)" value="51"/>
+			<dipvalue name="Poland (Poland5.kt)" value="52"/>
+			<dipvalue name="Czech (Czech5.kt)" value="53"/>
+			<dipvalue name="Russia (Russia5.kt)" value="54"/>
+			<dipvalue name="Latvia (Latvia5.kt)" value="55"/>
+			<dipvalue name="Turkey-Q5 (TurkeyQ5.kt)" value="56"/>
+			<dipvalue name="Greece (Greece5.kt)" value="57"/>
+			<dipvalue name="Arabic (Arabic5.kt)" value="58"/>
+			<dipvalue name="Lithuania (Lithuania5.kt)" value="59"/>
+			<dipvalue name="Belgium (Belgium5.kt)" value="60"/>
+			<dipvalue name="Turkey-F5 (TurkeyF5.kt)" value="62"/>
+			<dipvalue name="Canada/French (Canada_Fr5_TBITS5.kt)" value="63"/>
+		</dipswitch>
+		<dipswitch name="Unused" tag=":DIP" mask="64">
+			<diplocation name="DIP" number="2"/>
+			<dipvalue name="Off" value="0" default="yes"/>
+			<dipvalue name="On" value="64"/>
+		</dipswitch>
+		<dipswitch name="Identify as" tag=":DIP" mask="128">
+			<diplocation name="DIP" number="1"/>
+			<dipvalue name="Type 4" value="0" default="yes"/>
+			<dipvalue name="Type 3" value="128"/>
+		</dipswitch>
+	</machine>
+	<machine name="kbd_type5_hle_gb" sourcefile="devices/bus/sunkbd/hlekbd.cpp" isdevice="yes" runnable="no">
+		<description>Sun Type 5 Keyboard (Great Britain - HLE)</description>
+		<device_ref tag=":_tmp:bell" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<chip type="audio" tag=":bell" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="2083"/>
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="119"/>
+		</input>
+		<dipswitch name="Layout" tag=":DIP" mask="31">
+			<diplocation name="S" number="5"/>
+			<diplocation name="S" number="4"/>
+			<diplocation name="S" number="3"/>
+			<diplocation name="S" number="2"/>
+			<diplocation name="S" number="1"/>
+			<dipvalue name="U.S.A. (US5.kt)" value="1"/>
+			<dipvalue name="U.S.A./UNIX (US_UNIX5.kt)" value="2"/>
+			<dipvalue name="France (France5.kt)" value="3"/>
+			<dipvalue name="Denmark (Denmark5.kt)" value="4"/>
+			<dipvalue name="Germany (Germany5.kt)" value="5"/>
+			<dipvalue name="Italy (Italy5.kt)" value="6"/>
+			<dipvalue name="The Netherlands (Netherland5.kt)" value="7"/>
+			<dipvalue name="Norway (Norway5.kt)" value="8"/>
+			<dipvalue name="Portugal (Portugal5.kt)" value="9"/>
+			<dipvalue name="Spain (Spain5.kt)" value="10"/>
+			<dipvalue name="Sweden (Sweden5.kt)" value="11"/>
+			<dipvalue name="Switzerland/French (Switzer_Fr5.kt)" value="12"/>
+			<dipvalue name="Switzerland/German (Switzer_Ge5.kt)" value="13"/>
+			<dipvalue name="Great Britain (UK5.kt)" value="14" default="yes"/>
+			<dipvalue name="Korea (Korea5.kt)" value="15"/>
+			<dipvalue name="Taiwan (Taiwan5.kt)" value="16"/>
+			<dipvalue name="Japan (Japan5.kt)" value="17"/>
+			<dipvalue name="Canada/French (Canada_Fr5.kt)" value="18"/>
+			<dipvalue name="Hungary (Hungary5.kt)" value="19"/>
+			<dipvalue name="Poland (Poland5.kt)" value="20"/>
+			<dipvalue name="Czech (Czech5.kt)" value="21"/>
+			<dipvalue name="Russia (Russia5.kt)" value="22"/>
+			<dipvalue name="Latvia (Latvia5.kt)" value="23"/>
+			<dipvalue name="Turkey-Q5 (TurkeyQ5.kt)" value="24"/>
+			<dipvalue name="Greece (Greece5.kt)" value="25"/>
+			<dipvalue name="Arabic (Arabic5.kt)" value="26"/>
+			<dipvalue name="Lithuania (Lithuania5.kt)" value="27"/>
+			<dipvalue name="Belgium (Belgium5.kt)" value="28"/>
+			<dipvalue name="Turkey-F5 (TurkeyF5.kt)" value="30"/>
+			<dipvalue name="Canada/French (Canada_Fr5_TBITS5.kt)" value="31"/>
+		</dipswitch>
+	</machine>
+	<machine name="kbd_type5_hle_jp" sourcefile="devices/bus/sunkbd/hlekbd.cpp" isdevice="yes" runnable="no">
+		<description>Sun Type 5 Keyboard (Japan - HLE)</description>
+		<device_ref tag=":_tmp:bell" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<chip type="audio" tag=":bell" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="2083"/>
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="122"/>
+		</input>
+		<dipswitch name="Layout" tag=":DIP" mask="31">
+			<diplocation name="S" number="5"/>
+			<diplocation name="S" number="4"/>
+			<diplocation name="S" number="3"/>
+			<diplocation name="S" number="2"/>
+			<diplocation name="S" number="1"/>
+			<dipvalue name="U.S.A. (US5.kt)" value="1"/>
+			<dipvalue name="U.S.A./UNIX (US_UNIX5.kt)" value="2"/>
+			<dipvalue name="France (France5.kt)" value="3"/>
+			<dipvalue name="Denmark (Denmark5.kt)" value="4"/>
+			<dipvalue name="Germany (Germany5.kt)" value="5"/>
+			<dipvalue name="Italy (Italy5.kt)" value="6"/>
+			<dipvalue name="The Netherlands (Netherland5.kt)" value="7"/>
+			<dipvalue name="Norway (Norway5.kt)" value="8"/>
+			<dipvalue name="Portugal (Portugal5.kt)" value="9"/>
+			<dipvalue name="Spain (Spain5.kt)" value="10"/>
+			<dipvalue name="Sweden (Sweden5.kt)" value="11"/>
+			<dipvalue name="Switzerland/French (Switzer_Fr5.kt)" value="12"/>
+			<dipvalue name="Switzerland/German (Switzer_Ge5.kt)" value="13"/>
+			<dipvalue name="Great Britain (UK5.kt)" value="14"/>
+			<dipvalue name="Korea (Korea5.kt)" value="15"/>
+			<dipvalue name="Taiwan (Taiwan5.kt)" value="16"/>
+			<dipvalue name="Japan (Japan5.kt)" value="17" default="yes"/>
+			<dipvalue name="Canada/French (Canada_Fr5.kt)" value="18"/>
+			<dipvalue name="Hungary (Hungary5.kt)" value="19"/>
+			<dipvalue name="Poland (Poland5.kt)" value="20"/>
+			<dipvalue name="Czech (Czech5.kt)" value="21"/>
+			<dipvalue name="Russia (Russia5.kt)" value="22"/>
+			<dipvalue name="Latvia (Latvia5.kt)" value="23"/>
+			<dipvalue name="Turkey-Q5 (TurkeyQ5.kt)" value="24"/>
+			<dipvalue name="Greece (Greece5.kt)" value="25"/>
+			<dipvalue name="Arabic (Arabic5.kt)" value="26"/>
+			<dipvalue name="Lithuania (Lithuania5.kt)" value="27"/>
+			<dipvalue name="Belgium (Belgium5.kt)" value="28"/>
+			<dipvalue name="Turkey-F5 (TurkeyF5.kt)" value="30"/>
+			<dipvalue name="Canada/French (Canada_Fr5_TBITS5.kt)" value="31"/>
+		</dipswitch>
+	</machine>
+	<machine name="kbd_type5_hle_se" sourcefile="devices/bus/sunkbd/hlekbd.cpp" isdevice="yes" runnable="no">
+		<description>Sun Type 5 Keyboard (Sweden - HLE)</description>
+		<device_ref tag=":_tmp:bell" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<chip type="audio" tag=":bell" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="2083"/>
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="119"/>
+		</input>
+		<dipswitch name="Layout" tag=":DIP" mask="31">
+			<diplocation name="S" number="5"/>
+			<diplocation name="S" number="4"/>
+			<diplocation name="S" number="3"/>
+			<diplocation name="S" number="2"/>
+			<diplocation name="S" number="1"/>
+			<dipvalue name="U.S.A. (US5.kt)" value="1"/>
+			<dipvalue name="U.S.A./UNIX (US_UNIX5.kt)" value="2"/>
+			<dipvalue name="France (France5.kt)" value="3"/>
+			<dipvalue name="Denmark (Denmark5.kt)" value="4"/>
+			<dipvalue name="Germany (Germany5.kt)" value="5"/>
+			<dipvalue name="Italy (Italy5.kt)" value="6"/>
+			<dipvalue name="The Netherlands (Netherland5.kt)" value="7"/>
+			<dipvalue name="Norway (Norway5.kt)" value="8"/>
+			<dipvalue name="Portugal (Portugal5.kt)" value="9"/>
+			<dipvalue name="Spain (Spain5.kt)" value="10"/>
+			<dipvalue name="Sweden (Sweden5.kt)" value="11" default="yes"/>
+			<dipvalue name="Switzerland/French (Switzer_Fr5.kt)" value="12"/>
+			<dipvalue name="Switzerland/German (Switzer_Ge5.kt)" value="13"/>
+			<dipvalue name="Great Britain (UK5.kt)" value="14"/>
+			<dipvalue name="Korea (Korea5.kt)" value="15"/>
+			<dipvalue name="Taiwan (Taiwan5.kt)" value="16"/>
+			<dipvalue name="Japan (Japan5.kt)" value="17"/>
+			<dipvalue name="Canada/French (Canada_Fr5.kt)" value="18"/>
+			<dipvalue name="Hungary (Hungary5.kt)" value="19"/>
+			<dipvalue name="Poland (Poland5.kt)" value="20"/>
+			<dipvalue name="Czech (Czech5.kt)" value="21"/>
+			<dipvalue name="Russia (Russia5.kt)" value="22"/>
+			<dipvalue name="Latvia (Latvia5.kt)" value="23"/>
+			<dipvalue name="Turkey-Q5 (TurkeyQ5.kt)" value="24"/>
+			<dipvalue name="Greece (Greece5.kt)" value="25"/>
+			<dipvalue name="Arabic (Arabic5.kt)" value="26"/>
+			<dipvalue name="Lithuania (Lithuania5.kt)" value="27"/>
+			<dipvalue name="Belgium (Belgium5.kt)" value="28"/>
+			<dipvalue name="Turkey-F5 (TurkeyF5.kt)" value="30"/>
+			<dipvalue name="Canada/French (Canada_Fr5_TBITS5.kt)" value="31"/>
+		</dipswitch>
+	</machine>
+	<machine name="kbd_type5_hle_us" sourcefile="devices/bus/sunkbd/hlekbd.cpp" isdevice="yes" runnable="no">
+		<description>Sun Type 5 Keyboard (U.S.A. - HLE)</description>
+		<device_ref tag=":_tmp:bell" name="speaker"/>
+		<device_ref tag=":_tmp:beeper" name="beep"/>
+		<chip type="audio" tag=":bell" name="Speaker"/>
+		<chip type="audio" tag=":beeper" name="Beep" clock="2083"/>
+		<sound channels="1"/>
+		<input players="1">
+			<control type="keyboard" buttons="118"/>
+		</input>
+		<dipswitch name="Layout" tag=":DIP" mask="31">
+			<diplocation name="S" number="5"/>
+			<diplocation name="S" number="4"/>
+			<diplocation name="S" number="3"/>
+			<diplocation name="S" number="2"/>
+			<diplocation name="S" number="1"/>
+			<dipvalue name="U.S.A. (US5.kt)" value="1" default="yes"/>
+			<dipvalue name="U.S.A./UNIX (US_UNIX5.kt)" value="2"/>
+			<dipvalue name="France (France5.kt)" value="3"/>
+			<dipvalue name="Denmark (Denmark5.kt)" value="4"/>
+			<dipvalue name="Germany (Germany5.kt)" value="5"/>
+			<dipvalue name="Italy (Italy5.kt)" value="6"/>
+			<dipvalue name="The Netherlands (Netherland5.kt)" value="7"/>
+			<dipvalue name="Norway (Norway5.kt)" value="8"/>
+			<dipvalue name="Portugal (Portugal5.kt)" value="9"/>
+			<dipvalue name="Spain (Spain5.kt)" value="10"/>
+			<dipvalue name="Sweden (Sweden5.kt)" value="11"/>
+			<dipvalue name="Switzerland/French (Switzer_Fr5.kt)" value="12"/>
+			<dipvalue name="Switzerland/German (Switzer_Ge5.kt)" value="13"/>
+			<dipvalue name="Great Britain (UK5.kt)" value="14"/>
+			<dipvalue name="Korea (Korea5.kt)" value="15"/>
+			<dipvalue name="Taiwan (Taiwan5.kt)" value="16"/>
+			<dipvalue name="Japan (Japan5.kt)" value="17"/>
+			<dipvalue name="Canada/French (Canada_Fr5.kt)" value="18"/>
+			<dipvalue name="Hungary (Hungary5.kt)" value="19"/>
+			<dipvalue name="Poland (Poland5.kt)" value="20"/>
+			<dipvalue name="Czech (Czech5.kt)" value="21"/>
+			<dipvalue name="Russia (Russia5.kt)" value="22"/>
+			<dipvalue name="Latvia (Latvia5.kt)" value="23"/>
+			<dipvalue name="Turkey-Q5 (TurkeyQ5.kt)" value="24"/>
+			<dipvalue name="Greece (Greece5.kt)" value="25"/>
+			<dipvalue name="Arabic (Arabic5.kt)" value="26"/>
+			<dipvalue name="Lithuania (Lithuania5.kt)" value="27"/>
+			<dipvalue name="Belgium (Belgium5.kt)" value="28"/>
+			<dipvalue name="Turkey-F5 (TurkeyF5.kt)" value="30"/>
+			<dipvalue name="Canada/French (Canada_Fr5_TBITS5.kt)" value="31"/>
+		</dipswitch>
+	</machine>
+	<machine name="m37450" sourcefile="devices/cpu/m6502/m3745x.cpp" isdevice="yes" runnable="no">
+		<description>Mitsubishi M37450</description>
+	</machine>
+	<machine name="m37710s4" sourcefile="devices/cpu/m37710/m37710.cpp" isdevice="yes" runnable="no">
+		<description>Mitsubishi M37710S4</description>
+	</machine>
+	<machine name="m37732s4" sourcefile="devices/cpu/m37710/m37710.cpp" isdevice="yes" runnable="no">
+		<description>Mitsubishi M37732S4</description>
+	</machine>
+	<machine name="m6502" sourcefile="devices/cpu/m6502/m6502.cpp" isdevice="yes" runnable="no">
+		<description>MOS Technology 6502</description>
+	</machine>
+	<machine name="m6504" sourcefile="devices/cpu/m6502/m6504.cpp" isdevice="yes" runnable="no">
+		<description>MOS Technology 6504</description>
+	</machine>
+	<machine name="mb91f155a" sourcefile="devices/cpu/fr/fr.cpp" isdevice="yes" runnable="no">
+		<description>Fujitsu MB91F155A</description>
+	</machine>
+	<machine name="mc68hc11a1" sourcefile="devices/cpu/mc68hc11/mc68hc11.cpp" isdevice="yes" runnable="no">
+		<description>Motorola MC68HC11A1</description>
+	</machine>
+	<machine name="mc68hc11f1" sourcefile="devices/cpu/mc68hc11/mc68hc11.cpp" isdevice="yes" runnable="no">
+		<description>Motorola MC68HC11F1</description>
+	</machine>
+	<machine name="mc68hc16z1" sourcefile="devices/cpu/m68hc16/m68hc16z.cpp" isdevice="yes" runnable="no">
+		<description>Motorola MC68HC16Z1</description>
+	</machine>
+	<machine name="midiin" sourcefile="devices/imagedev/midiin.cpp" isdevice="yes" runnable="no">
+		<description>MIDI In image device</description>
+		<configuration name="MIDI file mode" tag=":CFG" mask="255">
+			<confsetting name="Multi" value="255" default="yes"/>
+			<confsetting name="Poly: Channel 1" value="0"/>
+			<confsetting name="Poly: Channel 2" value="1"/>
+			<confsetting name="Poly: Channel 3" value="2"/>
+			<confsetting name="Poly: Channel 4" value="3"/>
+			<confsetting name="Poly: Channel 5" value="4"/>
+			<confsetting name="Poly: Channel 6" value="5"/>
+			<confsetting name="Poly: Channel 7" value="6"/>
+			<confsetting name="Poly: Channel 8" value="7"/>
+			<confsetting name="Poly: Channel 9" value="8"/>
+			<confsetting name="Poly: Channel 10" value="9"/>
+			<confsetting name="Poly: Channel 11" value="10"/>
+			<confsetting name="Poly: Channel 12" value="11"/>
+			<confsetting name="Poly: Channel 13" value="12"/>
+			<confsetting name="Poly: Channel 14" value="13"/>
+			<confsetting name="Poly: Channel 15" value="14"/>
+			<confsetting name="Poly: Channel 16" value="15"/>
+		</configuration>
+	</machine>
+	<machine name="midiin_port" sourcefile="devices/bus/midi/midiinport.cpp" isdevice="yes" runnable="no">
+		<description>MIDI In port</description>
+		<device_ref tag=":_tmp:midiinimg" name="midiin"/>
+		<configuration name="MIDI file mode" tag=":midiinimg:CFG" mask="255">
+			<confsetting name="Multi" value="255" default="yes"/>
+			<confsetting name="Poly: Channel 1" value="0"/>
+			<confsetting name="Poly: Channel 2" value="1"/>
+			<confsetting name="Poly: Channel 3" value="2"/>
+			<confsetting name="Poly: Channel 4" value="3"/>
+			<confsetting name="Poly: Channel 5" value="4"/>
+			<confsetting name="Poly: Channel 6" value="5"/>
+			<confsetting name="Poly: Channel 7" value="6"/>
+			<confsetting name="Poly: Channel 8" value="7"/>
+			<confsetting name="Poly: Channel 9" value="8"/>
+			<confsetting name="Poly: Channel 10" value="9"/>
+			<confsetting name="Poly: Channel 11" value="10"/>
+			<confsetting name="Poly: Channel 12" value="11"/>
+			<confsetting name="Poly: Channel 13" value="12"/>
+			<confsetting name="Poly: Channel 14" value="13"/>
+			<confsetting name="Poly: Channel 15" value="14"/>
+			<confsetting name="Poly: Channel 16" value="15"/>
+		</configuration>
+		<device type="midiin" tag=":midiinimg">
+			<instance name="midiin" briefname="min"/>
+			<extension name="mid"/>
+			<extension name="syx"/>
+		</device>
+	</machine>
+	<machine name="midiout" sourcefile="devices/imagedev/midiout.cpp" isdevice="yes" runnable="no">
+		<description>MIDI Out image device</description>
+	</machine>
+	<machine name="midiout_port" sourcefile="devices/bus/midi/midioutport.cpp" isdevice="yes" runnable="no">
+		<description>MIDI Out port</description>
+		<device_ref tag=":_tmp:midioutimg" name="midiout"/>
+		<device type="midiout" tag=":midioutimg">
+			<instance name="midiout" briefname="mout"/>
+			<extension name="mid"/>
+		</device>
+	</machine>
+	<machine name="mm5740" sourcefile="devices/machine/mm5740.cpp" isdevice="yes" runnable="no">
+		<description>MM5740 Keyboard Encoder</description>
+		<rom name="mm5740aac.ic1" size="450" crc="aed404d3" sha1="e7b9feba5f789f388d27820b5f3fa591d41b4ab1" region="internal" offset="0"/>
+	</machine>
+	<machine name="mm74c923" sourcefile="devices/machine/mm74c922.cpp" isdevice="yes" runnable="no">
+		<description>MM74C923 20-Key Encoder</description>
+	</machine>
+	<machine name="mos6530" sourcefile="devices/machine/mos6530.cpp" isdevice="yes" runnable="no">
+		<description>MOS 6530 MIOT</description>
+	</machine>
+	<machine name="mos6532" sourcefile="devices/machine/mos6530.cpp" isdevice="yes" runnable="no">
+		<description>MOS 6532 RIOT</description>
+	</machine>
+	<machine name="ncr53c94" sourcefile="devices/machine/ncr53c90.cpp" isdevice="yes" runnable="no">
+		<description>NCR 53C94 Advanced SCSI Controller</description>
+	</machine>
+	<machine name="ncr53cf94" sourcefile="devices/machine/ncr53c90.cpp" isdevice="yes" runnable="no">
+		<description>NCR 53CF94-2 Fast SCSI Controller</description>
+	</machine>
+	<machine name="nscsi_cb" sourcefile="devices/machine/nscsi_cb.cpp" isdevice="yes" runnable="no">
+		<description>SCSI callback (new)</description>
+	</machine>
+	<machine name="nscsi_sa1403d" sourcefile="devices/bus/nscsi/sa1403d.cpp" isdevice="yes" runnable="no">
+		<description>Shugart SA1403D Winchester/Floppy Disk Controller</description>
+		<device_ref tag=":_tmp:fdc" name="fd1793"/>
+		<device_ref tag=":_tmp:fd0" name="floppy_connector"/>
+		<device_ref tag=":_tmp:fd1" name="floppy_connector"/>
+		<device_ref tag=":_tmp:fd2" name="floppy_connector"/>
+		<device_ref tag=":_tmp:hd3" name="harddisk_image"/>
+		<dipswitch name="LUN 3 Drive Type" tag=":DRIVETYPE" mask="3">
+			<diplocation name="2H" number="2"/>
+			<diplocation name="2H" number="1"/>
+			<dipvalue name="SA1002" value="0"/>
+			<dipvalue name="SA1004" value="1" default="yes"/>
+			<dipvalue name="SA800" value="2"/>
+			<dipvalue name="SA850" value="3"/>
+		</dipswitch>
+		<dipswitch name="LUN 2 Drive Type" tag=":DRIVETYPE" mask="12">
+			<diplocation name="2H" number="4"/>
+			<diplocation name="2H" number="3"/>
+			<dipvalue name="SA1002" value="0"/>
+			<dipvalue name="SA1004" value="4"/>
+			<dipvalue name="SA800" value="8"/>
+			<dipvalue name="SA850" value="12" default="yes"/>
+		</dipswitch>
+		<dipswitch name="LUN 1 Drive Type" tag=":DRIVETYPE" mask="48">
+			<diplocation name="2H" number="6"/>
+			<diplocation name="2H" number="5"/>
+			<dipvalue name="SA1002" value="0"/>
+			<dipvalue name="SA1004" value="16"/>
+			<dipvalue name="SA800" value="32"/>
+			<dipvalue name="SA850" value="48" default="yes"/>
+		</dipswitch>
+		<dipswitch name="LUN 0 Drive Type" tag=":DRIVETYPE" mask="192">
+			<diplocation name="2H" number="8"/>
+			<diplocation name="2H" number="7"/>
+			<dipvalue name="SA1002" value="0"/>
+			<dipvalue name="SA1004" value="64"/>
+			<dipvalue name="SA800" value="128"/>
+			<dipvalue name="SA850" value="192" default="yes"/>
+		</dipswitch>
+		<device type="harddisk" tag=":hd3" interface="scsi_hdd,hdd">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+		<slot name=":fd0">
+			<slotoption name="sa850" devname="floppy_8_dsdd" default="yes"/>
+			<slotoption name="sa450" devname="floppy_525_dd"/>
+			<slotoption name="sa800" devname="floppy_8_ssdd"/>
+			<slotoption name="sa400" devname="floppy_525_sssd_35t"/>
+		</slot>
+		<slot name=":fd1">
+			<slotoption name="sa850" devname="floppy_8_dsdd" default="yes"/>
+			<slotoption name="sa450" devname="floppy_525_dd"/>
+			<slotoption name="sa800" devname="floppy_8_ssdd"/>
+			<slotoption name="sa400" devname="floppy_525_sssd_35t"/>
+		</slot>
+		<slot name=":fd2">
+			<slotoption name="sa850" devname="floppy_8_dsdd"/>
+			<slotoption name="sa450" devname="floppy_525_dd"/>
+			<slotoption name="sa800" devname="floppy_8_ssdd"/>
+			<slotoption name="sa400" devname="floppy_525_sssd_35t"/>
+		</slot>
+	</machine>
+	<machine name="pit8254" sourcefile="devices/machine/pit8253.cpp" isdevice="yes" runnable="no">
+		<description>Intel 8254 PIT</description>
+		<device_ref tag=":_tmp:counter0" name="pit_counter"/>
+		<device_ref tag=":_tmp:counter1" name="pit_counter"/>
+		<device_ref tag=":_tmp:counter2" name="pit_counter"/>
+	</machine>
+	<machine name="pit_counter" sourcefile="devices/machine/pit8253.cpp" isdevice="yes" runnable="no">
+		<description>PIT Counter</description>
+	</machine>
+	<machine name="px320a" sourcefile="devices/bus/ata/px320a.cpp" isdevice="yes" runnable="no">
+		<description>PleXCombo PX-320A CD-RW/DVD-ROM Drive</description>
+		<biosset name="v106" description="Firmware v1.06"/>
+		<biosset name="v105" description="Firmware v1.05"/>
+		<biosset name="v104" description="Firmware v1.04a"/>
+		<biosset name="v103" description="Firmware v1.03"/>
+		<biosset name="v102" description="Firmware v1.02"/>
+		<rom name="sapp106.bin" size="524288" crc="2ba54c7a" sha1="032cc5009fe84db902096ea2bb9dc2221601ab20" region="firmware" offset="0"/>
+		<rom name="sapp105.bin" size="524288" crc="3755a053" sha1="fb966d506edb6e0a97ad64de3898ce9e75e22d7d" region="firmware" offset="0"/>
+		<rom name="sapp104.bin" size="524288" crc="7197425f" sha1="0b02508d668439a78ea8e3d97eddf5a3de6e2ba5" region="firmware" offset="0"/>
+		<rom name="sap1032.bin" size="524288" crc="9ff1c729" sha1="6ed44bf8decaac2ee9127bdd66e0ff1fd52969c3" region="firmware" offset="0"/>
+		<rom name="sapp102.bin" size="524288" crc="9f96bea4" sha1="5b70f32e83d8c19d2895d38d0f7e15f2eee326fd" region="firmware" offset="0"/>
+		<device_ref tag=":_tmp:frcpu" name="mb91f155a"/>
+		<chip type="cpu" tag=":frcpu" name="Fujitsu MB91F155A" clock="16000000"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="scsi_cdrom" sourcefile="devices/bus/nscsi/cd.cpp" isdevice="yes" runnable="no">
+		<description>SCSI CD-ROM</description>
+		<device_ref tag=":_tmp:image" name="cdrom_image"/>
+		<device_ref tag=":_tmp:cdda" name="cdda"/>
+		<chip type="audio" tag=":cdda" name="CD/DA" clock="44100"/>
+		<sound channels="0"/>
+		<device type="cdrom" tag=":image" interface="cdrom">
+			<instance name="cdrom" briefname="cdrm"/>
+			<extension name="chd"/>
+			<extension name="cue"/>
+			<extension name="toc"/>
+			<extension name="nrg"/>
+			<extension name="gdi"/>
+			<extension name="iso"/>
+			<extension name="cdr"/>
+		</device>
+	</machine>
+	<machine name="scsi_cdrom2x" sourcefile="devices/bus/nscsi/cd.cpp" isdevice="yes" runnable="no">
+		<description>SCSI CD-ROM (2X speed)</description>
+		<device_ref tag=":_tmp:image" name="cdrom_image"/>
+		<device_ref tag=":_tmp:cdda" name="cdda"/>
+		<chip type="audio" tag=":cdda" name="CD/DA" clock="44100"/>
+		<sound channels="0"/>
+		<device type="cdrom" tag=":image" interface="cdrom">
+			<instance name="cdrom" briefname="cdrm"/>
+			<extension name="chd"/>
+			<extension name="cue"/>
+			<extension name="toc"/>
+			<extension name="nrg"/>
+			<extension name="gdi"/>
+			<extension name="iso"/>
+			<extension name="cdr"/>
+		</device>
+	</machine>
+	<machine name="scsi_cdrom_apple" sourcefile="devices/bus/nscsi/cd.cpp" isdevice="yes" runnable="no">
+		<description>Apple SCSI CD-ROM</description>
+		<device_ref tag=":_tmp:image" name="cdrom_image"/>
+		<device_ref tag=":_tmp:cdda" name="cdda"/>
+		<chip type="audio" tag=":cdda" name="CD/DA" clock="44100"/>
+		<sound channels="0"/>
+		<device type="cdrom" tag=":image" interface="cdrom">
+			<instance name="cdrom" briefname="cdrm"/>
+			<extension name="chd"/>
+			<extension name="cue"/>
+			<extension name="toc"/>
+			<extension name="nrg"/>
+			<extension name="gdi"/>
+			<extension name="iso"/>
+			<extension name="cdr"/>
+		</device>
+	</machine>
+	<machine name="scsi_cdrom_apple_ext" sourcefile="devices/bus/nscsi/cd.cpp" isdevice="yes" runnable="no">
+		<description>Apple SCSI CD-ROM (external)</description>
+		<device_ref tag=":_tmp:image" name="cdrom_image"/>
+		<device_ref tag=":_tmp:cdda" name="cdda"/>
+		<device_ref tag=":_tmp:cdrom_speaker" name="speaker"/>
+		<chip type="audio" tag=":cdda" name="CD/DA" clock="44100"/>
+		<chip type="audio" tag=":cdrom_speaker" name="Speaker"/>
+		<sound channels="1"/>
+		<device type="cdrom" tag=":image" interface="cdrom">
+			<instance name="cdrom" briefname="cdrm"/>
+			<extension name="chd"/>
+			<extension name="cue"/>
+			<extension name="toc"/>
+			<extension name="nrg"/>
+			<extension name="gdi"/>
+			<extension name="iso"/>
+			<extension name="cdr"/>
+		</device>
+	</machine>
+	<machine name="scsi_dtc510" sourcefile="devices/bus/nscsi/dtc510.cpp" isdevice="yes" runnable="no">
+		<description>Data Technology DTC-510 5.25 Inch Winchester Disk Controller</description>
+		<device_ref tag=":_tmp:image" name="harddisk_image"/>
+		<device type="harddisk" tag=":image" interface="scsi_hdd,hdd">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="scsi_harddisk" sourcefile="devices/bus/nscsi/hd.cpp" isdevice="yes" runnable="no">
+		<description>SCSI Hard Disk</description>
+		<device_ref tag=":_tmp:image" name="harddisk_image"/>
+		<device type="harddisk" tag=":image" interface="scsi_hdd,hdd">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="scsi_pc98_hd" sourcefile="devices/bus/nscsi/pc98_hd.cpp" isdevice="yes" runnable="no">
+		<description>NEC PC-98 SCSI Hard Disk</description>
+		<device_ref tag=":_tmp:image" name="harddisk_image"/>
+		<device type="harddisk" tag=":image" interface="scsi_hdd,hdd">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="scsi_s1410" sourcefile="devices/bus/nscsi/s1410.cpp" isdevice="yes" runnable="no">
+		<description>Xebec S1410 5.25 Inch Winchester Disk Controller</description>
+		<device_ref tag=":_tmp:image" name="harddisk_image"/>
+		<device type="harddisk" tag=":image" interface="scsi_hdd,hdd">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="scsi_tape" sourcefile="devices/bus/nscsi/tape.cpp" isdevice="yes" runnable="no">
+		<description>SCSI tape</description>
+		<device_ref tag=":_tmp:image" name="simh_tape_image"/>
+		<device type="tape" tag=":image" interface="tape">
+			<instance name="tape" briefname="tap"/>
+			<extension name="tap"/>
+		</device>
+	</machine>
+	<machine name="scsihd" sourcefile="devices/bus/scsi/scsihd.cpp" isdevice="yes" runnable="no">
+		<description>SCSI HD</description>
+		<device_ref tag=":_tmp:image" name="harddisk_image"/>
+		<configuration name="SCSI ID" tag=":SCSI_ID" mask="7">
+			<confsetting name="0" value="0"/>
+			<confsetting name="1" value="1"/>
+			<confsetting name="2" value="2"/>
+			<confsetting name="3" value="3"/>
+			<confsetting name="4" value="4"/>
+			<confsetting name="5" value="5"/>
+			<confsetting name="6" value="6"/>
+			<confsetting name="7" value="7" default="yes"/>
+		</configuration>
+		<device type="harddisk" tag=":image" interface="scsi_hdd">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="sfd1001" sourcefile="devices/bus/ieee488/c8050.cpp" isdevice="yes" runnable="no">
+		<description>Commodore SFD-1001 disk drive</description>
+		<rom name="901887-01.1j" size="8192" crc="0073b8b2" sha1="b10603195f240118fe5fb6c6dfe5c5097463d890" region="un1" offset="0"/>
+		<rom name="901888-01.3j" size="8192" crc="de9b6132" sha1="2e6c2d7ca934e5c550ad14bd5e9e7749686b7af4" region="un1" offset="2000"/>
+		<rom name="901885-04.u1" size="1024" crc="bab998c9" sha1="0dc9a3b60f1b866c63eebd882403532fc59fe57f" region="uk3" offset="0"/>
+		<rom name="251257-02a.u2" size="2048" crc="b51150de" sha1="3b954eb34f7ea088eed1d33ebc6d6e83a3e9be15" region="uh3" offset="0"/>
+		<device_ref tag=":_tmp:un1" name="m6502"/>
+		<device_ref tag=":_tmp:uc1" name="mos6532"/>
+		<device_ref tag=":_tmp:ue1" name="mos6532"/>
+		<device_ref tag=":_tmp:uh3" name="m6504"/>
+		<device_ref tag=":_tmp:um3" name="mos6522"/>
+		<device_ref tag=":_tmp:uk3" name="mos6530"/>
+		<device_ref tag=":_tmp:fdc" name="c8050fdc"/>
+		<device_ref tag=":_tmp:fdc:0" name="floppy_connector"/>
+		<chip type="cpu" tag=":un1" name="MOS Technology 6502" clock="1000000"/>
+		<chip type="cpu" tag=":uh3" name="MOS Technology 6504" clock="1000000"/>
+		<dipswitch name="Device Address" tag=":ADDRESS" mask="7">
+			<dipvalue name="8" value="0" default="yes"/>
+			<dipvalue name="9" value="1"/>
+			<dipvalue name="10" value="2"/>
+			<dipvalue name="11" value="3"/>
+			<dipvalue name="12" value="4"/>
+			<dipvalue name="13" value="5"/>
+			<dipvalue name="14" value="6"/>
+			<dipvalue name="15" value="7"/>
+		</dipswitch>
+		<slot name=":fdc:0">
+			<slotoption name="525qd" devname="floppy_525_qd" default="yes"/>
+		</slot>
+	</machine>
+	<machine name="simh_tape_image" sourcefile="devices/imagedev/simh_tape_image.cpp" isdevice="yes" runnable="no">
+		<description>SIMH tape image</description>
+	</machine>
+	<machine name="smoc501" sourcefile="devices/bus/nscsi/smoc501.cpp" isdevice="yes" runnable="no">
+		<description>Sony SMO-C501 MO Disk Controller</description>
+		<rom name="c501-00.rom" size="65536" crc="0ae04500" sha1="96c73a3a2ecdc8c903e920f2afba5b4edd5cdba6" region="microcode" offset="0"/>
+		<device_ref tag=":_tmp:mpu" name="v40"/>
+		<device_ref tag=":_tmp:mpu:tcu" name="pit8254"/>
+		<device_ref tag=":_tmp:mpu:tcu:counter0" name="pit_counter"/>
+		<device_ref tag=":_tmp:mpu:tcu:counter1" name="pit_counter"/>
+		<device_ref tag=":_tmp:mpu:tcu:counter2" name="pit_counter"/>
+		<device_ref tag=":_tmp:mpu:dmau" name="v5x_dmau"/>
+		<device_ref tag=":_tmp:mpu:icu" name="v5x_icu"/>
+		<device_ref tag=":_tmp:mpu:scu" name="v5x_scu"/>
+		<device_ref tag=":_tmp:mpu:brc_timer" name="timer"/>
+		<device_ref tag=":_tmp:scsic" name="wd33c93"/>
+		<chip type="cpu" tag=":mpu" name="NEC V40" clock="16000000"/>
+		<chip type="cpu" tag=":mpu:dmau" name="V5X DMAU" clock="4000000"/>
+		<dipswitch name="Drive Number" tag=":DSW" mask="7">
+			<diplocation name="DSW" number="8"/>
+			<diplocation name="DSW" number="7"/>
+			<diplocation name="DSW" number="6"/>
+			<dipvalue name="0" value="7"/>
+			<dipvalue name="1" value="6" default="yes"/>
+			<dipvalue name="2" value="5"/>
+			<dipvalue name="3" value="4"/>
+			<dipvalue name="4" value="3"/>
+			<dipvalue name="5" value="2"/>
+			<dipvalue name="6" value="1"/>
+			<dipvalue name="7" value="0"/>
+		</dipswitch>
+		<dipswitch name="Auto Spin Up" tag=":DSW" mask="8">
+			<diplocation name="DSW" number="5"/>
+			<dipvalue name="By Drive Unit" value="8"/>
+			<dipvalue name="By Controller" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Terminator" tag=":DSW" mask="16">
+			<diplocation name="DSW" number="4"/>
+			<dipvalue name="Off" value="16"/>
+			<dipvalue name="On (Last Drive)" value="0" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Temporary Mode" tag=":DSW" mask="32">
+			<diplocation name="DSW" number="3"/>
+			<dipvalue name="512 Bytes/Sector" value="0"/>
+			<dipvalue name="1024 Bytes/Sector" value="32" default="yes"/>
+		</dipswitch>
+		<dipswitch name="Eject Mode" tag=":DSW" mask="64">
+			<diplocation name="DSW" number="2"/>
+			<dipvalue name="Eject Button" value="64" default="yes"/>
+			<dipvalue name="Controller" value="0"/>
+		</dipswitch>
+		<dipswitch name="Loading Control" tag=":DSW" mask="128">
+			<diplocation name="DSW" number="1"/>
+			<dipvalue name="Off" value="128" default="yes"/>
+			<dipvalue name="On" value="0"/>
+		</dipswitch>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="timer" sourcefile="devices/machine/timer.cpp" isdevice="yes" runnable="no">
+		<description>Timer</description>
+	</machine>
+	<machine name="v40" sourcefile="devices/cpu/nec/v5x.cpp" isdevice="yes" runnable="no">
+		<description>NEC V40</description>
+		<device_ref tag=":_tmp:tcu" name="pit8254"/>
+		<device_ref tag=":_tmp:tcu:counter0" name="pit_counter"/>
+		<device_ref tag=":_tmp:tcu:counter1" name="pit_counter"/>
+		<device_ref tag=":_tmp:tcu:counter2" name="pit_counter"/>
+		<device_ref tag=":_tmp:dmau" name="v5x_dmau"/>
+		<device_ref tag=":_tmp:icu" name="v5x_icu"/>
+		<device_ref tag=":_tmp:scu" name="v5x_scu"/>
+		<device_ref tag=":_tmp:brc_timer" name="timer"/>
+		<chip type="cpu" tag=":dmau" name="V5X DMAU" clock="0"/>
+	</machine>
+	<machine name="v5x_dmau" sourcefile="devices/machine/am9517a.cpp" isdevice="yes" runnable="no">
+		<description>V5X DMAU</description>
+	</machine>
+	<machine name="v5x_icu" sourcefile="devices/machine/pic8259.cpp" isdevice="yes" runnable="no">
+		<description>NEC V5X ICU</description>
+	</machine>
+	<machine name="v5x_scu" sourcefile="devices/machine/i8251.cpp" isdevice="yes" runnable="no">
+		<description>NEC V5X SCU</description>
+	</machine>
+	<machine name="vcs_joystick" sourcefile="devices/bus/vcs_ctrl/joystick.cpp" isdevice="yes" runnable="no">
+		<description>Atari / CBM Digital joystick</description>
+		<input players="1">
+			<control type="joy" buttons="1" ways="8"/>
+		</input>
+	</machine>
+	<machine name="vcs_joystick_booster" sourcefile="devices/bus/vcs_ctrl/joybooster.cpp" isdevice="yes" runnable="no">
+		<description>CBS Electronics Booster-Grip Joystick Adaptor</description>
+		<input players="1">
+			<control type="joy" buttons="3" ways="8"/>
+		</input>
+	</machine>
+	<machine name="vcs_keypad" sourcefile="devices/bus/vcs_ctrl/keypad.cpp" isdevice="yes" runnable="no">
+		<description>Atari / CBM Keypad</description>
+		<input players="1">
+			<control type="keypad" buttons="12"/>
+		</input>
+	</machine>
+	<machine name="vcs_lightpen" sourcefile="devices/bus/vcs_ctrl/lightpen.cpp" isdevice="yes" runnable="no">
+		<description>Atari / CBM Light Pen</description>
+		<input players="1">
+			<control type="lightgun" buttons="1" minimum="0" maximum="255" sensitivity="45" keydelta="15"/>
+		</input>
+	</machine>
+	<machine name="vcs_mouse" sourcefile="devices/bus/vcs_ctrl/mouse.cpp" isdevice="yes" runnable="no">
+		<description>Atari / CBM Mouse</description>
+		<input players="1">
+			<control type="mouse" buttons="2" minimum="0" maximum="63" sensitivity="15" keydelta="10" reverse="yes"/>
+		</input>
+	</machine>
+	<machine name="vcs_paddles" sourcefile="devices/bus/vcs_ctrl/paddles.cpp" isdevice="yes" runnable="no">
+		<description>Atari / CBM Dual paddles</description>
+		<input players="2">
+			<control type="paddle" player="1" buttons="1" minimum="0" maximum="255" sensitivity="30" keydelta="20" reverse="yes"/>
+			<control type="paddle" player="2" buttons="1" minimum="0" maximum="255" sensitivity="30" keydelta="20" reverse="yes"/>
+		</input>
+	</machine>
+	<machine name="vcs_wheel" sourcefile="devices/bus/vcs_ctrl/wheel.cpp" isdevice="yes" runnable="no">
+		<description>Atari / CBM Driving Wheel</description>
+		<input players="1">
+			<control type="trackball" buttons="1" minimum="0" maximum="255" sensitivity="40" keydelta="5"/>
+		</input>
+	</machine>
+	<machine name="wd33c93" sourcefile="devices/machine/wd33c9x.cpp" isdevice="yes" runnable="no">
+		<description>Western Digital WD33C93 SCSI Controller</description>
+	</machine>
+	<machine name="wd33c93a" sourcefile="devices/machine/wd33c9x.cpp" isdevice="yes" runnable="no">
+		<description>Western Digital WD33C93A SCSI Controller</description>
+	</machine>
+	<machine name="xm3301" sourcefile="devices/bus/ata/xm3301.cpp" isdevice="yes" runnable="no">
+		<description>Toshiba XM-3301 CD-ROM Drive</description>
+		<device_ref tag=":_tmp:image" name="cdrom_image"/>
+		<device_ref tag=":_tmp:cdda" name="cdda"/>
+		<chip type="audio" tag=":cdda" name="CD/DA" clock="44100"/>
+		<sound channels="0"/>
+		<feature type="disk" status="unemulated"/>
+		<device type="cdrom" tag=":image" interface="cdrom">
+			<instance name="cdrom" briefname="cdrm"/>
+			<extension name="chd"/>
+			<extension name="cue"/>
+			<extension name="toc"/>
+			<extension name="nrg"/>
+			<extension name="gdi"/>
+			<extension name="iso"/>
+			<extension name="cdr"/>
+		</device>
+	</machine>
+	<machine name="zip100_ide" sourcefile="devices/bus/ata/zip100.cpp" isdevice="yes" runnable="no">
+		<description>Iomega Zip 100MB IDE Drive</description>
+		<rom name="nm27c520m.u1" size="65536" crc="67a04459" sha1="b8df2a733838db5116982a7295484b77b272287c" region="eprom" offset="0"/>
+		<device_ref tag=":_tmp:mcu" name="i80c32"/>
+		<chip type="cpu" tag=":mcu" name="Intel 80C32" clock="12000000"/>
+		<feature type="disk" status="unemulated"/>
+	</machine>
+	<machine name="d9060hd" sourcefile="devices/bus/scsi/d9060hd.cpp" isdevice="yes" runnable="no">
+		<description>D9060HD</description>
+		<device_ref tag=":_tmp:image" name="harddisk_image"/>
+		<configuration name="SCSI ID" tag=":SCSI_ID" mask="7">
+			<confsetting name="0" value="0"/>
+			<confsetting name="1" value="1"/>
+			<confsetting name="2" value="2"/>
+			<confsetting name="3" value="3"/>
+			<confsetting name="4" value="4"/>
+			<confsetting name="5" value="5"/>
+			<confsetting name="6" value="6"/>
+			<confsetting name="7" value="7" default="yes"/>
+		</configuration>
+		<device type="harddisk" tag=":image" interface="scsi_hdd">
+			<instance name="harddisk" briefname="hard"/>
+			<extension name="chd"/>
+			<extension name="hd"/>
+			<extension name="hdv"/>
+			<extension name="2mg"/>
+			<extension name="hdi"/>
+		</device>
+	</machine>
+	<machine name="floppy_525_dd" sourcefile="devices/imagedev/floppy.cpp" isdevice="yes" runnable="no">
+		<description>5.25&quot; double density floppy drive</description>
+		<device_ref tag=":_tmp:flopsndout" name="speaker"/>
+		<device_ref tag=":_tmp:flopsnd" name="flopsnd"/>
+		<chip type="audio" tag=":flopsndout" name="Speaker"/>
+		<chip type="audio" tag=":flopsnd" name="Floppy sound" clock="44100"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="floppy_525_ssqd" sourcefile="devices/imagedev/floppy.cpp" isdevice="yes" runnable="no">
+		<description>5.25&quot; single-sided quad density floppy drive</description>
+		<device_ref tag=":_tmp:flopsndout" name="speaker"/>
+		<device_ref tag=":_tmp:flopsnd" name="flopsnd"/>
+		<chip type="audio" tag=":flopsndout" name="Speaker"/>
+		<chip type="audio" tag=":flopsnd" name="Floppy sound" clock="44100"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="floppy_525_sssd_35t" sourcefile="devices/imagedev/floppy.cpp" isdevice="yes" runnable="no">
+		<description>5.25&quot; single-sided single density 35-track floppy drive</description>
+		<device_ref tag=":_tmp:flopsndout" name="speaker"/>
+		<device_ref tag=":_tmp:flopsnd" name="flopsnd"/>
+		<chip type="audio" tag=":flopsndout" name="Speaker"/>
+		<chip type="audio" tag=":flopsnd" name="Floppy sound" clock="44100"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="floppy_8_dsdd" sourcefile="devices/imagedev/floppy.cpp" isdevice="yes" runnable="no">
+		<description>8&quot; double-sided double density floppy drive</description>
+		<device_ref tag=":_tmp:flopsndout" name="speaker"/>
+		<device_ref tag=":_tmp:flopsnd" name="flopsnd"/>
+		<chip type="audio" tag=":flopsndout" name="Speaker"/>
+		<chip type="audio" tag=":flopsnd" name="Floppy sound" clock="44100"/>
+		<sound channels="1"/>
+	</machine>
+	<machine name="floppy_8_ssdd" sourcefile="devices/imagedev/floppy.cpp" isdevice="yes" runnable="no">
+		<description>8&quot; single-sided double density floppy drive</description>
+		<device_ref tag=":_tmp:flopsndout" name="speaker"/>
+		<device_ref tag=":_tmp:flopsnd" name="flopsnd"/>
+		<chip type="audio" tag=":flopsndout" name="Speaker"/>
+		<chip type="audio" tag=":flopsnd" name="Floppy sound" clock="44100"/>
+		<sound channels="1"/>
+	</machine>
+</mame>

--- a/src/software/process.rs
+++ b/src/software/process.rs
@@ -128,7 +128,12 @@ impl State {
 			(Phase::SoftwarePartDataArea, b"rom") => {
 				let [name, size, crc, sha1, status] =
 					evt.find_attributes([b"name", b"size", b"crc", b"sha1", b"status"])?;
-				let name = name.unwrap_or_default().into();
+				let Some(name) = name else {
+					// the software list tag is <rom> but this is likely not a ROM (e.g. -
+					// NVRAM); software lists are weird
+					return Ok(None);
+				};
+				let name = name.into();
 				let size = parse(&size.unwrap_or_default())?;
 				let hash = AssetHash::from_hex_strings(crc.as_deref(), sha1.as_deref())?;
 				let status = status

--- a/src/software/test_data/softlist_bbcm_cart.xml
+++ b/src/software/test_data/softlist_bbcm_cart.xml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<!--
+license:CC0-1.0
+
+Acorn BBC Master ROM Cartridges
+
+    Loading Instructions:
+
+      Hold down the SHIFT key and SPACEbar and press and release the BREAK key.
+-->
+
+<softwarelist name="bbcm_cart" description="Acorn BBC Master cartridges">
+
+	<software name="abr">
+		<description>Advanced Battery-Backed RAM v1.10</description>
+		<year>1987</year>
+		<publisher>Advanced Computer Products</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<feature name="slot" value="abr" />
+			<dataarea name="nvram" size="32768">
+				<rom name="PRES-ABR-Utils-1.10.rom" size="16360" crc="e5aec5c1" sha1="b0066d9ee83a9144eb5942f106776174ae5df0d9" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="abr104" cloneof="abr">
+		<description>Advanced Battery-Backed RAM v1.04</description>
+		<year>1987</year>
+		<publisher>Advanced Computer Products</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<feature name="slot" value="abr" />
+			<dataarea name="nvram" size="32768">
+				<rom name="PRES-ABR-Utils-1.04.rom" size="16384" crc="2c009b06" sha1="be245a32bba1f18614963587a61bcb622f404c95" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="aqr">
+		<description>Advanced Quarter Meg RAM</description>
+		<year>1987</year>
+		<publisher>Advanced Computer Products</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<feature name="slot" value="aqr" />
+			<dataarea name="ram" size="262144" />
+		</part>
+	</software>
+
+	<software name="click100" cloneof="click">
+		<description>Click v1.00</description>
+		<year>1990</year>
+		<publisher>Slogger</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<feature name="slot" value="click" />
+			<dataarea name="rom" size="16384">
+				<rom name="Click_M128-1.00.rom" size="16384" crc="8c633300" sha1="e7223334fd5cb5b3ed715421aa278b96b3ea39af"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+				<rom value="0x00" size="8192" loadflag="fill" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="click">
+		<description>Click v1.01</description>
+		<year>1990</year>
+		<publisher>Slogger</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<feature name="slot" value="click" />
+			<dataarea name="rom" size="16384">
+				<rom name="Click_M128-1.01.rom" size="16384" crc="bab5539c" sha1="39732aad5fbb22c4ef3ac85d00e50a7f231d03bb"/>
+			</dataarea>
+			<dataarea name="nvram" size="8192">
+				<rom value="0x00" size="8192" loadflag="fill" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="demo">
+		<description>BBC Master Demonstration Cartridge</description>
+		<year>1986</year>
+		<publisher>Acorn</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<dataarea name="lorom" size="16384">
+				<rom name="bbcmasterdemonstrationcartridge_1.rom" size="16384" crc="fc40c0e8" sha1="970ff4721e707f3c843f4fb09ce7f03e7ab265ae" />
+			</dataarea>
+			<dataarea name="uprom" size="16384">
+				<rom name="bbcmasterdemonstrationcartridge_2.rom" size="16384" crc="2e73522d" sha1="ff39620d93b18fd36a4718474495211a46ef8184" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="isopascal">
+		<description>ISO-Pascal</description>
+		<year>1986</year>
+		<publisher>Acornsoft</publisher>
+		<info name="release" value="SQL18" />
+		<part name="cart" interface="bbcm_cart">
+			<dataarea name="lorom" size="16384">
+				<rom name="ISO-Pascal1-1.1.rom" size="16384" crc="ed1a7497" sha1="44cfe2d7fb0895a6c8858f09aaf5a96bcdcc3767" />
+			</dataarea>
+			<dataarea name="uprom" size="16384">
+				<rom name="ISO-Pascal2-1.1.rom" size="16384" crc="73455b67" sha1="0e2354e8d93d9858dbd9d24dfa0aa96a206b0b25" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="lisp">
+		<description>LISP</description>
+		<year>1986</year>
+		<publisher>Acornsoft</publisher>
+		<info name="release" value="SQL14" />
+		<part name="cart" interface="bbcm_cart">
+			<dataarea name="lorom" size="16384">
+				<rom name="Lisp_1.rom" size="16384" crc="fda4c546" sha1="24c7062fc3666cd6814d72e417146e32eb995b04" />
+			</dataarea>
+			<dataarea name="uprom" size="16384">
+				<rom name="Lisp_2.rom" size="16384" crc="2eb56fc0" sha1="bdf09e553578d27a0cc202d409484dd8c2c3c085" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mastersd">
+		<description>Master SD</description>
+		<year>2020</year>
+		<publisher>Ramtop</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<feature name="slot" value="mastersd" />
+			<dataarea name="rom" size="16384">
+				<rom name="swmmfs-1.44.rom" size="16384" crc="a2891718" sha1="5dbd871f9f0c77016869d051657d2403b432addb"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mastersdr2" cloneof="mastersd">
+		<description>Master SD R2</description>
+		<year>2020</year>
+		<publisher>Ramtop</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<feature name="slot" value="mastersdr2" />
+			<dataarea name="rom" size="16384">
+				<rom name="swmmfs-1.44r2.rom" size="16384" crc="36bc3af1" sha1="6086e31b3dd46595403a03e3027a5acd4d74d60b"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mega256">
+		<description>Master Mega 256</description>
+		<year>1987</year>
+		<publisher>Solidisk</publisher>
+		<info name="usage" value="Use only in slot cart2." />
+		<part name="cart" interface="bbcm_cart">
+			<feature name="slot" value="mega256" />
+			<dataarea name="rom" size="8192">
+				<rom name="Mega256-1.00.rom" size="8192" crc="4b8a1a44" sha1="d19b29fd849182901ec5755e9578e23382b4f479"/>
+			</dataarea>
+			<dataarea name="ram" size="262144">
+				<rom value="0x00" size="262144" loadflag="fill" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mr8000">
+		<description>MR8000 Master RAM Cartridge</description>
+		<year>1987</year>
+		<publisher>Peartree Computers</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<feature name="slot" value="mr8000" />
+			<dataarea name="nvram" size="65536">
+				<rom name="MR8000_1.1.rom" size="16384" crc="796085ac" sha1="0128c978754ae3ba723e98e230e5c36a84f5f03e" offset="0x4000" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="mr8000a" cloneof="mr8000">
+		<description>MR8000 Master RAM Cartridge (alt)</description>
+		<year>1987</year>
+		<publisher>Peartree Computers</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<feature name="slot" value="mr8000" />
+			<dataarea name="nvram" size="65536">
+				<rom name="MR8000_1.1_alt.rom" size="16384" crc="28b4e469" sha1="5a259291551c9fc3708ea6585092450a7cc6ccd4" offset="0x4000"/>
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="msc200" cloneof="msc">
+		<description>Master Smart Cartridge v2</description>
+		<year>1987</year>
+		<publisher>Care Electronics</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<feature name="slot" value="msc" />
+			<dataarea name="rom" size="16384">
+				<rom name="smart_v2.rom" size="16384" crc="e9a8139e" sha1="26d6bbfe4b43f76be1f0cb2d96143112d3503840" />
+			</dataarea>
+			<dataarea name="ram" size="2048" />
+		</part>
+	</software>
+
+	<software name="msc">
+		<description>Master Smart Cartridge v2.02</description>
+		<year>1987</year>
+		<publisher>Care Electronics</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<feature name="slot" value="msc" />
+			<dataarea name="rom" size="16384">
+				<rom name="smart_v2.02.rom" size="16384" crc="f9cc2e5e" sha1="1419f09408b83a9294c7b4a175d17ccf5d7eb76d" />
+			</dataarea>
+			<dataarea name="ram" size="2048" />
+		</part>
+	</software>
+
+	<software name="overview">
+		<description>OverView</description>
+		<year>1985</year>
+		<publisher>Acornsoft</publisher>
+		<info name="release" value="SQB30" />
+		<part name="cart" interface="bbcm_cart">
+			<dataarea name="uprom" size="16384">
+				<rom name="viewspell.rom" size="16384" crc="e8840023" sha1="94036e81c4684f245a0111279a0a665262e93271" />
+			</dataarea>
+			<dataarea name="lorom" size="16384">
+				<rom name="viewstore.rom" size="16384" crc="bc69c63e" sha1="5b9bf5bd57af043ddeaa182d188ceaea801bd11f" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="prisma2" supported="no">
+		<description>MasterPieCe 1.10</description>
+		<year>1987</year>
+		<publisher>G2 Systems</publisher>
+		<info name="usage" value="Requires Prisma-2"/>
+		<part name="cart" interface="bbcm_cart">
+			<dataarea name="rom" size="16384">
+				<rom name="MasterPieCe-1.10.rom" size="16384" crc="14b85cdd" sha1="c975041933dd0e223470292d169dd70568c25c59" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="prisma3" supported="no">
+		<description>Prisma-3 1.30</description>
+		<year>1988</year>
+		<publisher>Millipede</publisher>
+		<info name="usage" value="Requires Prisma-3"/>
+		<part name="cart" interface="bbcm_cart">
+			<dataarea name="lorom" size="16384">
+				<rom name="Prisma3-1.30-Main.rom" size="16384" crc="6ed1e8aa" sha1="ceda5ca869f960a4bb5368adbf4acd4861efd3a0" />
+			</dataarea>
+			<dataarea name="uprom" size="16384">
+				<rom name="Prisma3-1.30-Utils.rom" size="16384" crc="76c42acb" sha1="36aab45a3565325dd31ada64934597bafe765ed8" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="prisma3p" cloneof="prisma3" supported="no">
+		<description>Prisma-3 2.30</description>
+		<year>1990</year>
+		<publisher>Millipede</publisher>
+		<info name="usage" value="Requires Prisma-3/3+"/>
+		<part name="cart" interface="bbcm_cart">
+			<dataarea name="lorom" size="16384">
+				<rom name="Prisma3-2.30-Main.rom" size="16384" crc="b9489c7c" sha1="59a7606e3b92e1c7fbd0075d54e4fffd7c28417e" />
+			</dataarea>
+			<dataarea name="uprom" size="16384">
+				<rom name="Prisma3-2.30-Utils.rom" size="16384" crc="fa395bca" sha1="be7b1f590818e362a8acc5b203f0a08fce967f42" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="techcad">
+		<description>TechnoCAD</description>
+		<year>1988</year>
+		<publisher>Technomatic</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<dataarea name="lorom" size="16384">
+				<rom name="TechnoCAD-R1-1.00.rom" size="16384" crc="662a4f28" sha1="3a8a9c5c72212aeadf0c1f2ba8b3ff7f4a08ea2a" />
+			</dataarea>
+			<dataarea name="uprom" size="16384">
+				<rom name="TechnoCAD-R2-1.00.rom" size="16384" crc="19fd969a" sha1="845f73dad31635a307db2d16a61b20ca4561f659" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="vfs">
+		<description>Video Filing System ROM Cartridge</description>
+		<year>1986</year>
+		<publisher>Acorn</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<dataarea name="uprom" size="16384">
+				<rom name="vfs170.rom" size="16384" crc="b124a0bb" sha1="ba31c757815cf470402d7829a70a0e1d3fb1355b" />
+			</dataarea>
+		</part>
+	</software>
+
+	<software name="videorom">
+		<description>VideoROM: Videodisc Player Control Software</description>
+		<year>1988</year>
+		<publisher>The Soft Option</publisher>
+		<part name="cart" interface="bbcm_cart">
+			<dataarea name="uprom" size="16384">
+				<rom name="VideoROM_3.1.rom" size="16384" crc="e2089d1c" sha1="32c3aed1e8dc44997a7b567da012b85687062193" />
+			</dataarea>
+			<dataarea name="lorom" size="16384">
+				<rom name="BootROM_1.4.rom" size="16384" crc="59639755" sha1="173f619e0c794c5f2bbf1ad0beba92bce1d9716a" />
+			</dataarea>
+		</part>
+	</software>
+
+</softwarelist>


### PR DESCRIPTION
These are usually NVRAM or something else that is not an asset, and we were incorrectly interpreting them as assets with empty names