### PR TITLE
Changing initial image loads to use the LUA `image:load_software()` method

### DIFF
--- a/plugins/worker_ui/init.lua
+++ b/plugins/worker_ui/init.lua
@@ -1364,21 +1364,6 @@ function startplugin()
 		protected_call(callback_prestart, "callback_prestart")
 	end)
 
-	function callback_stop()
-		-- the emulation session has stopped; tidy things up
-		stop_polling_input_seq()
-		print("@INFO ### Session is stopping")
-	end
-	if emu.add_machine_stop_notifier ~= nil then
-		emu.add_machine_stop_notifier(function()
-			protected_call(callback_stop, "callback_stop")
-		end)
-	else
-		emu.register_stop(function()
-			protected_call(callback_stop, "callback_stop")
-		end)
-	end
-
 	-- register another handler to handle commands after prestart
 	function callback_periodic()
 		-- it is essential that we only perform these activities when there

--- a/plugins/worker_ui/init.lua
+++ b/plugins/worker_ui/init.lua
@@ -1334,7 +1334,11 @@ function startplugin()
 					local v = table.remove(start_load_args, 1)
 					local image = find_image_by_tag(k)
 					if image then
-						image:load(v)
+						if v:sub(1, 1) == "?" then
+							image:load_software(v:sub(2))
+						else
+							image:load(v)
+						end
 						if image.is_reset_on_load then
 							will_reset = true
 						end

--- a/src/imagedesc.rs
+++ b/src/imagedesc.rs
@@ -89,6 +89,10 @@ impl ImageDesc {
 		image_desc_to_string(self, ImageDescStringType::ImageDesc)
 	}
 
+	pub fn as_mame_start_argument(&self) -> Cow<'_, str> {
+		image_desc_to_string(self, ImageDescStringType::StartArgument)
+	}
+
 	pub fn display_name(&self) -> Cow<'_, str> {
 		image_desc_to_string(self, ImageDescStringType::Display)
 	}
@@ -97,10 +101,17 @@ impl ImageDesc {
 #[derive(Debug, PartialEq, Eq)]
 enum ImageDescStringType {
 	ImageDesc,
+	StartArgument,
 	Display,
 }
 
 fn image_desc_to_string(desc: &ImageDesc, string_type: ImageDescStringType) -> Cow<'_, str> {
+	let prefix = if string_type == ImageDescStringType::StartArgument {
+		"?"
+	} else {
+		""
+	};
+
 	match (desc, string_type) {
 		(ImageDesc::File(filename), ImageDescStringType::Display) => {
 			Path::new(filename).file_name().unwrap_or_default().to_string_lossy()
@@ -109,7 +120,7 @@ fn image_desc_to_string(desc: &ImageDesc, string_type: ImageDescStringType) -> C
 		(ImageDesc::Software { list, name, part }, _) => match (list.as_deref(), part.as_deref()) {
 			(None, None) => Cow::Borrowed(name.as_ref()),
 			(Some(list), None) => format!("{}:{}", list, name).into(),
-			(list, Some(part)) => format!("{}:{}:{}", list.unwrap_or_default(), name, part).into(),
+			(list, Some(part)) => format!("{}{}:{}:{}", prefix, list.unwrap_or_default(), name, part).into(),
 		},
 		(ImageDesc::Socket { hostname, port }, _) => format!("socket.{}:{}", hostname, *port).into(),
 	}
@@ -286,10 +297,12 @@ mod test {
 
 	#[allow(clippy::zero_prefixed_literal)]
 	#[test_case(00, ImageDesc::File("/foo/bar.img".into()), ImageDescStringType::ImageDesc, "/foo/bar.img")]
-	#[test_case(01, ImageDesc::Software{ list: None, name: "abcde".into(), part: None }, ImageDescStringType::ImageDesc, "abcde")]
-	#[test_case(02, ImageDesc::Software{ list: Some("abc".into()), name: "def".into(), part: None }, ImageDescStringType::ImageDesc, "abc:def")]
-	#[test_case(03, ImageDesc::Software{ list: Some("abc".into()), name: "def".into(), part: Some("ghi".into()) }, ImageDescStringType::ImageDesc, "abc:def:ghi")]
-	#[test_case(04, ImageDesc::socket("contoso.com", 8888).unwrap(), ImageDescStringType::ImageDesc, "socket.contoso.com:8888")]
+	#[test_case(01, ImageDesc::File("/foo/bar.img".into()), ImageDescStringType::StartArgument, "/foo/bar.img")]
+	#[test_case(02, ImageDesc::Software{ list: None, name: "abcde".into(), part: None }, ImageDescStringType::ImageDesc, "abcde")]
+	#[test_case(03, ImageDesc::Software{ list: Some("abc".into()), name: "def".into(), part: None }, ImageDescStringType::ImageDesc, "abc:def")]
+	#[test_case(04, ImageDesc::Software{ list: Some("abc".into()), name: "def".into(), part: Some("ghi".into()) }, ImageDescStringType::ImageDesc, "abc:def:ghi")]
+	#[test_case(05, ImageDesc::Software{ list: Some("abc".into()), name: "def".into(), part: Some("ghi".into()) }, ImageDescStringType::StartArgument, "?abc:def:ghi")]
+	#[test_case(06, ImageDesc::socket("contoso.com", 8888).unwrap(), ImageDescStringType::ImageDesc, "socket.contoso.com:8888")]
 	fn image_desc_to_string(_index: usize, desc: ImageDesc, string_type: ImageDescStringType, expected: &str) {
 		let actual = super::image_desc_to_string(&desc, string_type);
 		assert_eq!(expected, &*actual);

--- a/src/imagedesc.rs
+++ b/src/imagedesc.rs
@@ -86,27 +86,32 @@ impl ImageDesc {
 	}
 
 	pub fn as_mame_image_desc(&self) -> Cow<'_, str> {
-		match self {
-			Self::File(filename) => Cow::Borrowed(filename.as_ref()),
-			Self::Software {
-				list,
-				name: software,
-				part,
-			} => match (list.as_deref(), part.as_deref()) {
-				(None, None) => Cow::Borrowed(software.as_ref()),
-				(Some(list), None) => format!("{}:{}", list, software).into(),
-				(list, Some(part)) => format!("{}:{}:{}", list.unwrap_or_default(), software, part).into(),
-			},
-			Self::Socket { hostname, port } => format!("socket.{}:{}", hostname, *port).into(),
-		}
+		image_desc_to_string(self, ImageDescStringType::ImageDesc)
 	}
 
 	pub fn display_name(&self) -> Cow<'_, str> {
-		if let Self::File(filename) = self {
+		image_desc_to_string(self, ImageDescStringType::Display)
+	}
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ImageDescStringType {
+	ImageDesc,
+	Display,
+}
+
+fn image_desc_to_string(desc: &ImageDesc, string_type: ImageDescStringType) -> Cow<'_, str> {
+	match (desc, string_type) {
+		(ImageDesc::File(filename), ImageDescStringType::Display) => {
 			Path::new(filename).file_name().unwrap_or_default().to_string_lossy()
-		} else {
-			self.as_mame_image_desc()
 		}
+		(ImageDesc::File(filename), _) => Cow::Borrowed(filename.as_ref()),
+		(ImageDesc::Software { list, name, part }, _) => match (list.as_deref(), part.as_deref()) {
+			(None, None) => Cow::Borrowed(name.as_ref()),
+			(Some(list), None) => format!("{}:{}", list, name).into(),
+			(list, Some(part)) => format!("{}:{}:{}", list.unwrap_or_default(), name, part).into(),
+		},
+		(ImageDesc::Socket { hostname, port }, _) => format!("socket.{}:{}", hostname, *port).into(),
 	}
 }
 
@@ -276,16 +281,17 @@ mod test {
 	use test_case::test_case;
 
 	use super::ImageDesc;
+	use super::ImageDescStringType;
 	use super::ThisError;
 
 	#[allow(clippy::zero_prefixed_literal)]
-	#[test_case(00, ImageDesc::File("/foo/bar.img".into()), "/foo/bar.img")]
-	#[test_case(01, ImageDesc::Software{ list: None, name: "abcde".into(), part: None }, "abcde")]
-	#[test_case(02, ImageDesc::Software{ list: Some("abc".into()), name: "def".into(), part: None }, "abc:def")]
-	#[test_case(03, ImageDesc::Software{ list: Some("abc".into()), name: "def".into(), part: Some("ghi".into()) }, "abc:def:ghi")]
-	#[test_case(04, ImageDesc::socket("contoso.com", 8888).unwrap(), "socket.contoso.com:8888")]
-	fn as_mame_image_desc(_index: usize, image_desc: ImageDesc, expected: &str) {
-		let actual = image_desc.as_mame_image_desc();
+	#[test_case(00, ImageDesc::File("/foo/bar.img".into()), ImageDescStringType::ImageDesc, "/foo/bar.img")]
+	#[test_case(01, ImageDesc::Software{ list: None, name: "abcde".into(), part: None }, ImageDescStringType::ImageDesc, "abcde")]
+	#[test_case(02, ImageDesc::Software{ list: Some("abc".into()), name: "def".into(), part: None }, ImageDescStringType::ImageDesc, "abc:def")]
+	#[test_case(03, ImageDesc::Software{ list: Some("abc".into()), name: "def".into(), part: Some("ghi".into()) }, ImageDescStringType::ImageDesc, "abc:def:ghi")]
+	#[test_case(04, ImageDesc::socket("contoso.com", 8888).unwrap(), ImageDescStringType::ImageDesc, "socket.contoso.com:8888")]
+	fn image_desc_to_string(_index: usize, desc: ImageDesc, string_type: ImageDescStringType, expected: &str) {
+		let actual = super::image_desc_to_string(&desc, string_type);
 		assert_eq!(expected, &*actual);
 	}
 

--- a/src/runtime/command.rs
+++ b/src/runtime/command.rs
@@ -56,7 +56,7 @@ impl MameCommand {
 		let image_args_iter = start_args
 			.images
 			.iter()
-			.flat_map(|(tag, image_desc)| [Cow::Borrowed(tag.as_ref()), image_desc.as_mame_image_desc()]);
+			.flat_map(|(tag, image_desc)| [Cow::Borrowed(tag.as_ref()), image_desc.as_mame_start_argument()]);
 
 		// and assemble everything
 		let args = once(Cow::Borrowed(start_args.machine_name.as_str()))


### PR DESCRIPTION
`image:load()` no longer works with software part references