### PR TITLE
Changes to release artifact preparation

### DIFF
--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       # Install Rust toolchain
       - uses: actions-rs/toolchain@v1
@@ -31,6 +33,22 @@ jobs:
       - name: Caching
         uses: Swatinem/rust-cache@v2
         
+      # Install cargo-edit
+      - name: Install cargo-edit
+        shell: bash
+        run: |
+          cargo install cargo-edit
+
+      # Determine version and set crate version
+      - name: Determine version and set crate version
+        shell: bash
+        run: |
+          VERSION=$(git describe --tags | perl scripts/process_version.pl)
+          cargo set-version "$VERSION"
+          VERSION_UNDERSCORES=${VERSION//./_}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION_UNDERSCORES=$VERSION_UNDERSCORES" >> $GITHUB_ENV
+
       # Build
       - name: Build
         uses: actions-rs/cargo@v1
@@ -68,39 +86,37 @@ jobs:
           echo $wixBin >> $env:GITHUB_PATH
           Write-Host "Using WiX from $wixBin"
     
-      # Build MSI - Candle (replace 'echo' with 'git describe --tags' when we have actual tags)
+      # Build MSI - Candle
       - name: Build MSI - Candle
         shell: bash
-        run: candle -v bletchmame.wxs -dVERSION=`echo v3.0 | perl scripts/process_version.pl` -out bletchmame.wixobj
+        run: candle -v bletchmame.wxs -dVERSION="$VERSION" -out bletchmame.wixobj
             
       # Build MSI - Light
       - name: Build MSI - Light
         run: light -v -ext WixUIExtension -ext WixUtilExtension bletchmame.wixobj -out BletchMAME.msi
 
-      # Prepare Artifacts (replace 'echo' with 'git describe --tags' when we have actual tags)
+      # Prepare Artifacts
       - name: Prepare Artifacts
         shell: bash
         run: |
-          mkdir rel
-          echo v3.0 | perl scripts/process_version.pl > rel/version_latest.txt
-          mv BletchMAME.msi rel/BletchMAME_latest.msi
-          7z a rel/BletchMAME_latest.zip ./target/release/BletchMAME.exe
-          7z a rel/BletchMAME_latest.zip readme.html
-          7z a rel/BletchMAME_latest.zip plugins
+          mkdir -p rel
+          mv BletchMAME.msi rel/BletchMAME_${VERSION_UNDERSCORES}.msi
+          7z a rel/BletchMAME_${VERSION_UNDERSCORES}.zip ./target/release/BletchMAME.exe
+          7z a rel/BletchMAME_${VERSION_UNDERSCORES}.zip readme.html
+          7z a rel/BletchMAME_${VERSION_UNDERSCORES}.zip plugins
 
-      # Set date as env variable (PowerShell)
-      - name: Set date as env variable (PowerShell)
-        id: set_date
-        shell: pwsh
-        if: success() && github.ref == 'refs/heads/master'
-        run: |
-          $d = Get-Date -Format "yyyyMMddHHmm"
-          echo "ARTIFACT_DATE=$d" >> $env:GITHUB_ENV
-
-      # Upload build output
-      - name: Upload build output
+      # Upload build output MSI
+      - name: Upload build output MSI
         uses: actions/upload-artifact@v4
         if: success() && github.ref == 'refs/heads/master'
         with:
-          name: BletchMAME_latest_${{ env.ARTIFACT_DATE }}
-          path: rel
+          name: BletchMAME_${{ env.VERSION_UNDERSCORES }}.msi
+          path: rel/*.msi
+
+      # Upload build output ZIP
+      - name: Upload build output ZIP
+        uses: actions/upload-artifact@v4
+        if: success() && github.ref == 'refs/heads/master'
+        with:
+          name: BletchMAME_${{ env.VERSION_UNDERSCORES }}.zip
+          path: rel/*.zip

--- a/scripts/process_version.pl
+++ b/scripts/process_version.pl
@@ -4,33 +4,20 @@
 # process_version.pl - Generates BletchMAME version information in various forms  #
 ###################################################################################
 
-if (!(<STDIN> =~ /v([0-9]+)\.([0-9]+)(\-[0-9]+)?/))
-{
-	die "Cannot process build string";
+# read a line from stdin and extract version
+my $input = <STDIN>;
+if (!defined $input || $input !~ /v([0-9]+)\.([0-9]+)(\-[0-9]+)?/) {
+    die "Cannot process build string";
 }
 my $major = $1;
 my $minor = $2;
-my $subbuild = 0;
-my $build = $3;
+my $build = $3 // '';
 $build =~ s/^\-//;
-if ($build eq "")
-{
-	$build = 0;
-}
+my $delim = '.';
 
-if ($ARGV[0] eq "--versionhdr")
-{
-	# header file
-	print "#define BLETCHMAME_VERSION_COMMASEP	$major,$minor,$subbuild,$build\n";
-	print "#define BLETCHMAME_VERSION_STRING	\"$major.$minor";
-	if ($subbuild != 0 || $build != 0)
-	{
-		print ".$subbuild.$build";
-	}
-	print "\\0\"\n";
+if ($build eq "") {
+	print join($delim, ($major, $minor)) . "\n";
 }
-else
-{
-	# simple version text
-	print "$major.$minor.$subbuild.$build\n";
+else {
+	print join($delim, ($major, $minor, $build)) . "\n";
 }


### PR DESCRIPTION
- Using `cargo set-version` to set the build version
- Changing to use three digit release versions (Rust standard)
- Uploaded artifacts are `BletchMAME_[version].[msi|zip]`